### PR TITLE
test: add #[allow(...)] suppression and negative fixtures for all three lints

### DIFF
--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -52,6 +52,10 @@ pub mod soroban_sdk {
 
 use soroban_sdk::Env;
 
+// =======================================================================
+// soroban_storage_in_loop — Fixtures
+// =======================================================================
+
 fn bad_storage_in_for_loop(env: Env) {
     for i in 0..10 {
         env.storage().instance().set(&i, &1); // Should Warn
@@ -85,13 +89,44 @@ fn allowed_storage_in_loop(env: Env) {
     }
 }
 
+// =======================================================================
+// redundant_env_clone — Fixtures
+// =======================================================================
+
 fn bad_clone_env(env: Env) {
     let _cloned = env.clone(); // Should Warn
 }
 
+fn good_no_clone_needed(env: Env) {
+    let _ref = &env; // Good — no clone, just a reference
+}
+
+#[allow(redundant_env_clone)]
+fn allowed_clone_env(env: Env) {
+    let _cloned = env.clone(); // Good (allowed)
+}
+
+// =======================================================================
+// unnecessary_host_function_call — Fixtures
+// =======================================================================
+
 fn bad_host_call_in_loop(env: Env) {
     for _ in 0..10 {
         let _seq = env.ledger().sequence(); // Should Warn
+    }
+}
+
+fn good_host_call_outside_loop(env: Env) {
+    let seq = env.ledger().sequence(); // Good — called once before the loop
+    for _ in 0..10 {
+        let _seq = seq;
+    }
+}
+
+#[allow(unnecessary_host_function_call)]
+fn allowed_host_call_in_loop(env: Env) {
+    for _ in 0..10 {
+        let _seq = env.ledger().sequence(); // Good (allowed)
     }
 }
 

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -1,5 +1,5 @@
 warning: storage operation inside a loop
-  --> $DIR/main.rs:57:9
+  --> $DIR/main.rs:61:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = note: `#[warn(soroban_storage_in_loop)]` on by default
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:57:9
+  --> $DIR/main.rs:61:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:57:9
+  --> $DIR/main.rs:61:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:64:30
+  --> $DIR/main.rs:68:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:64:30
+  --> $DIR/main.rs:68:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:64:30
+  --> $DIR/main.rs:68:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:71:12
+  --> $DIR/main.rs:75:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:71:12
+  --> $DIR/main.rs:75:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:71:12
+  --> $DIR/main.rs:75:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:89:19
+  --> $DIR/main.rs:97:19
    |
 LL |     let _cloned = env.clone(); // Should Warn
    |                   ^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     let _cloned = env.clone(); // Should Warn
    = note: `#[warn(redundant_env_clone)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:94:20
+  --> $DIR/main.rs:115:20
    |
 LL |         let _seq = env.ledger().sequence(); // Should Warn
    |                    ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Adds `#[allow(...)]` suppression fixtures and negative (non-flagged) fixtures for the `redundant_env_clone` and `unnecessary_host_function_call` lints, which previously had no suppression coverage at all. The existing `soroban_storage_in_loop` suppression fixture was kept in place.

## Changes

### `soroban_cost_lints/ui/main.rs`
- Added section-comment markers to group fixtures by lint target, improving readability of the flat single-module file.
- **`redundant_env_clone`**:
  - `good_no_clone_needed` — negative fixture: takes a reference instead of cloning
  - `allowed_clone_env` — suppression fixture: `#[allow(redundant_env_clone)]` on the function
- **`unnecessary_host_function_call`**:
  - `good_host_call_outside_loop` — negative fixture: calls the host function once before the loop
  - `allowed_host_call_in_loop` — suppression fixture: `#[allow(unnecessary_host_function_call)]` on the function
- Removed duplicate `bad_clone_env` and `bad_host_call_in_loop` that were left at their old positions after restructuring.

### `soroban_cost_lints/ui/main.stderr`
- Regenerated via `DYLINT_BLESS=1` to reflect the updated line numbers in the expanded fixture file. Still 11 warnings emitted (unchanged count).

## Verification

- `cargo fmt --all -- --check` — passes
- `cargo clippy --workspace --all-targets -- -D warnings` — passes
- `cargo test --workspace` — passes

Closes #95