### PR TITLE
docs: note #207 is invalid - src/module_17.rs does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to Semantic Versioning.
 
 - New lint `symbol_new_for_short_literal` detecting `Symbol::new(&env, "literal")` calls where the literal is a valid short symbol (≤ 9 chars, alphanumeric + underscore) and suggesting the `symbol_short!` macro for compile-time creation.
 
+### Fixed
+
+- Confirmed that `src/module_17.rs` does not exist and the codebase contains no bitwise manipulation logic; issue #207 is invalid.
+
 ### Changed
 
 - `unnecessary_host_function_call` now covers every host accessor reachable from


### PR DESCRIPTION
## Summary

Closes #207

## Investigation

Issue #207 requested adding inline comments for complex bitwise operations in src/module_17.rs. After a thorough investigation of the entire codebase:

- **src/module_17.rs does not exist** -- the src/ directory itself is absent; all lint logic lives in soroban_cost_lints/src/lib.rs.
- **No bitwise operations exist anywhere in the codebase.** A regex search for <<, >>, 