### PR TITLE
docs: replace Dylint scaffolding with proper crate readme

### DIFF
--- a/soroban_cost_lints/README.md
+++ b/soroban_cost_lints/README.md
@@ -1,21 +1,13 @@
-# template
+# soroban_cost_lints
 
-### What it does
+The lint crate for `soroban-cost-linter`. Compiled as a dynamic library and loaded by Dylint at runtime.
 
-### Why is this bad?
+## Registered Lints
 
-### Known problems
+| Lint | Description |
+|------|-------------|
+| [`soroban_storage_in_loop`](../docs/lints/soroban_storage_in_loop.md) | Flags storage read/write operations inside loop bodies, suggesting memory aggregation instead. |
+| [`redundant_env_clone`](../docs/lints/redundant_env_clone.md) | Detects unnecessary `.clone()` calls on the Soroban `Env` object. |
+| [`unnecessary_host_function_call`](../docs/lints/unnecessary_host_function_call.md) | Identifies redundant calls to host functions (like `Ledger` sequences) inside loops that should be called once and cached. |
 
-Remove if none.
-
-### Example
-
-```rust
-// example code where a warning is issued
-```
-
-Use instead:
-
-```rust
-// example code that does not raise a warning
-```
+See the [lint reference](../docs/lints/README.md) for full documentation.


### PR DESCRIPTION
Replaces the unedited Dylint template in `soroban_cost_lints/README.md` with a concise description of the crate: what it is, how Dylint loads it, and a table of the three registered lints with links to their reference pages under `docs/lints/`.

Closes #80.