### PR TITLE
feat: implement symbol_new_for_short_literal lint (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+
+- New lint `symbol_new_for_short_literal` detecting `Symbol::new(&env, "literal")` calls where the literal is a valid short symbol (≤ 9 chars, alphanumeric + underscore) and suggesting the `symbol_short!` macro for compile-time creation.
+
 ## [0.1.1]
 
 ### Changed

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -20,6 +20,12 @@ This section provides detailed documentation for all lints supported by `soroban
 | --------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
 | [`redundant_env_clone`](redundant_env_clone.md)                       | `warn`           | Unnecessary `.clone()` calls on `Env`      |
 
+## Symbol Operations
+
+| Lint                                                                  | Default Severity | Catches                                    |
+| --------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
+| [`symbol_new_for_short_literal`](symbol_new_for_short_literal.md)     | `warn`           | `Symbol::new` with short literal arguments |
+
 {% hint style="info" %}
 Severities can be adjusted per-workspace via `budget.toml` — see the [Integration Guide](../integration.md).
 {% endhint %}

--- a/docs/lints/symbol_new_for_short_literal.md
+++ b/docs/lints/symbol_new_for_short_literal.md
@@ -1,0 +1,44 @@
+# `symbol_new_for_short_literal`
+
+**Default Severity:** `warn`
+
+## What it does
+
+Detects calls to `Symbol::new(&env, "literal")` where the string literal is short enough (≤ 9 characters) and contains only valid short-symbol characters (`a-zA-Z0-9_`). Such symbols can be created at compile time using the `symbol_short!` macro instead.
+
+## Why is this bad?
+
+{% hint style="danger" %}
+`Symbol::new` creates symbols at runtime, which incurs CPU overhead on every call. Short symbols (≤ 9 chars, alphanumeric + underscore) can be created at **compile time** using `symbol_short!`, producing a `const Symbol` with zero runtime cost.
+{% endhint %}
+
+## Example
+
+```rust
+// ❌ Bad: runtime symbol creation for a short literal
+let sym = Symbol::new(&env, "hello");
+```
+
+## Suggested Fix
+
+{% hint style="success" %}
+Use `symbol_short!` macro for compile-time symbol creation:
+{% endhint %}
+
+```rust
+// ✅ Good: compile-time symbol creation
+let sym = symbol_short!("hello");
+```
+
+## Valid Characters and Length
+
+- Maximum length: **9 characters**
+- Valid characters: `a-z`, `A-Z`, `0-9`, `_` (underscore)
+
+## Non-Flagged Cases
+
+The lint does **not** trigger for:
+- String literals longer than 9 characters
+- String literals containing invalid characters (e.g., `-`, `.`, spaces)
+- Non-literal string arguments (variables, expressions)
+- Empty strings

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -1,14 +1,19 @@
 #![feature(rustc_private)]
 #![warn(unused_extern_crates)]
 
+extern crate rustc_ast;
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_lint;
 extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
 
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use clippy_utils::get_enclosing_loop_or_multi_call_closure;
+use clippy_utils::source::snippet_opt;
+use rustc_ast::LitKind;
+use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_span::def_id::DefId;
@@ -27,6 +32,7 @@ pub enum LintCategory {
     Compute,
     Memory,
     EntryLifecycle,
+    SymbolOperations,
 }
 
 pub struct LintMetadata {
@@ -51,6 +57,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: HOST_IN_LOOP,
         category: LintCategory::Compute,
     },
+    LintMetadata {
+        lint: SYMBOL_NEW_FOR_SHORT_LITERAL,
+        category: LintCategory::SymbolOperations,
+    },
 ];
 
 #[unsafe(no_mangle)]
@@ -60,11 +70,13 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         REDUNDANT_ENV_CLONE,
         UNNECESSARY_HOST_FUNCTION_CALL,
         HOST_IN_LOOP,
+        SYMBOL_NEW_FOR_SHORT_LITERAL,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(RedundantEnvClone));
     lint_store.register_late_pass(|_| Box::new(UnnecessaryHostFunctionCall));
     lint_store.register_late_pass(|_| Box::new(HostInLoop));
+    lint_store.register_late_pass(|_| Box::new(SymbolNewForShortLiteral));
 }
 
 rustc_session::declare_lint! {
@@ -218,6 +230,69 @@ impl<'tcx> LateLintPass<'tcx> for HostInLoop {
             }
         }
     }
+}
+
+// =======================================================================
+// symbol_new_for_short_literal — Lint
+// =======================================================================
+
+rustc_session::declare_lint! {
+    pub SYMBOL_NEW_FOR_SHORT_LITERAL,
+    Warn,
+    "Symbol::new used with a short literal that could use symbol_short! macro"
+}
+pub struct SymbolNewForShortLiteral;
+rustc_session::impl_lint_pass!(SymbolNewForShortLiteral => [SYMBOL_NEW_FOR_SHORT_LITERAL]);
+
+impl<'tcx> LateLintPass<'tcx> for SymbolNewForShortLiteral {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        // Check for Symbol::new(&env, "literal") calls
+        if let hir::ExprKind::Call(callee, args) = expr.kind
+            && args.len() == 2
+            && let hir::ExprKind::Path(ref qpath) = callee.kind
+            && let Some(def_id) = cx.qpath_res(qpath, callee.hir_id).opt_def_id()
+            && match_soroban_def_path(cx, def_id, &["soroban_sdk", "Symbol", "new"])
+        {
+            // Check if the second argument is a string literal
+            if let hir::ExprKind::Lit(lit) = args[1].kind
+                && let LitKind::Str(symbol, _) = lit.node
+            {
+                let s = symbol.as_str();
+                if is_valid_short_symbol(s) {
+                    // Check if there's a valid suggestion
+                    if let Some(snippet) = snippet_opt(cx, args[1].span) {
+                        let suggestion = format!("symbol_short!({})", snippet);
+                        span_lint_and_sugg(
+                            cx,
+                            SYMBOL_NEW_FOR_SHORT_LITERAL,
+                            expr.span,
+                            "Symbol::new called with a short literal that could use symbol_short! macro",
+                            "use symbol_short! macro for compile-time symbol creation",
+                            suggestion,
+                            Applicability::MachineApplicable,
+                        );
+                    } else {
+                        span_lint_and_help(
+                            cx,
+                            SYMBOL_NEW_FOR_SHORT_LITERAL,
+                            expr.span,
+                            "Symbol::new called with a short literal that could use symbol_short! macro",
+                            None,
+                            "use symbol_short! macro for compile-time symbol creation",
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Check if a string is a valid short symbol (<= 9 chars, only a-zA-Z0-9_)
+fn is_valid_short_symbol(s: &str) -> bool {
+    if s.len() > 9 || s.is_empty() {
+        return false;
+    }
+    s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 #[test]

--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -60,9 +60,14 @@ pub mod soroban_sdk {
             pub fn budget_cloned(&self) {}
         }
     }
+
+    pub struct Symbol;
+    impl Symbol {
+        pub fn new(_env: &Env, _s: &str) -> Symbol { Symbol }
+    }
 }
 
-use soroban_sdk::Env;
+use soroban_sdk::{Env, Symbol};
 
 // =======================================================================
 // soroban_storage_in_loop — Fixtures
@@ -140,6 +145,48 @@ fn allowed_host_call_in_loop(env: Env) {
     for _ in 0..10 {
         let _seq = env.ledger().sequence(); // Good (allowed)
     }
+}
+
+// =======================================================================
+// symbol_new_for_short_literal — Fixtures
+// =======================================================================
+
+fn bad_symbol_new_short_literal(env: Env) {
+    let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
+}
+
+fn bad_symbol_new_9_chars(env: Env) {
+    let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn - exactly 9 chars
+}
+
+fn bad_symbol_new_with_underscore(env: Env) {
+    let _sym = Symbol::new(&env, "hello_world"); // Should Warn - 11 chars but only 9 allowed
+}
+
+fn bad_symbol_new_short_with_underscore(env: Env) {
+    let _sym = Symbol::new(&env, "hello_wor"); // Should Warn - 9 chars with underscore
+}
+
+fn good_symbol_new_too_long(env: Env) {
+    let _sym = Symbol::new(&env, "hello_world"); // Good - 11 chars > 9
+}
+
+fn good_symbol_new_invalid_chars(env: Env) {
+    let _sym = Symbol::new(&env, "hello-world"); // Good - contains invalid char '-'
+}
+
+fn good_symbol_new_non_literal(env: Env) {
+    let s = "hello";
+    let _sym = Symbol::new(&env, s); // Good - not a literal
+}
+
+fn good_symbol_new_empty(env: Env) {
+    let _sym = Symbol::new(&env, ""); // Good - empty string
+}
+
+#[allow(symbol_new_for_short_literal)]
+fn allowed_symbol_new_short_literal(env: Env) {
+    let _sym = Symbol::new(&env, "hello"); // Good (allowed)
 }
 
 fn main() {}

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -1,5 +1,5 @@
 warning: storage operation inside a loop
-  --> $DIR/main.rs:73:9
+  --> $DIR/main.rs:78:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = note: `#[warn(soroban_storage_in_loop)]` on by default
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:73:9
+  --> $DIR/main.rs:78:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:73:9
+  --> $DIR/main.rs:78:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:80:30
+  --> $DIR/main.rs:85:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:80:30
+  --> $DIR/main.rs:85:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:80:30
+  --> $DIR/main.rs:85:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:87:12
+  --> $DIR/main.rs:92:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:87:12
+  --> $DIR/main.rs:92:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:87:12
+  --> $DIR/main.rs:92:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:109:19
+  --> $DIR/main.rs:114:19
    |
 LL |     let _cloned = env.clone(); // Should Warn
    |                   ^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     let _cloned = env.clone(); // Should Warn
    = note: `#[warn(redundant_env_clone)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:127:20
+  --> $DIR/main.rs:132:20
    |
 LL |         let _seq = env.ledger().sequence(); // Should Warn
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,5 +89,25 @@ LL |         let _seq = env.ledger().sequence(); // Should Warn
    = help: call this function outside the loop and reuse the result
    = note: `#[warn(unnecessary_host_function_call)]` on by default
 
-warning: 11 warnings emitted
+warning: Symbol::new called with a short literal that could use symbol_short! macro
+  --> $DIR/main.rs:155:16
+   |
+LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello")`
+   |
+   = note: `#[warn(symbol_new_for_short_literal)]` on by default
+
+warning: Symbol::new called with a short literal that could use symbol_short! macro
+  --> $DIR/main.rs:159:16
+   |
+LL |     let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn - exactly 9 chars
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
+
+warning: Symbol::new called with a short literal that could use symbol_short! macro
+  --> $DIR/main.rs:167:16
+   |
+LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn - 9 chars with underscore
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
+
+warning: 14 warnings emitted
 


### PR DESCRIPTION
Closes #114. Implements the symbol_new_for_short_literal lint detecting Symbol::new calls with valid short literals and suggesting symbol_short!. Includes UI tests, #[allow] suppression test, documentation in docs/lints/, and CHANGELOG entry. Known false positives: none expected beyond non-literal dynamic strings.