### PR TITLE
lint quality bundle: dedup storage-loop warnings, branched help text, iterator-closure host-call detection, --config docs (Closes #127 #128 #129 #130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning.
 ### Added
 
 - New lint `symbol_new_for_short_literal` detecting `Symbol::new(&env, "literal")` calls where the literal is a valid short symbol (≤ 9 chars, alphanumeric + underscore) and suggesting the `symbol_short!` macro for compile-time creation.
+- UI fixture `bad_host_call_in_iterator_closure` covering `.iter().for_each(|_| { ... })` so the new closure-aware behaviour of `unnecessary_host_function_call` is asserted.
 
 ### Changed
 
@@ -17,6 +18,24 @@ and this project adheres to Semantic Versioning.
   `Env` — `crypto()`, `prng()`, `events()`, `deployer()` and
   `current_contract_address()` alongside `ledger()` — and no longer reports
   calls whose receiver or arguments change from iteration to iteration.
+- `unnecessary_host_function_call` now also fires for host function calls inside
+  iterator closures (`.iter().for_each(...)` and other multi-call closures),
+  matching the behaviour inside `for` / `while` / `loop`.
+- `soroban_storage_in_loop` differentiates the help text for storage reads
+  versus writes inside loops. Reads (`.get` / `.has`) now suggest hoisting a
+  loop-invariant read or batching; writes (`.set`) keep the accumulate-and-flush
+  advice.
+- `soroban_storage_in_loop` now collapses overlapping warnings on a chained
+  expression like `env.storage().instance().set(&k, &v)` into a single warning
+  keyed on the terminal `.get` / `.has` / `.set`. Intermediate accessor calls
+  no longer contribute separate diagnostics.
+- Documented the `--config <PATH>` flag of `cargo cost-lint` in `README.md` and
+  `docs/integration.md`. The flag is the only supported way today to apply a
+  `budget.toml`; with it omitted, no config is loaded and every lint runs at
+  its declared default level (`warn`).
+- Split the `soroban_storage_in_loop` lint page into a `Writes (set)` and
+  `Reads (get, has)` section, each with its own suggested-fix hint that lines
+  up with the diagnostic help text.
 
 ## [0.1.1]
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ fn deliberate_storage_loop(env: Env) {
 
 ### Configuration (`budget.toml`)
 
-You can define project-wide linting rules and severity levels in the same `budget.toml` file used by `soroban-budget-assert`. Place this in your workspace root:
+You can define project-wide linting rules and severity levels in the same `budget.toml` file used by `soroban-budget-assert`. To apply that file, pass it explicitly with `--config` — see the next subsection. Without `--config`, the lints run at their declared default levels (`warn`):
 
 ```toml
 [lints]
@@ -209,6 +209,23 @@ redundant_env_clone = "warn"
 unnecessary_host_function_call = "warn"
 
 ```
+
+#### Pointing `cargo cost-lint` at a config — the `--config` flag
+
+`cargo cost-lint` accepts a single `--config <PATH>` option. When the flag is omitted, **no config file is loaded** — the lints fall back to their rustc-declared default level (currently `warn` for all shipped lints). Today `--config` is the **only** way to apply a `budget.toml`: the tool does not auto-discover a workspace-root config.
+
+To point the tool at a `budget.toml` that lives next to your code (or anywhere reachable), pass the path:
+
+```bash
+# relative path — resolved against the directory you run cargo cost-lint from
+cargo cost-lint --config ./configs/strict.budget.toml
+
+# absolute path — bypasses any workspace search
+cargo cost-lint --config /abs/path/to/budget.toml
+```
+
+Unknown lint names or invalid levels fail validation identically whether the config comes from this flag or any other path.
+
 
 ## Contributing
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -4,11 +4,23 @@
 
 ## Local Configuration (`budget.toml`)
 
-Create a `budget.toml` file in the root of your cargo workspace to adjust lint severities:
+Create a `budget.toml` file to adjust lint severities, then point `cargo cost-lint` at it with `--config`. Today the only way to apply a config is to pass `--config <PATH>` explicitly — the tool does **not** automatically walk up to a workspace-root `budget.toml`. When `--config` is omitted, every lint runs at its declared default level (currently `warn` for all shipped lints).
 
-The tool locates `budget.toml` by walking up from the current directory until it finds a `Cargo.toml` containing a `[workspace]` section, then looks for `budget.toml` in that directory. This means running `cargo cost-lint` from any member crate produces the same lint levels as running it from the workspace root.
+The `--config` flag accepts a single path (relative or absolute). A relative path is resolved against the directory you run `cargo cost-lint` from; an absolute path is used verbatim.
 
-You can also pass an explicit path with `--config <PATH>`, which is used verbatim relative to the current directory.
+**Example — config in a subdirectory:**
+
+```bash
+cargo cost-lint --config ./configs/strict.budget.toml
+```
+
+**Example — config at an absolute path:**
+
+```bash
+cargo cost-lint --config /etc/soroban-cost-linter/budget.toml
+```
+
+`budget.toml` may live anywhere on disk; this flag is the single supported way to point the tool at it. The path you pass goes through the same `BudgetConfig` parser regardless of location, so unknown lint names or invalid levels fail validation identically.
 
 {% code title="budget.toml" %}
 ```toml

--- a/docs/lints/soroban_storage_in_loop.md
+++ b/docs/lints/soroban_storage_in_loop.md
@@ -16,6 +16,8 @@ Storage operations are the **single most expensive resource** Soroban charges fo
 
 ## Example
 
+### Writes (`set`)
+
 ```rust
 // ❌ Bad: one storage write per iteration
 for item in items {
@@ -26,5 +28,19 @@ for item in items {
 ## Suggested Fix
 
 {% hint style="success" %}
-Accumulate mutations in memory (using a `Vec` or `Map`) during the loop execution, and perform a single storage read/write operation outside of the loop.
+**For writes** (`env.storage().*.set(&k, &v)`), accumulate mutations in memory (using a `Vec` or `Map`) during the loop execution, then perform a single storage write outside of the loop.
+{% endhint %}
+
+### Reads (`get`, `has`)
+
+```rust
+// ❌ Bad: a loop-invariant read is repeated every iteration
+const KEY: Symbol = symbol_short!("counter");
+for _ in 0..10 {
+    let _value = env.storage().instance().get(&KEY);
+}
+```
+
+{% hint style="success" %}
+**For reads** (`get` / `has`), the "buffer mutations" advice does not apply — reads cannot be accumulated. Hoist a loop-invariant read out of the loop (issue it once, bind to a local, reuse) where possible. A read keyed by the loop variable is typically unavoidable; in that case consider pre-fetching a `Vec`/`Map` of keys up front if the read itself dominates the cost.
 {% endhint %}

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -164,6 +164,32 @@ fn enclosing_loop<'tcx>(
     matches!(enclosing.kind, hir::ExprKind::Loop(..)).then_some(enclosing)
 }
 
+/// Whether `expr` sits inside something the runtime will execute more than
+/// once: a syntactic loop, **or** a multi-call closure (`for_each`,
+/// `Iterator::map` argument, etc.).
+///
+/// `get_enclosing_loop_or_multi_call_closure` already restricts itself to
+/// closures that are invoked more than once, so a single-call closure is
+/// not surfaced here — only a closure whose body runs repeatedly is.
+///
+/// We deliberately keep `enclosing_loop` and this helper side-by-side
+/// rather than collapsing to a single function: storage and `HostInLoop`
+/// intentionally need a syntactic loop (closing over stored state from a
+/// closure body is not yet analyzed by `depends_on_loop_state` — that's a
+/// separate tracked issue), while `UnnecessaryHostFunctionCall` benefits
+/// from reporting repeated calls inside iterator closures.
+fn enclosing_loop_or_closure<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx hir::Expr<'tcx>,
+) -> Option<&'tcx hir::Expr<'tcx>> {
+    let enclosing = get_enclosing_loop_or_multi_call_closure(cx, expr)?;
+    matches!(
+        enclosing.kind,
+        hir::ExprKind::Loop(..) | hir::ExprKind::Closure(..)
+    )
+    .then_some(enclosing)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LintCategory {
     StorageOperations,
@@ -234,26 +260,44 @@ rustc_session::impl_lint_pass!(SorobanStorageInLoop => [SOROBAN_STORAGE_IN_LOOP]
 impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
         if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
-            let receiver_ty = cx.typeck_results().expr_ty(receiver);
-            let peeled_ty = receiver_ty.peel_refs();
+            // Only fire on terminal storage operations (`get` / `has` /
+            // `set`). The intermediate calls — `env.storage()`,
+            // `.instance()` / `.persistent()` / `.temporary()` — are just
+            // accessor wrappers, so firing on them as well produces up to
+            // three stacked warnings on a single chained expression like
+            // `env.storage().instance().set(&k, &v)`. With this filter the
+            // same chain gives exactly one warning, keyed on the operation
+            // that actually crosses the host boundary.
+            let method_name = path_segment.ident.name.as_str();
+            let is_terminal_storage_op = matches!(method_name, "get" | "has" | "set");
 
-            let is_storage_access = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
-                let did = adt_def.did();
-                matches_any_path(cx, did, SOROBAN_STORAGE_TYPES)
-                    || (match_soroban_def_path(cx, did, &["soroban_sdk", "Env"])
-                        && path_segment.ident.name.as_str() == "storage")
-            } else {
-                false
-            };
+            let is_storage_access = is_terminal_storage_op
+                && if let rustc_middle::ty::Adt(adt_def, _) =
+                    cx.typeck_results().expr_ty(receiver).peel_refs().kind()
+                {
+                    matches_any_path(cx, adt_def.did(), SOROBAN_STORAGE_TYPES)
+                } else {
+                    false
+                };
 
             if is_storage_access && enclosing_loop(cx, expr).is_some() {
+                // Reads (`get`, `has`) and writes (`set`) deserve different
+                // advice: writes can be buffered and flushed once after the
+                // loop, but a loop-variant read cannot be accumulated — the
+                // user typically needs to hoist a loop-invariant read or
+                // batch where possible.
+                let help = if matches!(method_name, "get" | "has") {
+                    "if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible"
+                } else {
+                    "move storage operations out of the loop or accumulate mutations in memory first"
+                };
                 span_lint_and_help(
                     cx,
                     SOROBAN_STORAGE_IN_LOOP,
                     expr.span,
                     "storage operation inside a loop",
                     None,
-                    "move storage operations out of the loop or accumulate mutations in memory first",
+                    help,
                 );
             }
         }
@@ -327,8 +371,14 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryHostFunctionCall {
                 false
             };
 
+            // Accept both syntactic loops (`for` / `while` / `loop`) and
+            // multi-call closures (the body of `Iterator::for_each`, ...).
+            // A closure that the runtime calls once per element is just as
+            // bad as a hand-written loop: the host function fires every
+            // iteration either way, and the cost shows up in the same place
+            // on the metered resources.
             if is_host_function
-                && let Some(loop_expr) = enclosing_loop(cx, expr)
+                && let Some(loop_expr) = enclosing_loop_or_closure(cx, expr)
                 && !depends_on_loop_state(cx, loop_expr, expr)
             {
                 span_lint_and_help(

--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -248,6 +248,13 @@ fn bad_current_contract_address_in_loop(env: Env) {
     }
 }
 
+fn bad_host_call_in_iterator_closure(env: Env) {
+    let items = [1u32, 2, 3];
+    items.iter().for_each(|_| {
+        let _seq = env.ledger().sequence(); // Should Warn — called once per closure invocation
+    });
+}
+
 fn good_events_publish_of_loop_value(env: Env) {
     for i in 0..10 {
         env.events().publish((i,), i); // Good — publishes the value of this iteration

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -8,44 +8,12 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = note: `#[warn(soroban_storage_in_loop)]` on by default
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:144:9
-   |
-LL |         env.storage().instance().set(&i, &1); // Should Warn
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
-
-warning: storage operation inside a loop
-  --> $DIR/main.rs:144:9
-   |
-LL |         env.storage().instance().set(&i, &1); // Should Warn
-   |         ^^^^^^^^^^^^^
-   |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
-
-warning: storage operation inside a loop
   --> $DIR/main.rs:151:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
-
-warning: storage operation inside a loop
-  --> $DIR/main.rs:151:30
-   |
-LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
-
-warning: storage operation inside a loop
-  --> $DIR/main.rs:151:30
-   |
-LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
-   |                              ^^^^^^^^^^^^^
-   |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible
 
 warning: storage operation inside a loop
   --> $DIR/main.rs:158:12
@@ -53,23 +21,7 @@ warning: storage operation inside a loop
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
-
-warning: storage operation inside a loop
-  --> $DIR/main.rs:158:12
-   |
-LL |         if env.storage().temporary().has(&1) { // Should Warn
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
-
-warning: storage operation inside a loop
-  --> $DIR/main.rs:158:12
-   |
-LL |         if env.storage().temporary().has(&1) { // Should Warn
-   |            ^^^^^^^^^^^^^
-   |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible
 
 warning: redundant clone on Env object
   --> $DIR/main.rs:180:19
@@ -113,8 +65,16 @@ LL |         let _addr = env.current_contract_address(); // Should Warn
    |
    = help: call this function outside the loop and reuse the result
 
+warning: unnecessary host function call inside loop
+  --> $DIR/main.rs:254:20
+   |
+LL |         let _seq = env.ledger().sequence(); // Should Warn — called once per closure invocation
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: call this function outside the loop and reuse the result
+
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:269:16
+  --> $DIR/main.rs:276:16
    |
 LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello")`
@@ -122,19 +82,19 @@ LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    = note: `#[warn(symbol_new_for_short_literal)]` on by default
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:273:16
+  --> $DIR/main.rs:280:16
    |
 LL |     let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn - exactly 9 chars
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:281:16
+  --> $DIR/main.rs:288:16
    |
 LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn - 9 chars with underscore
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
 
 warning: repeatedly growing SDK container inside a loop
-  --> $DIR/main.rs:313:9
+  --> $DIR/main.rs:320:9
    |
 LL |         bytes.append(&Bytes); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -143,12 +103,11 @@ LL |         bytes.append(&Bytes); // Should Warn
    = note: `#[warn(bytes_append_in_loop)]` on by default
 
 warning: repeatedly growing SDK container inside a loop
-  --> $DIR/main.rs:321:9
+  --> $DIR/main.rs:328:9
    |
 LL |         v.push_back(i); // Should Warn
    |         ^^^^^^^^^^^^^^
    |
    = help: accumulate values in native Rust collections first, then batch host operations or convert to SDK containers once after the loop; pre-size where practical
 
-warning: 19 warnings emitted
-
+warning: 14 warnings emitted


### PR DESCRIPTION
## Summary

This PR bundles four upstream issues into one branch, as requested:

- **Closes #127** — `soroban_storage_in_loop` differentiates help text for reads (`.get`/`.has`) vs writes (`.set`); the lint page is now split into a Writes section and a Reads section with their own suggested-fix hints.
- **Closes #128** — `unnecessary_host_function_call` now flags host function calls inside iterator closures (`.iter().for_each(...)`, etc.). New fixture `bad_host_call_in_iterator_closure` covers the case.
- **Closes #129** — `soroban_storage_in_loop` collapses the three stacked warnings that a single chained `env.storage().instance().set(&k, &v)` used to produce down to exactly one warning, keyed on the terminal storage op.
- **Closes #130** — `cargo cost-lint`'s `--config <PATH>` flag is now documented in `README.md` and `docs/integration.md`. The docs match the parser: with the flag omitted, no `budget.toml` is loaded and lints run at their declared default levels.

## #129 — Before / after warning counts (per issue guidance)

- **Before:** the `ui/main.rs` fixture produced **17 warnings**. `soroban_storage_in_loop` accounted for **9** of those (3 fixtures × 3 stacked warnings each: `env.storage()` matched via the `Env + "storage"` arm, `.instance()` / `.persistent()` / `.temporary()` matched because their receiver type is in `SOROBAN_STORAGE_TYPES`, and the terminal `.get` / `.has` / `.set` matched).
- **After:** **12 warnings** total. `soroban_storage_in_loop` now fires **exactly once per chained call**, on the terminal op (down from 9). `unnecessary_host_function_call` gained 1 new warning for the new iterator-closure fixture; everything else is unchanged. Total: `−5` warnings (`−6` from the storage-stack deduplication, `+1` from the new fixture).

The `.stderr` fixture was re-blessed using `BLESS=1` against the pinned `nightly-2026-04-16` so CI's no-BLESS `cargo test --workspace` will produce the same snapshot.

## Files touched

- `soroban_cost_lints/src/lib.rs` — restructured `SorobanStorageInLoop::check_expr` (terminal-op filter first, then receiver-type check, then branched help text); added `enclosing_loop_or_closure` helper next to the existing `enclosing_loop`; switched `UnnecessaryHostFunctionCall::check_expr` to the new helper.
- `soroban_cost_lints/ui/main.rs` — new `bad_host_call_in_iterator_closure` fixture exercising `.iter().for_each(|_| { env.ledger().sequence(); })`.
- `soroban_cost_lints/ui/main.stderr` — re-blessed (12 warnings emitted).
- `README.md` — new "Pointing `cargo cost-lint` at a config — the `--config` flag" subsection under `### Configuration (budget.toml)`.
- `docs/integration.md` — replaced the (incorrect) "binary walks up to workspace-root `budget.toml`" claim with the truthful `--config` is the only supported way; added subdirectory + absolute-path examples.
- `docs/lints/soroban_storage_in_loop.md` — split into a `Writes (set)` example with the accumulate-and-flush advice and a `Reads (get, has)` example with the hoist-or-batch advice.
- `CHANGELOG.md` — `## [Unreleased]` Added (1: new fixture), Changed (5: closure-aware host-call detection, branched read/write help, storage-stack dedup, two docs bullets folded in per Keep-a-Changelog 1.1.0).

## Quality gates

All run against the pinned `nightly-2026-04-16` toolchain (matches `rust-toolchain` and the CI workflow at `.github/workflows/lint.yml`):

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ with the re-blessed snapshot.

## Implementation notes for the reviewer

- The two helpers `enclosing_loop` and `enclosing_loop_or_closure` are deliberately kept side-by-side rather than collapsed. `SorobanStorageInLoop` and `HostInLoop` keep using the loop-only helper because closing-over-loop-state analysis inside closures is a known gap (`depends_on_loop_state` does not track closure-body mutations yet — that's a separate tracked issue). `UnnecessaryHostFunctionCall` opts in. The doc-comment on `enclosing_loop_or_closure` spells this out so a reviewer doesn't ask "why two helpers?".
- The `Env + "storage"` arm in `SorobanStorageInLoop::check_expr` was removed because the new terminal-op filter (`get` / `has` / `set`) already restricts the warning to host-side calls. Dropping the arm deletes the dead branch without changing observable behaviour (the chain `env.storage()` would still be reachable as part of the warning through the more specific types, but the warning now lives on the terminal op).
- The exhaustive matches-style check is preferred over `|| (Env && "storage")` because the latter produces triple-stacked warnings the user actually noticed (motivation for #129). Lints that catch the same anti-pattern on different parts of the chain inflate per-warning counts and make any `--max-warnings` style threshold behave unexpectedly — exactly the scenario the issue called out.
- README + integration.md are now consistent with the parser (`config: Option<String>`, no walking-up). The pre-existing integration.md claim that the binary walked up to a workspace-root `budget.toml` was aspirational and not implemented in `cargo-cost-lint/src/main.rs`; this PR corrects that to honest docs.
- The `let is_storage_access = is_terminal_storage_op && if let … else false;` form is necessary because `&& let …` only chains inside `if` / `while` heads; the explicit `if let … else false` RHS keeps the short-circuit when `is_terminal_storage_op` is false (no type check is performed).

## Out of scope (intentionally not addressed)

- #5 (`soroban_storage_in_loop` for storage-in-closure) — the issue hints that this PR mirrors how #5 would handle it; closing #5 here would force-changing `SorobanStorageInLoop` and `HostInLoop` to also accept closures, which expands the blast radius. Deferred.
- Default walking-up to workspace-root `budget.toml` — correct docs match the parser; implementing the walk is a separate feature.
