### PR TITLE
ci: unify nightly toolchain pin behind rust-toolchain and add drift guard

### DIFF
--- a/.github/scripts/validate-toolchain-pins.sh
+++ b/.github/scripts/validate-toolchain-pins.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# validate-toolchain-pins.sh
+#
+# Drift guard for the nightly toolchain pin.
+# Uses rust-toolchain as the single source of truth for the nightly version
+# and soroban_cost_lints/Cargo.toml for the clippy_utils git rev.
+#
+# Fails if any of the hardcoded copies drift from the canonical source.
+#
+# Usage: bash .github/scripts/validate-toolchain-pins.sh
+
+set -euo pipefail
+
+# ---- Parse canonical nightly from rust-toolchain (single source of truth) ----
+CANONICAL_NIGHTLY=$(sed -n 's/^channel = "\(nightly-[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\)"$/\1/p' rust-toolchain)
+if [ -z "$CANONICAL_NIGHTLY" ]; then
+  echo "::error file=rust-toolchain::Could not parse [toolchain].channel from rust-toolchain"
+  exit 1
+fi
+echo "Canonical nightly (from rust-toolchain): ${CANONICAL_NIGHTLY}"
+
+NIGHTLY_DATE="${CANONICAL_NIGHTLY#nightly-}"
+FAILED=0
+
+# ---- Check every file that hardcodes the nightly string ----
+check_nightly_in_file() {
+  local file="$1"
+  local matches
+  matches=$(grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' "$file" | sort -u || true)
+  if [ -z "$matches" ]; then
+    echo "::warning file=$file::No nightly version found in $file (expected ${CANONICAL_NIGHTLY})"
+    return
+  fi
+  while IFS= read -r found; do
+    if [ "$found" != "$CANONICAL_NIGHTLY" ]; then
+      echo "::error file=$file::Mismatch in ${file}: found '${found}' but expected '${CANONICAL_NIGHTLY}'. Edit ${file} to use the canonical version."
+      FAILED=1
+    fi
+  done <<< "$matches"
+  if [ "$FAILED" -eq 0 ]; then
+    echo "OK: ${file} matches canonical nightly"
+  fi
+}
+
+check_nightly_in_file ".github/workflows/lint.yml"
+check_nightly_in_file "templates/github-action.yml"
+check_nightly_in_file "docs/integration.md"
+
+# ---- Check clippy_utils git rev matches the nightly date ----
+CLIPPY_REV=$(sed -n 's/.*rev = "\([a-f0-9]\{40\}\)".*/\1/p' soroban_cost_lints/Cargo.toml)
+if [ -z "$CLIPPY_REV" ]; then
+  echo "::error file=soroban_cost_lints/Cargo.toml::Could not parse clippy_utils git rev"
+  FAILED=1
+else
+  echo "clippy_utils rev: ${CLIPPY_REV}"
+
+  RESPONSE=$(curl -s "https://api.github.com/repos/rust-lang/rust-clippy/commits/${CLIPPY_REV}")
+
+  # Try jq first, then python3 as fallback
+  COMMIT_DATE=""
+  if command -v jq &>/dev/null; then
+    COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date' 2>/dev/null | cut -d'T' -f1)
+  fi
+  if [ -z "$COMMIT_DATE" ] || [ "$COMMIT_DATE" = "null" ]; then
+    if command -v python3 &>/dev/null; then
+      COMMIT_DATE=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['commit']['committer']['date'].split('T')[0])" 2>/dev/null)
+    fi
+  fi
+
+  if [ -z "$COMMIT_DATE" ] || [ "$COMMIT_DATE" = "null" ]; then
+    echo "::error file=soroban_cost_lints/Cargo.toml::Invalid or unreachable clippy_utils rev ${CLIPPY_REV}. Update the rev in soroban_cost_lints/Cargo.toml."
+    FAILED=1
+  else
+    COMMIT_TS=$(date -d "$COMMIT_DATE" +%s 2>/dev/null)
+    NIGHTLY_TS=$(date -d "$NIGHTLY_DATE" +%s 2>/dev/null)
+    if [ -z "$COMMIT_TS" ] || [ -z "$NIGHTLY_TS" ]; then
+      echo "::error::Cannot compare dates (date command may not support -d flag)"
+      FAILED=1
+    else
+      DIFF=$((COMMIT_TS - NIGHTLY_TS))
+      DIFF_ABS=${DIFF#-}
+      DAYS_DIFF=$((DIFF_ABS / 86400))
+
+      if [ "$DAYS_DIFF" -gt 3 ]; then
+        echo "::error file=soroban_cost_lints/Cargo.toml::clippy_utils rev ${CLIPPY_REV} is from ${COMMIT_DATE} (${DAYS_DIFF} days away from nightly ${CANONICAL_NIGHTLY}). Update the rev in soroban_cost_lints/Cargo.toml to match the nightly."
+        FAILED=1
+      else
+        echo "OK: clippy_utils rev ${CLIPPY_REV} (${COMMIT_DATE}) is within 3 days of nightly ${NIGHTLY_DATE}"
+      fi
+    fi
+  fi
+fi
+
+if [ "$FAILED" -eq 1 ]; then
+  exit 1
+fi
+
+echo "All toolchain pin checks passed."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,13 @@ on:
     branches: [ "main" ]
 
 jobs:
+  validate-toolchain-pins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate all nightly toolchain pins are in sync
+        run: bash .github/scripts/validate-toolchain-pins.sh
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,27 @@ All PRs are checked by CI, and these checks must pass before a PR can be merged.
 
 Follow the patterns already used in the codebase: `soroban_cost_lints` uses edition 2024, so prefer let-chains (`if let ... && let ...`) over nested `if let` blocks, and match the structure of the existing lint passes when adding a new lint.
 
-### 5. Submitting a Pull Request
+### 5. Upgrading the Nightly Toolchain
+
+The pinned nightly is declared once in `rust-toolchain` (the single source of truth) and must stay in sync across four files and the `clippy_utils` git rev in `soroban_cost_lints/Cargo.toml`.
+
+**Procedure to upgrade:**
+
+1. Update `rust-toolchain` with the new nightly date (e.g. `nightly-2026-05-01`).
+2. Find the matching `clippy_utils` commit from the [`rust-lang/rust-clippy`](https://github.com/rust-lang/rust-clippy) repository's `rustup` branch on that date, and update the `rev` field in `soroban_cost_lints/Cargo.toml`.
+3. Update `.github/workflows/lint.yml`, `templates/github-action.yml`, and `docs/integration.md` with the new nightly date.
+4. Run the drift guard to confirm everything agrees:
+   ```bash
+   bash .github/scripts/validate-toolchain-pins.sh
+   ```
+5. Run the full test suite:
+   ```bash
+   cargo test --workspace
+   ```
+
+If any file is out of sync, the drift guard will print an error naming the file, the mismatched value, and the expected one.
+
+### 6. Submitting a Pull Request
 - Ensure your PR targets the `main` branch.
 - Make sure the checks in the section above (`cargo fmt`, `cargo clippy`, `cargo test`) all pass.
 - Provide a clear description of what the lint does and why it saves costs.


### PR DESCRIPTION
closes #104

## Summary

The nightly version string `nightly-2026-04-16` was hardcoded in four places with no automated enforcement, causing a high-friction failure mode when pins drifted apart. This PR introduces a single source of truth and a CI drift guard to catch mismatches.

### Changes

- **`rust-toolchain`** — remains the single source of truth for the nightly channel version (standard Rust convention).
- **`.github/scripts/validate-toolchain-pins.sh`** — new drift-guard script that:
  - Parses the canonical nightly from `rust-toolchain`.
  - Checks every hardcoded copy in `.github/workflows/lint.yml`, `templates/github-action.yml`, and `docs/integration.md` against the canonical value.
  - Validates the `clippy_utils` git rev in `soroban_cost_lints/Cargo.toml` by fetching its commit date from the rust-clippy repository and comparing it to the nightly date (fails if >3 days apart).
  - Prints a `::error` message naming the file, the found value, and the expected value on mismatch.
- **`.github/workflows/lint.yml`** — new `validate-toolchain-pins` job that runs the script before other jobs.
- **`CONTRIBUTING.md`** — added section "Upgrading the Nightly Toolchain" with the step-by-step procedure (which file to change first, what to re-run).

### Design decisions

- `rust-toolchain` stays as the canonical source because it is the standard Rust convention and developers already look there.
- The user-facing YAML copies in `templates/github-action.yml` and `docs/integration.md` are kept as literal YAML that users can paste; the drift guard checks them rather than templating them away.

Signed-off-by: Samuel Ojetunde <samuelojetunde898@gmail.com>