### PR TITLE
feat: extend unnecessary_host_function_call beyond Ledger to the remaining host object types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to Semantic Versioning.
 
 - New lint `symbol_new_for_short_literal` detecting `Symbol::new(&env, "literal")` calls where the literal is a valid short symbol (≤ 9 chars, alphanumeric + underscore) and suggesting the `symbol_short!` macro for compile-time creation.
 
+### Changed
+
+- `unnecessary_host_function_call` now covers every host accessor reachable from
+  `Env` — `crypto()`, `prng()`, `events()`, `deployer()` and
+  `current_contract_address()` alongside `ledger()` — and no longer reports
+  calls whose receiver or arguments change from iteration to iteration.
+
 ## [0.1.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The linter hooks into the Rust compiler's AST to catch specific Soroban anti-pat
 
 *   **[`soroban_storage_in_loop`](docs/lints/soroban_storage_in_loop.md):** Flags storage read/write operations placed inside loop bodies, suggesting memory aggregation instead.
 *   **[`redundant_env_clone`](docs/lints/redundant_env_clone.md):** Detects unnecessary `.clone()` calls on the Soroban `Env` object.
-*   **[`unnecessary_host_function_call`](docs/lints/unnecessary_host_function_call.md):** Identifies redundant calls to host functions (like fetching the ledger sequence) that should be called once and bound to a local variable.
+*   **[`unnecessary_host_function_call`](docs/lints/unnecessary_host_function_call.md):** Identifies host accessor calls (`Ledger`, `Crypto`, `Prng`, `Events`, `Deployer`, `Env::current_contract_address`) repeated inside a loop with unchanged inputs, which should be called once and bound to a local variable.
 
 ## How it Fits into Tollcraft
 

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -12,7 +12,7 @@ This section provides detailed documentation for all lints supported by `soroban
 
 | Lint                                                                  | Default Severity | Catches                                    |
 | --------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
-| [`unnecessary_host_function_call`](unnecessary_host_function_call.md) | `warn`           | Redundant host function calls inside loops |
+| [`unnecessary_host_function_call`](unnecessary_host_function_call.md) | `warn`           | `Ledger`, `Crypto`, `Prng`, `Events`, `Deployer` and `Env::current_contract_address` calls repeated inside loops with unchanged inputs |
 
 ## Memory
 

--- a/docs/lints/unnecessary_host_function_call.md
+++ b/docs/lints/unnecessary_host_function_call.md
@@ -4,7 +4,23 @@
 
 ## What it does
 
-Identifies redundant calls to host functions, such as fetching the ledger sequence or timestamp, inside loop bodies.
+Flags calls to Soroban host functions inside a loop body when the call takes the
+same inputs on every iteration.
+
+The lint covers the host accessors reachable from `Env`:
+
+| Accessor                        | Type(s) matched                                             |
+| ------------------------------- | ----------------------------------------------------------- |
+| `env.ledger()`                  | `soroban_sdk::ledger::Ledger`                                |
+| `env.crypto()`                  | `soroban_sdk::crypto::Crypto`, `CryptoHazmat`, `Bls12_381`, `Bn254` |
+| `env.prng()`                    | `soroban_sdk::prng::Prng`                                    |
+| `env.events()`                  | `soroban_sdk::events::Events`                                |
+| `env.deployer()`                | `soroban_sdk::deploy::Deployer`, `DeployerWithAddress`, `DeployerWithAsset` |
+| `env.current_contract_address()`| `soroban_sdk::Env`                                           |
+
+Storage accessors (`env.storage()`) are handled by
+[`soroban_storage_in_loop`](soroban_storage_in_loop.md) instead, so they are not
+reported twice.
 
 ## Why is this bad?
 
@@ -19,6 +35,18 @@ Calling a host function crosses the boundary into the Soroban environment, which
 for item in items {
     let current_seq = env.ledger().sequence();
 }
+
+// ❌ Bad: the hashed input never changes
+for _ in 0..n {
+    let digest = env.crypto().sha256(&payload);
+}
+```
+
+```rust
+// ✅ Good: the argument changes every iteration, so the call is real work
+for chunk in chunks.iter() {
+    let digest = env.crypto().sha256(chunk);
+}
 ```
 
 ## Suggested Fix
@@ -26,3 +54,30 @@ for item in items {
 {% hint style="success" %}
 Call the host function once before the loop, store the result in a local variable, and reference that variable inside the loop.
 {% endhint %}
+
+## What is not reported
+
+A call is left alone when it reads anything that changes between iterations —
+the loop variable, a `let` inside the loop body, or a variable mutated by the
+loop. Hoisting such a call would change behaviour, so it is not a cost problem
+the lint should raise.
+
+When the mutation analysis cannot reach a verdict for a loop, every call in that
+loop is left alone rather than reported on incomplete information.
+
+Two gaps remain, and both make the lint report a call it could have skipped:
+
+- Bindings and mutations inside a closure body nested in the loop are not seen.
+- Mutation through a raw pointer or through interior mutability (`Cell`,
+  `RefCell`) is not tracked.
+
+## Deliberately not covered
+
+- `env.invoke_contract()`, `env.try_invoke_contract()` and
+  `env.authorize_as_current_contract()` — invoking or authorizing per iteration
+  is what the loop is for, and the cost is inherent rather than redundant.
+- Calls whose per-iteration repetition is intentional, most commonly
+  `env.prng()` generators and `env.events().publish()` with constant arguments,
+  are still reported: they are metered host calls with unchanged inputs, and the
+  lint cannot tell intent. Use `#[allow(unnecessary_host_function_call)]` on
+  those call sites.

--- a/soroban_cost_lints/README.md
+++ b/soroban_cost_lints/README.md
@@ -8,6 +8,6 @@ The lint crate for `soroban-cost-linter`. Compiled as a dynamic library and load
 |------|-------------|
 | [`soroban_storage_in_loop`](../docs/lints/soroban_storage_in_loop.md) | Flags storage read/write operations inside loop bodies, suggesting memory aggregation instead. |
 | [`redundant_env_clone`](../docs/lints/redundant_env_clone.md) | Detects unnecessary `.clone()` calls on the Soroban `Env` object. |
-| [`unnecessary_host_function_call`](../docs/lints/unnecessary_host_function_call.md) | Identifies redundant calls to host functions (like `Ledger` sequences) inside loops that should be called once and cached. |
+| [`unnecessary_host_function_call`](../docs/lints/unnecessary_host_function_call.md) | Identifies calls to host accessors (`Ledger`, `Crypto`, `Prng`, `Events`, `Deployer`, `Env::current_contract_address`) repeated inside loops with unchanged inputs, which should be called once and cached. |
 
 See the [lint reference](../docs/lints/README.md) for full documentation.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -12,9 +12,12 @@ extern crate rustc_span;
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use clippy_utils::get_enclosing_loop_or_multi_call_closure;
 use clippy_utils::source::snippet_opt;
+use clippy_utils::usage::mutated_variables;
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_hir::{HirId, HirIdSet};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_span::def_id::DefId;
 
@@ -24,6 +27,128 @@ fn match_soroban_def_path<'tcx>(cx: &LateContext<'tcx>, def_id: DefId, segments:
     let full = cx.tcx.def_path_str(def_id);
     let suffix: String = segments.join("::");
     full.ends_with(&suffix)
+}
+
+/// Soroban storage accessor types. Every method call on one of these reaches
+/// the host's storage subsystem.
+const SOROBAN_STORAGE_TYPES: &[&[&str]] = &[
+    &["soroban_sdk", "storage", "Storage"],
+    &["soroban_sdk", "storage", "Instance"],
+    &["soroban_sdk", "storage", "Persistent"],
+    &["soroban_sdk", "storage", "Temporary"],
+];
+
+/// Soroban host accessor types reachable from `Env`. A method call on any of
+/// them crosses the guest/host boundary and is metered, so repeating it inside
+/// a loop with unchanged inputs is wasted CPU budget.
+///
+/// `soroban_sdk::storage::*` is deliberately absent: storage operations in a
+/// loop are reported by [`SOROBAN_STORAGE_IN_LOOP`] instead.
+const SOROBAN_HOST_TYPES: &[&[&str]] = &[
+    &["soroban_sdk", "ledger", "Ledger"],
+    &["soroban_sdk", "crypto", "Crypto"],
+    &["soroban_sdk", "crypto", "CryptoHazmat"],
+    &["soroban_sdk", "crypto", "bls12_381", "Bls12_381"],
+    &["soroban_sdk", "crypto", "bn254", "Bn254"],
+    &["soroban_sdk", "prng", "Prng"],
+    &["soroban_sdk", "events", "Events"],
+    &["soroban_sdk", "deploy", "Deployer"],
+    &["soroban_sdk", "deploy", "DeployerWithAddress"],
+    &["soroban_sdk", "deploy", "DeployerWithAsset"],
+];
+
+/// Host calls that live directly on `Env` rather than on an accessor type, and
+/// whose result is constant for the whole invocation.
+///
+/// The accessor methods themselves (`Env::ledger`, `Env::crypto`, ...) are not
+/// listed: they only build a wrapper value, the metered work happens in the
+/// method called on the wrapper. Argument-taking `Env` methods such as
+/// `invoke_contract` or `authorize_as_current_contract` are also excluded
+/// because their cost is inherent to what the loop is doing.
+const SOROBAN_ENV_HOST_METHODS: &[&str] = &["current_contract_address"];
+
+fn matches_any_path<'tcx>(cx: &LateContext<'tcx>, def_id: DefId, paths: &[&[&str]]) -> bool {
+    paths
+        .iter()
+        .any(|segments| match_soroban_def_path(cx, def_id, segments))
+}
+
+/// Collects the `HirId`s of every binding introduced inside the visited
+/// subtree, e.g. the loop variable of a `for` loop or a per-iteration `let`.
+#[derive(Default)]
+struct BindingCollector {
+    bindings: HirIdSet,
+}
+
+impl<'tcx> Visitor<'tcx> for BindingCollector {
+    fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+        if let hir::PatKind::Binding(_, hir_id, _, _) = pat.kind {
+            self.bindings.insert(hir_id);
+        }
+        intravisit::walk_pat(self, pat);
+    }
+}
+
+/// Collects the `HirId`s of every local read in the visited subtree.
+#[derive(Default)]
+struct LocalReadCollector {
+    reads: Vec<HirId>,
+}
+
+impl<'tcx> Visitor<'tcx> for LocalReadCollector {
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        if let hir::ExprKind::Path(hir::QPath::Resolved(None, path)) = expr.kind
+            && let hir::def::Res::Local(hir_id) = path.res
+        {
+            self.reads.push(hir_id);
+        }
+        intravisit::walk_expr(self, expr);
+    }
+}
+
+/// Whether `call` — receiver chain and arguments included — reads anything that
+/// changes from iteration to iteration of `loop_expr`.
+///
+/// Such a call is doing real per-iteration work, so hoisting it out of the loop
+/// would change behaviour and it must not be reported. The answer errs towards
+/// "depends": when the mutation analysis cannot give a verdict, the call is
+/// treated as loop-dependent and stays unreported.
+///
+/// Known gaps, all of which cause a call to be reported rather than skipped:
+/// bindings and mutations inside a closure body nested in the loop are not
+/// seen, and mutation through a raw pointer or interior mutability (`RefCell`,
+/// `Cell`) is not tracked.
+fn depends_on_loop_state<'tcx>(
+    cx: &LateContext<'tcx>,
+    loop_expr: &'tcx hir::Expr<'tcx>,
+    call: &'tcx hir::Expr<'tcx>,
+) -> bool {
+    let Some(mutated) = mutated_variables(loop_expr, cx) else {
+        return true;
+    };
+
+    let mut bound = BindingCollector::default();
+    bound.visit_expr(loop_expr);
+
+    let mut read = LocalReadCollector::default();
+    read.visit_expr(call);
+
+    read.reads
+        .iter()
+        .any(|hir_id| bound.bindings.contains(hir_id) || mutated.contains(hir_id))
+}
+
+/// Whether `expr` sits directly inside a loop body, returning that loop.
+///
+/// A call inside a closure that the loop calls is not reported: the closure may
+/// well be defined elsewhere, and the receiver is out of reach for the
+/// loop-dependence analysis.
+fn enclosing_loop<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx hir::Expr<'tcx>,
+) -> Option<&'tcx hir::Expr<'tcx>> {
+    let enclosing = get_enclosing_loop_or_multi_call_closure(cx, expr)?;
+    matches!(enclosing.kind, hir::ExprKind::Loop(..)).then_some(enclosing)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,20 +220,14 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
 
             let is_storage_access = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
                 let did = adt_def.did();
-                match_soroban_def_path(cx, did, &["soroban_sdk", "storage", "Storage"])
-                    || match_soroban_def_path(cx, did, &["soroban_sdk", "storage", "Instance"])
-                    || match_soroban_def_path(cx, did, &["soroban_sdk", "storage", "Persistent"])
-                    || match_soroban_def_path(cx, did, &["soroban_sdk", "storage", "Temporary"])
+                matches_any_path(cx, did, SOROBAN_STORAGE_TYPES)
                     || (match_soroban_def_path(cx, did, &["soroban_sdk", "Env"])
                         && path_segment.ident.name.as_str() == "storage")
             } else {
                 false
             };
 
-            if is_storage_access
-                && let Some(enclosing_expr) = get_enclosing_loop_or_multi_call_closure(cx, expr)
-                && let hir::ExprKind::Loop(..) = enclosing_expr.kind
-            {
+            if is_storage_access && enclosing_loop(cx, expr).is_some() {
                 span_lint_and_help(
                     cx,
                     SOROBAN_STORAGE_IN_LOOP,
@@ -176,19 +295,22 @@ rustc_session::impl_lint_pass!(HostInLoop => [HOST_IN_LOOP]);
 
 impl<'tcx> LateLintPass<'tcx> for UnnecessaryHostFunctionCall {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
-        if let hir::ExprKind::MethodCall(_path_segment, receiver, _args, _span) = expr.kind {
+        if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
             let receiver_ty = cx.typeck_results().expr_ty(receiver);
             let peeled_ty = receiver_ty.peel_refs();
 
             let is_host_function = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
-                match_soroban_def_path(cx, adt_def.did(), &["soroban_sdk", "ledger", "Ledger"])
+                let did = adt_def.did();
+                matches_any_path(cx, did, SOROBAN_HOST_TYPES)
+                    || (match_soroban_def_path(cx, did, &["soroban_sdk", "Env"])
+                        && SOROBAN_ENV_HOST_METHODS.contains(&path_segment.ident.name.as_str()))
             } else {
                 false
             };
 
             if is_host_function
-                && let Some(enclosing_expr) = get_enclosing_loop_or_multi_call_closure(cx, expr)
-                && let hir::ExprKind::Loop(..) = enclosing_expr.kind
+                && let Some(loop_expr) = enclosing_loop(cx, expr)
+                && !depends_on_loop_state(cx, loop_expr, expr)
             {
                 span_lint_and_help(
                     cx,
@@ -215,10 +337,7 @@ impl<'tcx> LateLintPass<'tcx> for HostInLoop {
                 false
             };
 
-            if is_host
-                && let Some(enclosing_expr) = get_enclosing_loop_or_multi_call_closure(cx, expr)
-                && let hir::ExprKind::Loop(..) = enclosing_expr.kind
-            {
+            if is_host && enclosing_loop(cx, expr).is_some() {
                 span_lint_and_help(
                     cx,
                     HOST_IN_LOOP,

--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -13,7 +13,24 @@ pub mod soroban_sdk {
         pub fn host(&self) -> host::Host {
             host::Host
         }
+        pub fn crypto(&self) -> crypto::Crypto {
+            crypto::Crypto
+        }
+        pub fn prng(&self) -> prng::Prng {
+            prng::Prng
+        }
+        pub fn events(&self) -> events::Events {
+            events::Events
+        }
+        pub fn deployer(&self) -> deploy::Deployer {
+            deploy::Deployer
+        }
+        pub fn current_contract_address(&self) -> Address {
+            Address
+        }
     }
+
+    pub struct Address;
 
     pub mod storage {
         pub struct Storage;
@@ -49,6 +66,35 @@ pub mod soroban_sdk {
         pub struct Ledger;
         impl Ledger {
             pub fn sequence(&self) -> u32 { 0 }
+        }
+    }
+
+    pub mod crypto {
+        pub struct Crypto;
+        impl Crypto {
+            pub fn sha256(&self, _data: &[u8]) -> [u8; 32] { [0; 32] }
+            pub fn keccak256(&self, _data: &[u8]) -> [u8; 32] { [0; 32] }
+        }
+    }
+
+    pub mod prng {
+        pub struct Prng;
+        impl Prng {
+            pub fn u64_in_range(&self, _lo: u64, _hi: u64) -> u64 { 0 }
+        }
+    }
+
+    pub mod events {
+        pub struct Events;
+        impl Events {
+            pub fn publish<T, D>(&self, _topics: T, _data: D) {}
+        }
+    }
+
+    pub mod deploy {
+        pub struct Deployer;
+        impl Deployer {
+            pub fn uploaded_wasm_hash(&self) -> [u8; 32] { [0; 32] }
         }
     }
 
@@ -144,6 +190,54 @@ fn good_host_call_outside_loop(env: Env) {
 fn allowed_host_call_in_loop(env: Env) {
     for _ in 0..10 {
         let _seq = env.ledger().sequence(); // Good (allowed)
+    }
+}
+
+fn bad_crypto_call_in_loop(env: Env) {
+    let data = [1u8, 2, 3];
+    for _ in 0..10 {
+        let _hash = env.crypto().sha256(&data); // Should Warn — same input every iteration
+    }
+}
+
+fn good_crypto_call_on_loop_variable(env: Env) {
+    let data = [[1u8; 4], [2u8; 4], [3u8; 4]];
+    for chunk in data.iter() {
+        let _hash = env.crypto().sha256(chunk); // Good — hashes a different input each iteration
+    }
+}
+
+fn good_crypto_call_indexed_by_counter(env: Env) {
+    let data = [1u8, 2, 3];
+    let mut i = 0;
+    while i < 3 {
+        let _hash = env.crypto().keccak256(&data[i..]); // Good — argument moves with the counter
+        i += 1;
+    }
+}
+
+fn bad_prng_call_in_loop(env: Env) {
+    for _ in 0..10 {
+        let _n = env.prng().u64_in_range(0, 100); // Should Warn
+    }
+}
+
+fn bad_current_contract_address_in_loop(env: Env) {
+    for _ in 0..10 {
+        let _addr = env.current_contract_address(); // Should Warn
+    }
+}
+
+fn good_events_publish_of_loop_value(env: Env) {
+    for i in 0..10 {
+        env.events().publish((i,), i); // Good — publishes the value of this iteration
+    }
+}
+
+fn good_deployer_call_outside_loop(env: Env) {
+    let hash = env.deployer().uploaded_wasm_hash(); // Good — called once before the loop
+    for _ in 0..10 {
+        let _hash = hash;
     }
 }
 

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -1,5 +1,5 @@
 warning: storage operation inside a loop
-  --> $DIR/main.rs:78:9
+  --> $DIR/main.rs:124:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = note: `#[warn(soroban_storage_in_loop)]` on by default
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:78:9
+  --> $DIR/main.rs:124:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:78:9
+  --> $DIR/main.rs:124:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:85:30
+  --> $DIR/main.rs:131:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:85:30
+  --> $DIR/main.rs:131:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:85:30
+  --> $DIR/main.rs:131:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:92:12
+  --> $DIR/main.rs:138:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:92:12
+  --> $DIR/main.rs:138:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:92:12
+  --> $DIR/main.rs:138:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:114:19
+  --> $DIR/main.rs:160:19
    |
 LL |     let _cloned = env.clone(); // Should Warn
    |                   ^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     let _cloned = env.clone(); // Should Warn
    = note: `#[warn(redundant_env_clone)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:132:20
+  --> $DIR/main.rs:178:20
    |
 LL |         let _seq = env.ledger().sequence(); // Should Warn
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,8 +89,32 @@ LL |         let _seq = env.ledger().sequence(); // Should Warn
    = help: call this function outside the loop and reuse the result
    = note: `#[warn(unnecessary_host_function_call)]` on by default
 
+warning: unnecessary host function call inside loop
+  --> $DIR/main.rs:199:21
+   |
+LL |         let _hash = env.crypto().sha256(&data); // Should Warn — same input every iteration
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: call this function outside the loop and reuse the result
+
+warning: unnecessary host function call inside loop
+  --> $DIR/main.rs:221:18
+   |
+LL |         let _n = env.prng().u64_in_range(0, 100); // Should Warn
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: call this function outside the loop and reuse the result
+
+warning: unnecessary host function call inside loop
+  --> $DIR/main.rs:227:21
+   |
+LL |         let _addr = env.current_contract_address(); // Should Warn
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: call this function outside the loop and reuse the result
+
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:155:16
+  --> $DIR/main.rs:249:16
    |
 LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello")`
@@ -98,16 +122,16 @@ LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    = note: `#[warn(symbol_new_for_short_literal)]` on by default
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:159:16
+  --> $DIR/main.rs:253:16
    |
 LL |     let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn - exactly 9 chars
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:167:16
+  --> $DIR/main.rs:261:16
    |
 LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn - 9 chars with underscore
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
 
-warning: 14 warnings emitted
+warning: 17 warnings emitted
 


### PR DESCRIPTION
## Description

`unnecessary_host_function_call` matched exactly one receiver type, `soroban_sdk::ledger::Ledger`. Every other metered host accessor reachable from `Env` was invisible to it. This PR widens the scope to the rest of them and adds a loop-dependence check so the wider scope does not turn into false positives.

Host types are now listed once, in a table:

```rust
const SOROBAN_HOST_TYPES: &[&[&str]] = &[
    &["soroban_sdk", "ledger", "Ledger"],
    &["soroban_sdk", "crypto", "Crypto"],
    &["soroban_sdk", "crypto", "CryptoHazmat"],
    &["soroban_sdk", "crypto", "bls12_381", "Bls12_381"],
    &["soroban_sdk", "crypto", "bn254", "Bn254"],
    &["soroban_sdk", "prng", "Prng"],
    &["soroban_sdk", "events", "Events"],
    &["soroban_sdk", "deploy", "Deployer"],
    &["soroban_sdk", "deploy", "DeployerWithAddress"],
    &["soroban_sdk", "deploy", "DeployerWithAsset"],
];
```

`env.current_contract_address()` is a host call on `Env` itself rather than on an accessor type, so it lives in a separate one-line method list. The storage lint's comparison chain was folded into the same table form, so the `def_path_str` chains no longer grow by hand — a new host type is one line.

`soroban_sdk` has no `Env::auth()` accessor (the issue lists one); the auth-related surface is `Env::authorize_as_current_contract` and `Env::invoke_contract`, both deliberately excluded — see *Deliberately not covered* in the reference page.

### Loop-dependence check

A call is reported only when nothing it reads changes between iterations. It is skipped when the receiver chain or any argument reads a local bound inside the loop (the `for` variable, a per-iteration `let`) or a local the loop mutates, and it is skipped when the mutation analysis returns no verdict at all. `env.crypto().sha256(&data[i])` is real per-iteration work and stays unreported; hoisting it would be wrong.

Two gaps are documented in the reference page, both erring towards reporting rather than silently skipping: bindings and mutations inside a closure nested in the loop are not seen, and mutation through raw pointers or interior mutability is not tracked.

`prng` and `events` calls with constant arguments are still reported. They are metered host calls with unchanged inputs and the lint cannot read intent; the reference page says so and points at `#[allow(...)]`.

## Related Issue

Closes #94

## Motivation and Context

The lint's name and its description in `docs/lints/README.md` both promise host function calls in general, while the implementation covered one type. Contracts calling `env.crypto()`, `env.prng()`, `env.events()`, `env.deployer()` or `env.current_contract_address()` in a loop were paying the repeated host cost with no warning.

Out of scope, as stated in the issue: the path-resolution rework tracked in #15. `match_soroban_def_path` still suffix-matches.

## How Has This Been Tested?

- [x] Added/Updated tests
- [x] Passed `cargo test`
- [x] Passed `cargo clippy`
- [x] Formatted with `cargo fmt`

UI fixtures in `soroban_cost_lints/ui/main.rs` cover four newly supported host types, flagged and non-flagged:

| Fixture | Expected |
| --- | --- |
| `bad_crypto_call_in_loop` | warns — hashes the same input every iteration |
| `good_crypto_call_on_loop_variable` | quiet — hashes the loop variable |
| `good_crypto_call_indexed_by_counter` | quiet — argument indexed by a counter the loop mutates |
| `bad_prng_call_in_loop` | warns |
| `bad_current_contract_address_in_loop` | warns |
| `good_events_publish_of_loop_value` | quiet — publishes this iteration's value |
| `good_deployer_call_outside_loop` | quiet — called once before the loop |

`main.stderr` regenerated: 11 -> 14 warnings, with the three new ones landing exactly on the `bad_*` fixtures.

Local run on `nightly-2026-04-16` with `cargo-dylint`/`dylint-link` 6.0.1: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` all green including the `ui` test and the `cargo-cost-lint` JSON integration test.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

Docs updated: the lint reference page now describes the real scope (covered accessors, what is not reported, what is deliberately excluded), and the `docs/lints/README.md` table, both READMEs and `CHANGELOG.md` match it.