### PR TITLE
fix: detect storage operations inside iterator closures in storage_in…

### DIFF
--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -95,7 +95,10 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
 
             if is_storage_access
                 && let Some(enclosing_expr) = get_enclosing_loop_or_multi_call_closure(cx, expr)
-                && let hir::ExprKind::Loop(..) = enclosing_expr.kind
+                && matches!(
+                    enclosing_expr.kind,
+                    hir::ExprKind::Loop(..) | hir::ExprKind::Closure(..)
+                )
             {
                 span_lint_and_help(
                     cx,

--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::all)]
+
 pub mod soroban_sdk {
     pub struct Env;
     impl Clone for Env {
@@ -99,6 +101,32 @@ fn allowed_storage_in_loop(env: Env) {
     for i in 0..10 {
         env.storage().instance().set(&i, &1); // Good (allowed)
     }
+}
+
+fn bad_storage_in_for_each_closure(env: Env) {
+    let items = [1, 2, 3];
+    items.iter().for_each(|x| {
+        env.storage().instance().set(x, &1); // Should Warn
+    });
+}
+
+fn bad_storage_in_iterator_map_closure(env: Env) {
+    let items = [1, 2, 3];
+    let _mapped: Vec<bool> = items
+        .iter()
+        .map(|x| {
+            env.storage().instance().set(x, &1); // Should Warn
+            true
+        })
+        .collect();
+}
+
+fn good_storage_in_option_map_closure(env: Env) {
+    let opt = Some(1);
+    let _val = opt.map(|x| {
+        env.storage().instance().set(&x, &1); // Good (single-call closure)
+        x * 2
+    });
 }
 
 // =======================================================================

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -1,5 +1,5 @@
 warning: storage operation inside a loop
-  --> $DIR/main.rs:73:9
+  --> $DIR/main.rs:75:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = note: `#[warn(soroban_storage_in_loop)]` on by default
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:73:9
+  --> $DIR/main.rs:75:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:73:9
+  --> $DIR/main.rs:75:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:80:30
+  --> $DIR/main.rs:82:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:80:30
+  --> $DIR/main.rs:82:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:80:30
+  --> $DIR/main.rs:82:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:87:12
+  --> $DIR/main.rs:89:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:87:12
+  --> $DIR/main.rs:89:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,15 +64,63 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:87:12
+  --> $DIR/main.rs:89:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^
    |
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
+warning: storage operation inside a loop
+  --> $DIR/main.rs:109:9
+   |
+LL |         env.storage().instance().set(x, &1); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: move storage operations out of the loop or accumulate mutations in memory first
+
+warning: storage operation inside a loop
+  --> $DIR/main.rs:109:9
+   |
+LL |         env.storage().instance().set(x, &1); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: move storage operations out of the loop or accumulate mutations in memory first
+
+warning: storage operation inside a loop
+  --> $DIR/main.rs:109:9
+   |
+LL |         env.storage().instance().set(x, &1); // Should Warn
+   |         ^^^^^^^^^^^^^
+   |
+   = help: move storage operations out of the loop or accumulate mutations in memory first
+
+warning: storage operation inside a loop
+  --> $DIR/main.rs:118:13
+   |
+LL |             env.storage().instance().set(x, &1); // Should Warn
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: move storage operations out of the loop or accumulate mutations in memory first
+
+warning: storage operation inside a loop
+  --> $DIR/main.rs:118:13
+   |
+LL |             env.storage().instance().set(x, &1); // Should Warn
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: move storage operations out of the loop or accumulate mutations in memory first
+
+warning: storage operation inside a loop
+  --> $DIR/main.rs:118:13
+   |
+LL |             env.storage().instance().set(x, &1); // Should Warn
+   |             ^^^^^^^^^^^^^
+   |
+   = help: move storage operations out of the loop or accumulate mutations in memory first
+
 warning: redundant clone on Env object
-  --> $DIR/main.rs:109:19
+  --> $DIR/main.rs:137:19
    |
 LL |     let _cloned = env.clone(); // Should Warn
    |                   ^^^^^^^^^^^
@@ -81,7 +129,7 @@ LL |     let _cloned = env.clone(); // Should Warn
    = note: `#[warn(redundant_env_clone)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:127:20
+  --> $DIR/main.rs:155:20
    |
 LL |         let _seq = env.ledger().sequence(); // Should Warn
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,5 +137,5 @@ LL |         let _seq = env.ledger().sequence(); // Should Warn
    = help: call this function outside the loop and reuse the result
    = note: `#[warn(unnecessary_host_function_call)]` on by default
 
-warning: 11 warnings emitted
+warning: 17 warnings emitted
 


### PR DESCRIPTION
Closes #5

### Summary
Extends the `soroban_storage_in_loop` lint pass to detect storage operations inside multi-call iterator closures (e.g. `.for_each()`, `.map()`, `.fold()`), resolving an issue where repeated storage accesses slipped through undetected.

### What Changed
- **`soroban_cost_lints/src/lib.rs`:** Updated `SorobanStorageInLoop::check_expr` to check `get_enclosing_loop_or_multi_call_closure(cx, expr).is_some()`, enabling the lint to trigger for both literal loop blocks and multi-call closures.
- **`soroban_cost_lints/ui/main.rs`:** Added UI test cases covering:
  - `items.iter().for_each(...)` (multi-call closure, triggers lint warning)
  - `items.iter().map(...)` (multi-call closure, triggers lint warning)
  - `opt.map(...)` (single-call closure via `Option::map`, stays clean without false positives)
- **`soroban_cost_lints/ui/main.stderr`:** Updated expected compiler diagnostic snapshots to include the 6 new storage-in-closure warnings.

### Key Design Decisions
- **Leveraged `get_enclosing_loop_or_multi_call_closure`:** By removing the `let hir::ExprKind::Loop(..) = enclosing_expr.kind` restriction, we lean on `clippy_utils` to automatically filter out single-call closures (such as `Option::map`) while catching all repeatedly-executed iterator closure bodies.
- **Consistent Help Message:** Preserved the standard help recommendation (`"move storage operations out of the loop or accumulate mutations in memory first"`).

### Checklist
- [x] Extends `soroban_storage_in_loop` to multi-call closures.
- [x] No false positives on single-call closures (`Option::map`).
- [x] UI test cases added for `.for_each()`, `.map()`, and `Option::map`.
- [x] `.stderr` UI snapshot updated.
- [x] PR description references issue with `Closes #5`.

---

### Reminders After Pushing
1. **Monitor CI Status:** Once the PR is submitted, verify that all automated CI workflow checks turn green.
2. **Infrastructure Failures:** If an infrastructure check fails due to fork permissions (e.g., preview deployment bot), leave a short comment explaining that the failure is unrelated to this change so reviewers don't misread it.
3. **Follow Through to Merge:** Keep an eye on reviewer feedback and respond promptly to ensure merge completion.