### PR TITLE
docs: update social and contact links

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more detailed guidelines.
 
 ## Community
 
-Join the discussion on our [Discord](https://discord.gg/tollcraft).
+Join the discussion on our [Discord](https://discord.gg/5aprtMSyR).
 
 ## Maintainers
 
 | Name | Role | Contact |
 |---|---|---|
 | [mallison031](https://github.com/mallison031) | Maintainer | [GitHub](https://github.com/mallison031) |
-| Tollcraft Team | Core Maintainers | [@Tollcraft on Telegram](https://t.me/Tollcraft) |
+| Tollcraft Team | Core Maintainers | [Tollcraft on Telegram](https://t.me/+Gflo5jZStw1jMjE0) |
 
 ## Contributors
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,6 @@ Please do not report security vulnerabilities through public GitHub issues.
 
 Instead, please report them to the maintainers privately:
 - Contact via email: security@tollcraft.org
-- Or via Telegram: [@Tollcraft](https://t.me/Tollcraft)
+- Or via Telegram: [Tollcraft](https://t.me/+Gflo5jZStw1jMjE0)
 
 You should receive a response within 48 hours. If the issue is confirmed as a vulnerability, we will open a private security advisory and work on a patch before public disclosure.


### PR DESCRIPTION
replace placeholder with active social links for telegram and discord support