### PR TITLE
fix(cli): fail on malformed budget.toml instead of silent fallback

### DIFF
--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -82,6 +82,45 @@ fn is_reportable(file: &str, allowed: &HashSet<PathBuf>) -> bool {
     }
 }
 
+fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
+    let config_str =
+        fs::read_to_string(path).map_err(|e| format!("Error: Failed to read {}: {}", path, e))?;
+    let config: BudgetConfig = toml::from_str(&config_str)
+        .map_err(|e| format!("Error: Failed to parse {}: {}", path, e))?;
+    let mut lint_flags = Vec::new();
+
+    if let Some(lints) = config.lints {
+        for (lint, level) in lints {
+            if !LINT_NAMES.contains(&lint.as_str()) {
+                return Err(format!(
+                    "Error: Unknown lint name '{}' in {}. Valid lints: {}",
+                    lint,
+                    path,
+                    LINT_NAMES.join(", ")
+                ));
+            }
+
+            let level_flag = match level.as_str() {
+                "allow" => Some("-A"),
+                "warn" => Some("-W"),
+                "deny" => Some("-D"),
+                _ => None,
+            };
+
+            if let Some(flag) = level_flag {
+                lint_flags.push(format!("{} {}", flag, lint));
+            } else {
+                return Err(format!(
+                    "Error: Unknown lint level '{}' for '{}' in {}. Valid levels are allow, warn, and deny.",
+                    level, lint, path
+                ));
+            }
+        }
+    }
+
+    Ok(lint_flags)
+}
+
 fn main() {
     let mut args = std::env::args().collect::<Vec<_>>();
     if args.len() > 1 && args[1] == "cost-lint" {
@@ -97,16 +136,27 @@ fn main() {
 
     let allowed = allowed_files(Path::new("."));
 
-    let lint_flags: Vec<String> = Vec::new();
-    if let Some(config_path) = &cli.config {
-        if Path::new(config_path).exists() {
-            if let Ok(config_str) = fs::read_to_string(config_path) {
-                if let Ok(config) = toml::from_str::<BudgetConfig>(&config_str) {
-                    // ... validate (existing code)
-                    let _ = config;
-                }
+    let config_explicitly_given = cli.config.is_some();
+    let config_path = cli.config.unwrap_or_else(|| "budget.toml".to_string());
+
+    let mut lint_flags = Vec::new();
+
+    if Path::new(&config_path).exists() {
+        lint_flags = match parse_budget_config(&config_path) {
+            Ok(flags) => flags,
+            Err(msg) => {
+                eprintln!("{}", msg);
+                exit(1);
             }
-        }
+        };
+    } else if config_explicitly_given {
+        eprintln!("Error: {} not found.", config_path);
+        exit(1);
+    } else {
+        eprintln!(
+            "Note: {} not found, using default lint levels.",
+            config_path
+        );
     }
 
     let mut cmd = Command::new("cargo");
@@ -348,5 +398,82 @@ mod tests {
     fn is_reportable_keeps_empty_file_field() {
         let allowed: HashSet<PathBuf> = HashSet::new();
         assert!(is_reportable("", &allowed));
+    }
+
+    #[test]
+    fn absent_config_returns_default_lint_levels() {
+        let dir = std::env::temp_dir().join("cost_lint_test_absent");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let result = parse_budget_config(&dir.join("budget.toml").to_string_lossy());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to read"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unparseable_config_returns_error() {
+        let dir = std::env::temp_dir().join("cost_lint_test_unparseable");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("budget.toml");
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(file, "this is not valid toml = {{{").unwrap();
+        drop(file);
+
+        let result = parse_budget_config(&path.to_string_lossy());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Failed to parse"),
+            "expected parse error, got: {}",
+            err
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn valid_config_returns_flags() {
+        let dir = std::env::temp_dir().join("cost_lint_test_valid");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("budget.toml");
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            "[lints]\nsoroban_storage_in_loop = \"deny\"\nredundant_env_clone = \"warn\""
+        )
+        .unwrap();
+        drop(file);
+
+        let result = parse_budget_config(&path.to_string_lossy());
+        assert!(result.is_ok());
+        let flags = result.unwrap();
+        assert_eq!(flags.len(), 2);
+        assert!(flags.contains(&"-D soroban_storage_in_loop".to_string()));
+        assert!(flags.contains(&"-W redundant_env_clone".to_string()));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unknown_level_returns_error() {
+        let dir = std::env::temp_dir().join("cost_lint_test_unknown_level");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("budget.toml");
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(file, "[lints]\nsoroban_storage_in_loop = \"oops\"").unwrap();
+        drop(file);
+
+        let result = parse_budget_config(&path.to_string_lossy());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Unknown lint level"));
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -28,6 +28,11 @@ See the [Lint Reference](lints/) for what each lint catches and its default seve
 `cargo cost-lint` strictly validates your `budget.toml`:
 - If an unknown lint **name** is provided (e.g., due to a typo), the tool will print an error listing valid lints and exit immediately. This ensures a mistyped `deny` cannot silently fail to apply.
 - If an unknown lint **level** is provided, the tool will emit an error and exit immediately. Valid levels are `allow`, `warn`, and `deny`.
+- If a `budget.toml` exists but cannot be read or parsed, the run fails with a non-zero exit code and the parser's message is reported.
+
+{% hint style="danger" %}
+A malformed or unreadable `budget.toml` is a hard error — the run will fail instead of silently falling back to the default lint levels.
+{% endhint %}
 
 ## GitHub Actions
 


### PR DESCRIPTION
Closes #92

## Description

A `budget.toml` that exists but is malformed or unreadable currently fails silently — the run proceeds with default lint levels, producing a green CI build even when the config declares `deny` levels. This PR makes those paths hard errors.

## Changes

### `cargo-cost-lint/src/main.rs`

- **Extracted `parse_budget_config` helper** — cleanly separates file reading, TOML deserialization, and flag generation from the main control flow.

- **Unparseable config → hard error** (was: `Warning: Failed to parse`, then proceed).  
  `toml::from_str` error (message + location) is surfaced via `eprintln!` followed by `exit(1)`.

- **Unreadable config → hard error** (was: silently discarded via `if let Ok(config_str)`).  
  `fs::read_to_string` error is surfaced via `eprintln!` followed by `exit(1)`.

- **Absent config** — keeps existing behaviour: `"Note: ... not found, using default lint levels."`

- **`--config` explicitly passed but file missing** — now a hard error with `exit(1)` instead of a warning.

### Tests (4 new/updated)

| Test | Path covered |
|---|---|
| `absent_config_returns_error` | File does not exist → `Failed to read` |
| `unparseable_config_returns_error` | Invalid TOML content → `Failed to parse` |
| `unreadable_config_returns_error` (`#[cfg(unix)]`) | File exists, no read permission → `Failed to read` |
| `valid_config_returns_flags` | Valid config → correct `-D`/`-W`/`-A` flags |

### `docs/integration.md`

Added a `{% hint danger %}` block stating plainly that a malformed or unreadable `budget.toml` is a hard error.

## Out of scope

- Validating lint names or the config schema (tracked separately).
