### PR TITLE
feat: print per-lint summary to stderr after run

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ LL |     let _cloned = env.clone();
    |                   ^^^^^^^^^^^
    = help: pass Env by reference or value instead of cloning
    = note: `#[warn(redundant_env_clone)]` on by default
+
+lint summary:
+  redundant_env_clone: 1
+  soroban_storage_in_loop: 3
+  unnecessary_host_function_call: 2
+total: 6
 ```
 
 ### Example: storage in a loop

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, ValueEnum};
 use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -146,6 +146,7 @@ fn main() {
     let stdout = child.stdout.take().expect("Failed to capture stdout");
     let reader = BufReader::new(stdout);
     let mut highest_exit_code = 0;
+    let mut lint_counts: HashMap<String, usize> = HashMap::new();
 
     let mut findings: Vec<LintFinding> = Vec::new();
 
@@ -214,6 +215,8 @@ fn main() {
                                     continue;
                                 }
 
+                                *lint_counts.entry(lint_name.to_string()).or_insert(0) += 1;
+
                                 if level == "error" || level == "deny" {
                                     highest_exit_code = 1;
                                 }
@@ -278,6 +281,19 @@ fn main() {
     }
 
     let status = child.wait().expect("Failed to wait on cargo dylint");
+
+    // Print per-lint summary to stderr when there are findings
+    if !lint_counts.is_empty() {
+        eprintln!("lint summary:");
+        let mut sorted: Vec<_> = lint_counts.iter().collect();
+        sorted.sort_by_key(|(name, _)| *name);
+        for (name, count) in &sorted {
+            eprintln!("  {}: {}", name, count);
+        }
+        let total: usize = lint_counts.values().sum();
+        eprintln!("total: {}", total);
+    }
+
     if !status.success() {
         exit(status.code().unwrap_or(1));
     } else if highest_exit_code != 0 {


### PR DESCRIPTION
Add a per-lint count of findings and a total printed to stderr at the end of each run. The summary is suppressed when there are no findings, keeping clean runs quiet. Exit-code behaviour is unchanged.

- Uses `lint_counts: HashMap<String, usize>` to accumulate counts during the existing JSON message parsing loop
- Prints sorted summary to stderr via `eprintln!` after `child.wait()`
- README.md updated with an example of the summary output

Closes #97