### PR TITLE
chore: remove references to nonexistent v1 branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ "main", "v1" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "v1" ]
+    branches: [ "main" ]
 
 jobs:
   quality:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,6 @@ All PRs are checked by CI, and these checks must pass before a PR can be merged.
 Follow the patterns already used in the codebase: `soroban_cost_lints` uses edition 2024, so prefer let-chains (`if let ... && let ...`) over nested `if let` blocks, and match the structure of the existing lint passes when adding a new lint.
 
 ### 5. Submitting a Pull Request
-- Ensure your PR targets the `v1` branch.
+- Ensure your PR targets the `main` branch.
 - Make sure the checks in the section above (`cargo fmt`, `cargo clippy`, `cargo test`) all pass.
 - Provide a clear description of what the lint does and why it saves costs.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ We are actively looking for contributors in cost-model research, AST parsing, an
 
 1. Check the open issues to find tasks labeled `good first issue` or `help wanted`.
 2. Fork the repository.
-3. Ensure all Pull Requests target the `v1` branch.
+3. Ensure all Pull Requests target the `main` branch.
 4. Pass all local tests before submitting.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more detailed guidelines.


### PR DESCRIPTION
CONTRIBUTING.md and README.md told contributors to target their PRs at a `v1` branch that was never created, and the lint workflow listed it as a trigger. This points contributors at `main` (the actual working branch, where branch protection and the CI quality gate live) and drops the dead workflow trigger.