### PR TITLE
chore: fill in crate metadata for soroban_cost_lints

### DIFF
--- a/soroban_cost_lints/Cargo.toml
+++ b/soroban_cost_lints/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "soroban_cost_lints"
 version = "0.1.1"
-authors = ["authors go here"]
-description = "description goes here"
+authors = ["Tollcraft Team <https://tollcraft.gitbook.io/docs>"]
+description = "Dylint library providing Soroban cost-analysis lints for cargo-cost-lint"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
## Summary

Replaces the scaffold placeholder values in `soroban_cost_lints/Cargo.toml` with real metadata.

## Changes

- **authors**: `"authors go here"` → `"Tollcraft Team <https://tollcraft.gitbook.io/docs>"`
- **description**: `"description goes here"` → `"Dylint library providing Soroban cost-analysis lints for cargo-cost-lint"`

The `authors` field now reflects the Tollcraft team, consistent with the README's maintainers table and the GitHub organization owning this repository. The `description` accurately summarizes the crate's role as the Dylint lint library that backs the `cargo-cost-lint` CLI tool. No other manifest fields were modified.

Closes #78