### PR TITLE
ci: add fmt and clippy quality checks for contributor PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,20 @@ on:
     branches: [ "main", "v1" ]
 
 jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-04-16
+          components: rustc-dev, llvm-tools-preview, rustfmt, clippy
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,25 @@ This tool leverages Dylint to hook into the Rust compiler's AST and High-Level I
 - Implement the lint using the `dylint` framework, checking the AST or HIR for the specific pattern.
 - Update the documentation and `README.md`.
 
-### 4. Submitting a Pull Request
+### 4. Code Quality Standards
+All PRs are checked by CI, and these checks must pass before a PR can be merged. Run them locally before pushing:
+
+1. Format your code with rustfmt (CI rejects unformatted code):
+   ```bash
+   cargo fmt --all
+   ```
+2. Make sure Clippy passes with no warnings:
+   ```bash
+   cargo clippy --workspace --all-targets -- -D warnings
+   ```
+3. Make sure the test suite passes:
+   ```bash
+   cargo test --workspace
+   ```
+
+Follow the patterns already used in the codebase: `soroban_cost_lints` uses edition 2024, so prefer let-chains (`if let ... && let ...`) over nested `if let` blocks, and match the structure of the existing lint passes when adding a new lint.
+
+### 5. Submitting a Pull Request
 - Ensure your PR targets the `v1` branch.
-- Make sure `cargo test` passes.
+- Make sure the checks in the section above (`cargo fmt`, `cargo clippy`, `cargo test`) all pass.
 - Provide a clear description of what the lint does and why it saves costs.

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use serde::Deserialize;
 use std::fs;
-use std::process::{Command, exit};
 use std::path::Path;
+use std::process::{exit, Command};
 
 #[derive(Parser, Debug)]
 #[command(name = "cargo-cost-lint")]
@@ -56,7 +56,10 @@ fn main() {
             }
         }
     } else {
-        eprintln!("Warning: {} not found, using default lint levels.", cli.config);
+        eprintln!(
+            "Warning: {} not found, using default lint levels.",
+            cli.config
+        );
     }
 
     let mut cmd = Command::new("cargo");
@@ -75,7 +78,9 @@ fn main() {
         }
     }
 
-    let status = cmd.status().expect("Failed to execute cargo dylint. Is cargo-dylint installed?");
+    let status = cmd
+        .status()
+        .expect("Failed to execute cargo dylint. Is cargo-dylint installed?");
     if !status.success() {
         exit(status.code().unwrap_or(1));
     }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -86,28 +86,28 @@ rustc_session::impl_lint_pass!(RedundantEnvClone => [REDUNDANT_ENV_CLONE]);
 
 impl<'tcx> LateLintPass<'tcx> for RedundantEnvClone {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
-        if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
-            if path_segment.ident.name.as_str() == "clone" {
-                let receiver_ty = cx.typeck_results().expr_ty(receiver);
-                let peeled_ty = receiver_ty.peel_refs();
+        if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind
+            && path_segment.ident.name.as_str() == "clone"
+        {
+            let receiver_ty = cx.typeck_results().expr_ty(receiver);
+            let peeled_ty = receiver_ty.peel_refs();
 
-                let is_env = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
-                    let path = cx.tcx.def_path_str(adt_def.did());
-                    path == "soroban_sdk::Env" || path.ends_with("::soroban_sdk::Env")
-                } else {
-                    false
-                };
+            let is_env = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
+                let path = cx.tcx.def_path_str(adt_def.did());
+                path == "soroban_sdk::Env" || path.ends_with("::soroban_sdk::Env")
+            } else {
+                false
+            };
 
-                if is_env {
-                    span_lint_and_help(
-                        cx,
-                        REDUNDANT_ENV_CLONE,
-                        expr.span,
-                        "redundant clone on Env object",
-                        None,
-                        "pass Env by reference or value instead of cloning",
-                    );
-                }
+            if is_env {
+                span_lint_and_help(
+                    cx,
+                    REDUNDANT_ENV_CLONE,
+                    expr.span,
+                    "redundant clone on Env object",
+                    None,
+                    "pass Env by reference or value instead of cloning",
+                );
             }
         }
     }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -2,14 +2,14 @@
 #![warn(unused_extern_crates)]
 
 extern crate rustc_hir;
-extern crate rustc_middle;
 extern crate rustc_lint;
+extern crate rustc_middle;
 extern crate rustc_session;
 
-use rustc_lint::{LateContext, LateLintPass, LintStore};
-use rustc_hir as hir;
-use clippy_utils::get_enclosing_loop_or_multi_call_closure;
 use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::get_enclosing_loop_or_multi_call_closure;
+use rustc_hir as hir;
+use rustc_lint::{LateContext, LateLintPass, LintStore};
 
 dylint_linting::dylint_library!();
 
@@ -40,7 +40,7 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
         if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
             let receiver_ty = cx.typeck_results().expr_ty(receiver);
             let peeled_ty = receiver_ty.peel_refs();
-            
+
             let is_storage_access = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
                 let path = cx.tcx.def_path_str(adt_def.did());
                 path == "soroban_sdk::storage::Storage"
@@ -51,7 +51,8 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
                     || path.ends_with("::soroban_sdk::storage::Persistent")
                     || path == "soroban_sdk::storage::Temporary"
                     || path.ends_with("::soroban_sdk::storage::Temporary")
-                    || ((path == "soroban_sdk::Env" || path.ends_with("::soroban_sdk::Env")) && path_segment.ident.name.as_str() == "storage")
+                    || ((path == "soroban_sdk::Env" || path.ends_with("::soroban_sdk::Env"))
+                        && path_segment.ident.name.as_str() == "storage")
             } else {
                 false
             };
@@ -90,7 +91,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantEnvClone {
             if path_segment.ident.name.as_str() == "clone" {
                 let receiver_ty = cx.typeck_results().expr_ty(receiver);
                 let peeled_ty = receiver_ty.peel_refs();
-                
+
                 let is_env = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
                     let path = cx.tcx.def_path_str(adt_def.did());
                     path == "soroban_sdk::Env" || path.ends_with("::soroban_sdk::Env")
@@ -128,10 +129,11 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryHostFunctionCall {
         if let hir::ExprKind::MethodCall(_path_segment, receiver, _args, _span) = expr.kind {
             let receiver_ty = cx.typeck_results().expr_ty(receiver);
             let peeled_ty = receiver_ty.peel_refs();
-            
+
             let is_host_function = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
                 let path = cx.tcx.def_path_str(adt_def.did());
-                path == "soroban_sdk::ledger::Ledger" || path.ends_with("::soroban_sdk::ledger::Ledger")
+                path == "soroban_sdk::ledger::Ledger"
+                    || path.ends_with("::soroban_sdk::ledger::Ledger")
             } else {
                 false
             };

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -57,19 +57,18 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
                 false
             };
 
-            if is_storage_access {
-                if let Some(enclosing_expr) = get_enclosing_loop_or_multi_call_closure(cx, expr) {
-                    if let hir::ExprKind::Loop(..) = enclosing_expr.kind {
-                        span_lint_and_help(
-                            cx,
-                            SOROBAN_STORAGE_IN_LOOP,
-                            expr.span,
-                            "storage operation inside a loop",
-                            None,
-                            "move storage operations out of the loop or accumulate mutations in memory first",
-                        );
-                    }
-                }
+            if is_storage_access
+                && let Some(enclosing_expr) = get_enclosing_loop_or_multi_call_closure(cx, expr)
+                && let hir::ExprKind::Loop(..) = enclosing_expr.kind
+            {
+                span_lint_and_help(
+                    cx,
+                    SOROBAN_STORAGE_IN_LOOP,
+                    expr.span,
+                    "storage operation inside a loop",
+                    None,
+                    "move storage operations out of the loop or accumulate mutations in memory first",
+                );
             }
         }
     }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -137,19 +137,18 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryHostFunctionCall {
                 false
             };
 
-            if is_host_function {
-                if let Some(enclosing_expr) = get_enclosing_loop_or_multi_call_closure(cx, expr) {
-                    if let hir::ExprKind::Loop(..) = enclosing_expr.kind {
-                        span_lint_and_help(
-                            cx,
-                            UNNECESSARY_HOST_FUNCTION_CALL,
-                            expr.span,
-                            "unnecessary host function call inside loop",
-                            None,
-                            "call this function outside the loop and reuse the result",
-                        );
-                    }
-                }
+            if is_host_function
+                && let Some(enclosing_expr) = get_enclosing_loop_or_multi_call_closure(cx, expr)
+                && let hir::ExprKind::Loop(..) = enclosing_expr.kind
+            {
+                span_lint_and_help(
+                    cx,
+                    UNNECESSARY_HOST_FUNCTION_CALL,
+                    expr.span,
+                    "unnecessary host function call inside loop",
+                    None,
+                    "call this function outside the loop and reuse the result",
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds automated code quality gates to CI so contributor PRs are checked for formatting and lint cleanliness, not just test correctness.

- New fast `quality` job in the lint workflow running `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` (runs in parallel with the test job, no dylint install needed, so contributors get style feedback in about a minute)
- Existing code brought into compliance: rustfmt applied across the workspace, and five `collapsible_if` clippy errors fixed by collapsing nested `if let` blocks into let-chains (one commit per lint pass; behavior unchanged)
- CONTRIBUTING.md gains a "Code Quality Standards" section documenting the checks and the codebase patterns to follow

## Testing

- `cargo fmt --all -- --check` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo test --workspace` passes (UI tests confirm lint behavior is unchanged)
