### PR TITLE
Implement bytes_append_in_loop lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ dependencies = [
  "serde",
  "tar",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ dependencies = [
  "rustversion",
  "serde",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1191,6 +1191,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -1367,17 +1376,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1390,13 +1420,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -1608,6 +1658,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
   * [soroban\_storage\_in\_loop](lints/soroban_storage_in_loop.md)
   * [redundant\_env\_clone](lints/redundant_env_clone.md)
   * [unnecessary\_host\_function\_call](lints/unnecessary_host_function_call.md)
+  * [bytes\_append\_in\_loop](lints/bytes_append_in_loop.md)
 
 ## Branding
 

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -23,6 +23,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | Lint                                                                  | Default Severity | Catches                                    |
 | --------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
 | [`redundant_env_clone`](redundant_env_clone.md)                       | `warn`           | Unnecessary `.clone()` calls on `Env`      |
+| [`bytes_append_in_loop`](bytes_append_in_loop.md)                   | `warn`           | Growth-method calls on `Bytes`/`Vec`/`Map` inside loops |
 
 ## Symbol Operations
 

--- a/docs/lints/bytes_append_in_loop.md
+++ b/docs/lints/bytes_append_in_loop.md
@@ -1,0 +1,59 @@
+# `bytes_append_in_loop`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [CPU — host function dispatch and serialization cost](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Detects calls to growth methods (`append`, `push_back`, `insert`, `extend_from_array`) on Soroban SDK container types (`Bytes`, `Vec`, `Map`) inside loop bodies (`for`, `while`, or `loop`).
+
+## Why is this bad?
+
+Each call to a growth method on a Soroban SDK container performs host-side work: the host must reallocate its internal buffer, copy existing elements, and serialize the new data. As the container grows, these operations become progressively more expensive because the buffer being reallocated and copied is larger each time.
+
+Placing such calls inside a loop compounds this cost by the iteration count, turning an O(n) pattern into an O(n²) one for both CPU budget and memory allocation overhead.
+
+## Example
+
+```rust
+use soroban_sdk::{Bytes, Vec};
+
+// ❌ Bad: Host reallocates and copies an increasingly large buffer on
+//          every iteration.
+fn bad(bytes: &mut Bytes) {
+    for _ in 0..10 {
+        bytes.append(&other);
+    }
+}
+```
+
+```rust
+use soroban_sdk::{Bytes, Vec};
+
+// ✅ Good: Accumulate in a native Vec, then convert to the SDK container
+//          once after the loop.
+fn good(items: &[u8]) -> Bytes {
+    let mut buf = Vec::new();
+    for item in items {
+        buf.push(*item);
+    }
+    Bytes::from(buf)
+}
+```
+
+## Small fixed-bound loops
+
+A loop with a small, fixed number of iterations (e.g. 2–3) is usually inexpensive in absolute terms. This is why the lint defaults to `warn` rather than `deny` — use `#[allow(bytes_append_in_loop)]` on the specific call site when the iteration count is small and bounded.
+
+## Suggested Fix
+
+- Accumulate values in native Rust collections (`Vec`, `HashMap`, etc.) during the loop.
+- Convert to the Soroban SDK container once after the loop using `From`/`Into` or equivalent.
+- Pre-size your native collection with `Vec::with_capacity` when the final size is known.
+
+## What is not reported
+
+- Calls made outside a loop body.
+- Calls on types that are not `soroban_sdk::Bytes`, `soroban_sdk::Vec`, or `soroban_sdk::Map`.
+- Methods other than `append`, `push_back`, `insert`, and `extend_from_array`.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -67,6 +67,19 @@ const SOROBAN_HOST_TYPES: &[&[&str]] = &[
 /// because their cost is inherent to what the loop is doing.
 const SOROBAN_ENV_HOST_METHODS: &[&str] = &["current_contract_address"];
 
+/// Soroban SDK container types. Growth-method calls (append, push_back, insert,
+/// extend_from_array) on these inside a loop reallocate host-side state on
+/// every iteration.
+const SOROBAN_CONTAINER_TYPES: &[&[&str]] = &[
+    &["soroban_sdk", "Bytes"],
+    &["soroban_sdk", "Vec"],
+    &["soroban_sdk", "Map"],
+];
+
+/// Methods on [`SOROBAN_CONTAINER_TYPES`] that grow the container's backing
+/// buffer, causing increasingly expensive host-side work per call.
+const BYTES_APPEND_METHODS: &[&str] = &["append", "push_back", "insert", "extend_from_array"];
+
 fn matches_any_path<'tcx>(cx: &LateContext<'tcx>, def_id: DefId, paths: &[&[&str]]) -> bool {
     paths
         .iter()
@@ -186,6 +199,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: SYMBOL_NEW_FOR_SHORT_LITERAL,
         category: LintCategory::SymbolOperations,
     },
+    LintMetadata {
+        lint: BYTES_APPEND_IN_LOOP,
+        category: LintCategory::Memory,
+    },
 ];
 
 #[unsafe(no_mangle)]
@@ -196,12 +213,14 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         UNNECESSARY_HOST_FUNCTION_CALL,
         HOST_IN_LOOP,
         SYMBOL_NEW_FOR_SHORT_LITERAL,
+        BYTES_APPEND_IN_LOOP,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(RedundantEnvClone));
     lint_store.register_late_pass(|_| Box::new(UnnecessaryHostFunctionCall));
     lint_store.register_late_pass(|_| Box::new(HostInLoop));
     lint_store.register_late_pass(|_| Box::new(SymbolNewForShortLiteral));
+    lint_store.register_late_pass(|_| Box::new(BytesAppendInLoop));
 }
 
 rustc_session::declare_lint! {
@@ -401,6 +420,51 @@ impl<'tcx> LateLintPass<'tcx> for SymbolNewForShortLiteral {
                         );
                     }
                 }
+            }
+        }
+    }
+}
+
+// =======================================================================
+// bytes_append_in_loop — Lint
+// =======================================================================
+
+rustc_session::declare_lint! {
+    pub BYTES_APPEND_IN_LOOP,
+    Warn,
+    "repeatedly growing SDK containers inside loops"
+}
+pub struct BytesAppendInLoop;
+rustc_session::impl_lint_pass!(BytesAppendInLoop => [BYTES_APPEND_IN_LOOP]);
+
+impl<'tcx> LateLintPass<'tcx> for BytesAppendInLoop {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
+            let method_name = path_segment.ident.name.as_str();
+            if !BYTES_APPEND_METHODS.contains(&method_name) {
+                return;
+            }
+
+            let receiver_ty = cx.typeck_results().expr_ty(receiver);
+            let peeled_ty = receiver_ty.peel_refs();
+
+            let is_container = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
+                matches_any_path(cx, adt_def.did(), SOROBAN_CONTAINER_TYPES)
+            } else {
+                false
+            };
+
+            if is_container && enclosing_loop(cx, expr).is_some() {
+                span_lint_and_help(
+                    cx,
+                    BYTES_APPEND_IN_LOOP,
+                    expr.span,
+                    "repeatedly growing SDK container inside a loop",
+                    None,
+                    "accumulate values in native Rust collections first, then batch host \
+                     operations or convert to SDK containers once after the loop; \
+                     pre-size where practical",
+                );
             }
         }
     }

--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -107,13 +107,33 @@ pub mod soroban_sdk {
         }
     }
 
+    pub struct Bytes;
+    impl Bytes {
+        pub fn append(&mut self, _other: &Bytes) {}
+        pub fn push_back(&mut self, _v: i32) {}
+        pub fn insert(&mut self, _pos: u32, _v: i32) {}
+        pub fn extend_from_array(&mut self, _v: &[i32]) {}
+    }
+
+    pub struct Vec;
+    impl Vec {
+        pub fn push_back(&mut self, _v: i32) {}
+        pub fn insert(&mut self, _pos: u32, _v: i32) {}
+        pub fn extend_from_array(&mut self, _v: &[i32]) {}
+    }
+
+    pub struct Map;
+    impl Map {
+        pub fn insert(&mut self, _k: i32, _v: i32) {}
+    }
+
     pub struct Symbol;
     impl Symbol {
         pub fn new(_env: &Env, _s: &str) -> Symbol { Symbol }
     }
 }
 
-use soroban_sdk::{Env, Symbol};
+use soroban_sdk::{Bytes, Env, Map, Symbol, Vec};
 
 // =======================================================================
 // soroban_storage_in_loop — Fixtures
@@ -281,6 +301,31 @@ fn good_symbol_new_empty(env: Env) {
 #[allow(symbol_new_for_short_literal)]
 fn allowed_symbol_new_short_literal(env: Env) {
     let _sym = Symbol::new(&env, "hello"); // Good (allowed)
+}
+
+// =======================================================================
+// bytes_append_in_loop — Fixtures
+// =======================================================================
+
+fn bad_bytes_append_in_for_loop() {
+    let mut bytes = Bytes;
+    for _ in 0..10 {
+        bytes.append(&Bytes); // Should Warn
+    }
+}
+
+fn bad_vec_push_back_in_while_loop() {
+    let mut v = Vec;
+    let mut i = 0;
+    while i < 10 {
+        v.push_back(i); // Should Warn
+        i += 1;
+    }
+}
+
+fn good_single_append_outside_loop() {
+    let mut bytes = Bytes;
+    bytes.append(&Bytes); // Good - single append outside loop
 }
 
 fn main() {}

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -1,5 +1,5 @@
 warning: storage operation inside a loop
-  --> $DIR/main.rs:124:9
+  --> $DIR/main.rs:144:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = note: `#[warn(soroban_storage_in_loop)]` on by default
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:124:9
+  --> $DIR/main.rs:144:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:124:9
+  --> $DIR/main.rs:144:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:131:30
+  --> $DIR/main.rs:151:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:131:30
+  --> $DIR/main.rs:151:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:131:30
+  --> $DIR/main.rs:151:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:138:12
+  --> $DIR/main.rs:158:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:138:12
+  --> $DIR/main.rs:158:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:138:12
+  --> $DIR/main.rs:158:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:160:19
+  --> $DIR/main.rs:180:19
    |
 LL |     let _cloned = env.clone(); // Should Warn
    |                   ^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     let _cloned = env.clone(); // Should Warn
    = note: `#[warn(redundant_env_clone)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:178:20
+  --> $DIR/main.rs:198:20
    |
 LL |         let _seq = env.ledger().sequence(); // Should Warn
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |         let _seq = env.ledger().sequence(); // Should Warn
    = note: `#[warn(unnecessary_host_function_call)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:199:21
+  --> $DIR/main.rs:219:21
    |
 LL |         let _hash = env.crypto().sha256(&data); // Should Warn — same input every iteration
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -98,7 +98,7 @@ LL |         let _hash = env.crypto().sha256(&data); // Should Warn — same inp
    = help: call this function outside the loop and reuse the result
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:221:18
+  --> $DIR/main.rs:241:18
    |
 LL |         let _n = env.prng().u64_in_range(0, 100); // Should Warn
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,7 +106,7 @@ LL |         let _n = env.prng().u64_in_range(0, 100); // Should Warn
    = help: call this function outside the loop and reuse the result
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:227:21
+  --> $DIR/main.rs:247:21
    |
 LL |         let _addr = env.current_contract_address(); // Should Warn
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL |         let _addr = env.current_contract_address(); // Should Warn
    = help: call this function outside the loop and reuse the result
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:249:16
+  --> $DIR/main.rs:269:16
    |
 LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello")`
@@ -122,13 +122,13 @@ LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    = note: `#[warn(symbol_new_for_short_literal)]` on by default
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:253:16
+  --> $DIR/main.rs:273:16
    |
 LL |     let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn - exactly 9 chars
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:261:16
+  --> $DIR/main.rs:281:16
    |
 LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn - 9 chars with underscore
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -133,5 +133,22 @@ warning: Symbol::new called with a short literal that could use symbol_short! ma
 LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn - 9 chars with underscore
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
 
-warning: 17 warnings emitted
+warning: repeatedly growing SDK container inside a loop
+  --> $DIR/main.rs:313:9
+   |
+LL |         bytes.append(&Bytes); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: accumulate values in native Rust collections first, then batch host operations or convert to SDK containers once after the loop; pre-size where practical
+   = note: `#[warn(bytes_append_in_loop)]` on by default
+
+warning: repeatedly growing SDK container inside a loop
+  --> $DIR/main.rs:321:9
+   |
+LL |         v.push_back(i); // Should Warn
+   |         ^^^^^^^^^^^^^^
+   |
+   = help: accumulate values in native Rust collections first, then batch host operations or convert to SDK containers once after the loop; pre-size where practical
+
+warning: 19 warnings emitted
 


### PR DESCRIPTION
##close #7 

## Summary

This PR introduces a new `bytes_append_in_loop` lint that detects repeated growth operations on Soroban SDK container types inside loop bodies, helping developers avoid quadratic host-cost patterns.

## Changes

### Lint
- Added the new `BYTES_APPEND_IN_LOOP` lint.
- Registered it with a default severity of **Warn**.
- Detects the following methods when called inside `for`, `while`, or `loop` bodies:
  - `Bytes::append`
  - `Vec::push_back`
  - `Map::insert`
  - `Bytes::extend_from_array`
- Uses the existing receiver type resolution approach based on `cx.typeck_results()` and `def_path_str()`.

### Diagnostics
- Emits a warning explaining the performance implications of repeatedly growing Soroban SDK containers in loops.
- Suggests accumulating data in native Rust collections, batching host operations, or converting once after the loop.

### Documentation
- Added `docs/lints/bytes_append_in_loop.md`.
- Linked the new lint in `docs/SUMMARY.md`.
- Documented why the lint is a warning rather than a deny-level lint for small fixed-bound loops.

### Tests
Added UI tests covering:
- `Bytes::append` inside a `for` loop (warning expected)
- `Vec::push_back` inside a `while` loop (warning expected)
- A single append outside a loop (no warning)

## Verification

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo test --workspace`

Closes #<issue-number>

---

### Local Test Output

Paste the full output of:

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

before submitting the PR.