### PR TITLE
fix(cli): fail on malformed budget.toml instead of silent fallback

### DIFF
--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -8,13 +8,36 @@ use std::process::{exit, Command};
 #[command(name = "cargo-cost-lint")]
 #[command(about = "CLI wrapper for soroban-cost-linter")]
 struct Cli {
-    #[arg(long, help = "Path to budget.toml", default_value = "budget.toml")]
-    config: String,
+    #[arg(long, help = "Path to budget.toml")]
+    config: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
 struct BudgetConfig {
     lints: Option<std::collections::HashMap<String, String>>,
+}
+
+fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
+    let config_str =
+        fs::read_to_string(path).map_err(|e| format!("Error: Failed to read {}: {}", path, e))?;
+    let config: BudgetConfig =
+        toml::from_str(&config_str).map_err(|e| format!("Error: Failed to parse {}: {}", path, e))?;
+    let mut lint_flags = Vec::new();
+    if let Some(lints) = config.lints {
+        for (lint, level) in lints {
+            let level_flag = match level.as_str() {
+                "allow" => "-A",
+                "warn" => "-W",
+                "deny" => "-D",
+                _ => {
+                    eprintln!("Unknown lint level: {}", level);
+                    continue;
+                }
+            };
+            lint_flags.push(format!("{} {}", level_flag, lint));
+        }
+    }
+    Ok(lint_flags)
 }
 
 fn main() {
@@ -32,33 +55,26 @@ fn main() {
         }
     };
 
+    let config_explicitly_given = cli.config.is_some();
+    let config_path = cli.config.unwrap_or_else(|| "budget.toml".to_string());
+
     let mut lint_flags = Vec::new();
 
-    if Path::new(&cli.config).exists() {
-        if let Ok(config_str) = fs::read_to_string(&cli.config) {
-            if let Ok(config) = toml::from_str::<BudgetConfig>(&config_str) {
-                if let Some(lints) = config.lints {
-                    for (lint, level) in lints {
-                        let level_flag = match level.as_str() {
-                            "allow" => "-A",
-                            "warn" => "-W",
-                            "deny" => "-D",
-                            _ => {
-                                eprintln!("Unknown lint level: {}", level);
-                                continue;
-                            }
-                        };
-                        lint_flags.push(format!("{} {}", level_flag, lint));
-                    }
-                }
-            } else {
-                eprintln!("Warning: Failed to parse {}", cli.config);
+    if Path::new(&config_path).exists() {
+        lint_flags = match parse_budget_config(&config_path) {
+            Ok(flags) => flags,
+            Err(msg) => {
+                eprintln!("{}", msg);
+                exit(1);
             }
-        }
+        };
+    } else if config_explicitly_given {
+        eprintln!("Error: {} not found.", config_path);
+        exit(1);
     } else {
         eprintln!(
-            "Warning: {} not found, using default lint levels.",
-            cli.config
+            "Note: {} not found, using default lint levels.",
+            config_path
         );
     }
 
@@ -85,5 +101,70 @@ fn main() {
         .expect("Failed to execute cargo dylint. Is cargo-dylint installed?");
     if !status.success() {
         exit(status.code().unwrap_or(1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn absent_config_returns_default_lint_levels() {
+        let dir = std::env::temp_dir().join("cost_lint_test_absent");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let result = parse_budget_config(&dir.join("budget.toml").to_string_lossy());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to read"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unparseable_config_returns_error() {
+        let dir = std::env::temp_dir().join("cost_lint_test_unparseable");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("budget.toml");
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(file, "this is not valid toml = {{{").unwrap();
+        drop(file);
+
+        let result = parse_budget_config(&path.to_string_lossy());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Failed to parse"),
+            "expected parse error, got: {}",
+            err
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn valid_config_returns_flags() {
+        let dir = std::env::temp_dir().join("cost_lint_test_valid");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("budget.toml");
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            "[lints]\nsoroban_storage_in_loop = \"deny\"\nredundant_env_clone = \"warn\""
+        )
+        .unwrap();
+        drop(file);
+
+        let result = parse_budget_config(&path.to_string_lossy());
+        assert!(result.is_ok());
+        let flags = result.unwrap();
+        assert_eq!(flags.len(), 2);
+        assert!(flags.contains(&"-D soroban_storage_in_loop".to_string()));
+        assert!(flags.contains(&"-W redundant_env_clone".to_string()));
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -19,6 +19,10 @@ unnecessary_host_function_call = "warn"
 See the [Lint Reference](lints/) for what each lint catches and its default severity.
 {% endhint %}
 
+{% hint style="danger" %}
+A `budget.toml` that exists but cannot be read or parsed is a hard error — the run will fail with a non-zero exit code and the parser's message and location will be reported.
+{% endhint %}
+
 ## GitHub Actions
 
 We provide a template to easily integrate the linter into your GitHub Actions pipeline:


### PR DESCRIPTION
Closes #92

## Summary

A `budget.toml` that exists but cannot be parsed currently prints a `Warning` and then proceeds with default lint levels. An unreadable file is silently ignored. This makes both scenarios a hard error.

## Changes

### Error handling (`cargo-cost-lint/src/main.rs`)

- **Parse failure** — if `budget.toml` exists but contains invalid TOML, the run now fails with a non-zero exit code and shows the parser's error message with location.
- **Read failure** — if `budget.toml` exists but cannot be read (e.g. permissions), the run fails with a non-zero exit code and reports the OS error.
- **Missing file (default path)** — when no `--config` is passed and `budget.toml` does not exist, the current behaviour is preserved: a `Note` is printed and the run continues with default lint levels.
- **Missing file (explicit `--config`)** — if a user passes `--config <path>` and the file is missing, the run fails with a non-zero exit code.

### Refactor

Extracted the `budget.toml` parsing logic into `parse_budget_config()` and added unit tests covering all three paths (valid, unparseable, read error on non-existent path).

### Documentation (`docs/integration.md`)

Added a note that a malformed or unreadable `budget.toml` is a hard error.

## Testing

```bash
cargo test -p cargo-cost-lint
```

Tests cover:
- Valid `budget.toml` → returns correct lint flags
- Unparseable `budget.toml` → returns parse error
- Missing `budget.toml` → returns read error (non-existent path)