### PR TITLE
chore: add Dependabot configuration for Cargo and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+updates:
+  # Cargo — workspace root. Dependabot resolves both workspace members
+  # (soroban_cost_lints, cargo-cost-lint) from the root manifest's
+  # [workspace.members] list, so a single entry here covers both crates.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # Pinned to a specific rust-clippy revision that must stay in lockstep
+      # with the nightly toolchain in `rust-toolchain` / .github/workflows/lint.yml
+      # (soroban_cost_lints links against rustc's private HIR/MIR APIs via this rev).
+      # Bumping it independently of the toolchain will break the build. Update
+      # manually, in the same PR as a toolchain bump.
+      - dependency-name: "clippy_utils"
+
+  # GitHub Actions — only .github/workflows/*.yml is in Dependabot's scan scope.
+  # templates/github-action.yml is a boilerplate workflow shipped for downstream
+  # consumers to copy into their own repos; it is not executed here, so
+  # Dependabot cannot see or update it. Its `dtolnay/rust-toolchain` pin needs a
+  # manual sync when the toolchain changes.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` covering the `cargo` and `github-actions` ecosystems.

## Why
Neither dependency surface had automated update checks. Notably, `soroban_cost_lints`
depends on `clippy_utils` pinned to a raw git revision — nothing currently signals when
that pin is stale.

## Details
- **Cargo**: single entry at the workspace root (`/`), which covers both
  `soroban_cost_lints` and `cargo-cost-lint` via `[workspace.members]`.
- **`clippy_utils` is explicitly ignored.** It's pinned to a rustc-nightly-compatible
  revision of clippy that has to move in lockstep with the toolchain pinned in
  `rust-toolchain` (`nightly-2026-04-16`). Dependabot bumping it in isolation would break
  the build against rustc's private HIR/MIR APIs — this needs a human to update it
  alongside a toolchain bump.
- **GitHub Actions**: covers `.github/workflows/*.yml` (currently just `lint.yml`).
  `templates/github-action.yml` is a boilerplate workflow shipped for downstream
  consumers to copy into their own repos — it isn't executed by this repo's CI, and
  Dependabot's `github-actions` ecosystem doesn't scan outside `.github/workflows/`, so
  it's out of reach of this config. Its toolchain pin will still need manual syncing.
- **Volume**: both ecosystems are grouped into a single weekly PR each (Monday), rather
  than defaults that would open one PR per dependency per week.

## Testing
No Rust source changed, so `cargo fmt` / `cargo clippy` / `cargo test` are unaffected.
Validated the YAML parses and is schema-valid via GitHub's Dependabot config check
(Insights → Dependency graph → Dependabot) once this branch/PR is up.

## Limitations
Dependabot only evaluates `dependabot.yml` from the default branch, so the actual
first scheduled run can only be verified after this merges. I'll follow up on this
issue thread once it fires to confirm the resulting PRs look sensible.

Closes #86