### PR TITLE
fix(cli): budget.toml lint levels broke cargo cost-lint

### DIFF
--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
                                 continue;
                             }
                         };
-                        lint_flags.push(format!("{}={}", level_flag, lint));
+                        lint_flags.push(format!("{} {}", level_flag, lint));
                     }
                 }
             } else {
@@ -68,14 +68,16 @@ fn main() {
     cmd.arg("soroban_cost_lints");
 
     if !lint_flags.is_empty() {
-        cmd.arg("--");
+        // Trailing args to `cargo dylint` are forwarded to `cargo check`, which
+        // rejects lint-level flags; they must reach rustc via DYLINT_RUSTFLAGS.
+        let mut rustflags = std::env::var("DYLINT_RUSTFLAGS").unwrap_or_default();
         for flag in lint_flags {
-            let parts: Vec<&str> = flag.split('=').collect();
-            cmd.arg(parts[0]);
-            // Add the soroban_cost prefix if not present or just the lint name?
-            // Dylint uses the exact lint name declared in declare_lint!
-            cmd.arg(parts[1]);
+            if !rustflags.is_empty() {
+                rustflags.push(' ');
+            }
+            rustflags.push_str(&flag);
         }
+        cmd.env("DYLINT_RUSTFLAGS", rustflags);
     }
 
     let status = cmd


### PR DESCRIPTION
`cargo cost-lint` passed the lint-level flags from `budget.toml` as trailing args to `cargo dylint`, which forwards them to `cargo check` — and cargo rejects them:

```
error: unexpected argument '-W' found
```

So the documented `budget.toml` workflow failed before linting even started. This routes the levels through `DYLINT_RUSTFLAGS` (appending to any existing value) so they reach rustc, where the dylint driver registers the lints.

Verified end to end against a real soroban-sdk contract while recording the demo: with `soroban_storage_in_loop = "deny"`, a storage write inside a loop fails the build with exit code 1, and the corrected contract passes with exit code 0.