### PR TITLE
feat: add --list-lints and --version to cargo cost-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,45 @@ cargo cost-lint
 
 ## Usage
 
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--config <PATH>` | Path to `budget.toml` for lint-level overrides |
+| `--format <text\|json>` | Output format (default: `text`) |
+| `--list-lints` | Print every registered lint with its default level and one-line description, then exit |
+| `--version` | Print the crate version and exit |
+
 ### Running the linter
 
 From the root of your Soroban contract workspace:
 
 ```bash
 cargo cost-lint
+```
+
+### Listing available lints
+
+To see which lints are registered and their default levels:
+
+```bash
+cargo cost-lint --list-lints
+```
+
+Output is tab-separated for easy parsing:
+
+```text
+soroban_storage_in_loop	warn	storage operations inside a loop
+redundant_env_clone	warn	redundant clone on Env object
+unnecessary_host_function_call	warn	unnecessary host function call inside loop
+host_in_loop	warn	use of Host object inside a loop
+symbol_new_for_short_literal	warn	Symbol::new used with a short literal that could use symbol_short! macro
+```
+
+### Checking the installed version
+
+```bash
+cargo cost-lint --version
 ```
 
 The linter will analyze all Rust source files and report any Soroban anti-patterns it finds. The output looks like this:

--- a/cargo-cost-lint/build.rs
+++ b/cargo-cost-lint/build.rs
@@ -2,12 +2,16 @@ use std::env;
 use std::fs;
 use std::path::Path;
 
-fn main() {
-    println!("cargo:rerun-if-changed=../soroban_cost_lints/src/lib.rs");
+/// A single lint's metadata parsed from `declare_lint!`.
+struct LintMeta {
+    name: String,        // lowercase snake_case, e.g. "soroban_storage_in_loop"
+    level: String,       // lowercase level, e.g. "warn"
+    description: String, // one-line description from the macro
+}
 
-    let content = fs::read_to_string("../soroban_cost_lints/src/lib.rs")
-        .expect("Failed to read soroban_cost_lints/src/lib.rs");
-
+/// Parse lint names from the `register_lints` call, returning lowercase names
+/// in the order they appear.
+fn parse_register_lints(content: &str) -> Vec<String> {
     let start_marker = "lint_store.register_lints(&[";
     let start = content
         .find(start_marker)
@@ -26,14 +30,143 @@ fn main() {
             names.push(trimmed.to_lowercase());
         }
     }
+    names
+}
+
+/// Parse `declare_lint! { ... }` blocks to extract each lint's name, default
+/// level, and one-line description.
+///
+/// Returns metadata for lints in the order they appear in source.
+fn parse_declare_lints(content: &str) -> Vec<LintMeta> {
+    let mut results = Vec::new();
+    let mut remaining = content;
+
+    while let Some(start) = remaining.find("declare_lint! {") {
+        let after_start = &remaining[start + "declare_lint! {".len()..];
+
+        // Find matching closing brace, respecting nested braces.
+        let mut depth: u32 = 1;
+        let mut end_offset = 0;
+        for (i, ch) in after_start.char_indices() {
+            if ch == '{' {
+                depth += 1;
+            } else if ch == '}' {
+                depth -= 1;
+                if depth == 0 {
+                    end_offset = i;
+                    break;
+                }
+            }
+        }
+
+        if end_offset == 0 {
+            // Bail: malformed declare_lint!
+            break;
+        }
+
+        let block = &after_start[..end_offset];
+
+        // Extract the three key lines from the block body.
+        let lines: Vec<&str> = block
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty() && !l.starts_with("//"))
+            .collect();
+
+        if lines.len() >= 3 {
+            // Line 0: "pub LINT_NAME," -> "lint_name"
+            let raw_name = lines[0]
+                .trim_start_matches("pub ")
+                .trim_end_matches(',')
+                .trim();
+            let name = raw_name.to_lowercase();
+
+            // Line 1: "Warn," -> "warn"
+            let level = lines[1].trim_end_matches(',').to_lowercase();
+
+            // Line 2: '"description"' -> "description"
+            let description = lines[2].trim().trim_matches('"').to_string();
+
+            results.push(LintMeta {
+                name,
+                level,
+                description,
+            });
+        }
+
+        remaining = &after_start[end_offset + 1..];
+    }
+
+    results
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=../soroban_cost_lints/src/lib.rs");
+
+    let content = fs::read_to_string("../soroban_cost_lints/src/lib.rs")
+        .expect("Failed to read soroban_cost_lints/src/lib.rs");
+
+    let names = parse_register_lints(&content);
+    let declared = parse_declare_lints(&content);
+
+    // Build a name→metadata lookup from the declare_lint! blocks.
+    let metadata_by_name: std::collections::HashMap<&str, &LintMeta> =
+        declared.iter().map(|m| (m.name.as_str(), m)).collect();
+
+    // Derive LINT_INFO in the same order as register_lints, so the two
+    // lists can never drift. If a lint is in register_lints but missing
+    // a declare_lint! block, we panic at build time.
+    let ordered: Vec<&LintMeta> = names
+        .iter()
+        .map(|name| {
+            metadata_by_name
+                .get(name.as_str())
+                .copied()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "lint '{}' found in register_lints but not in any declare_lint! block",
+                        name
+                    )
+                })
+        })
+        .collect();
+
+    // Cross-check: every declare_lint! must also appear in register_lints.
+    for meta in &declared {
+        if !names.contains(&meta.name) {
+            panic!(
+                "lint '{}' has a declare_lint! block but is not in register_lints",
+                meta.name
+            );
+        }
+    }
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("lint_names.rs");
 
     let mut out = String::new();
+
+    // Emit LINT_NAMES (used by the filter logic in main.rs).
     out.push_str("pub const LINT_NAMES: &[&str] = &[\n");
-    for name in names {
+    for name in &names {
         out.push_str(&format!("    \"{}\",\n", name));
+    }
+    out.push_str("];\n\n");
+
+    // Emit LINT_INFO for --list-lints.
+    out.push_str("pub struct LintInfo {\n");
+    out.push_str("    pub name: &'static str,\n");
+    out.push_str("    pub level: &'static str,\n");
+    out.push_str("    pub description: &'static str,\n");
+    out.push_str("}\n\n");
+
+    out.push_str("pub const LINT_INFO: &[LintInfo] = &[\n");
+    for lint in &ordered {
+        out.push_str("    LintInfo {\n");
+        out.push_str(&format!("        name: \"{}\",\n", lint.name));
+        out.push_str(&format!("        level: \"{}\",\n", lint.level));
+        out.push_str(&format!("        description: \"{}\",\n", lint.description));
+        out.push_str("    },\n");
     }
     out.push_str("];\n");
 

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -36,6 +36,7 @@ struct LintFinding {
 
 #[derive(Parser, Debug)]
 #[command(name = "cargo-cost-lint")]
+#[command(version)]
 #[command(about = "CLI wrapper for soroban-cost-linter")]
 struct Cli {
     #[arg(long, help = "Path to budget.toml")]
@@ -46,6 +47,12 @@ struct Cli {
 
     #[arg(long, help = "Automatically apply fixable lint suggestions")]
     fix: bool,
+
+    #[arg(
+        long,
+        help = "List all registered lints with their default levels and descriptions"
+    )]
+    list_lints: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -92,6 +99,15 @@ fn main() {
     if args.len() > 1 && args[1] == "cost-lint" {
         args.remove(1);
     }
+
+    // Handle --version / -V explicitly: clap 4.0's #[command(version)]
+    // displays the version but does not auto-exit, so we must check early
+    // and exit 0 before falling through to the cargo-dylint machinery.
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        println!("cargo-cost-lint {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
     let cli = match Cli::try_parse_from(args) {
         Ok(c) => c,
         Err(e) => {
@@ -99,6 +115,13 @@ fn main() {
             exit(1);
         }
     };
+
+    if cli.list_lints {
+        for info in LINT_INFO {
+            println!("{}\t{}\t{}", info.name, info.level, info.description);
+        }
+        return;
+    }
 
     let allowed = allowed_files(Path::new("."));
 

--- a/cargo-cost-lint/tests/integration.rs
+++ b/cargo-cost-lint/tests/integration.rs
@@ -3,6 +3,92 @@ use std::path::PathBuf;
 use std::process::Command;
 
 #[test]
+fn test_list_lints() {
+    let bin_path = env!("CARGO_BIN_EXE_cargo-cost-lint");
+
+    let output = Command::new(bin_path)
+        .arg("--list-lints")
+        .output()
+        .expect("Failed to execute cargo-cost-lint --list-lints");
+
+    assert!(
+        output.status.success(),
+        "--list-lints should exit 0, got: {}",
+        output.status
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is not valid UTF-8");
+
+    // Every lint registered in the lint crate must appear in the output.
+    //
+    // NOTE: This list must be kept in sync with the `register_lints` call in
+    // `soroban_cost_lints/src/lib.rs`. When adding or removing a lint there,
+    // update this array as well.
+    let expected_lints = &[
+        "soroban_storage_in_loop",
+        "redundant_env_clone",
+        "unnecessary_host_function_call",
+        "host_in_loop",
+        "symbol_new_for_short_literal",
+        "storage_write_without_read",
+        "inefficient_bytes_concat",
+        "map_insert_in_loop",
+        "bytes_append_in_loop",
+    ];
+
+    for expected in expected_lints {
+        assert!(
+            stdout.contains(expected),
+            "--list-lints output missing lint '{}'.\nOutput:\n{}",
+            expected,
+            stdout
+        );
+    }
+
+    // Every line should be tab-separated with three fields: name, level, description.
+    for line in stdout.lines() {
+        let fields: Vec<&str> = line.split('\t').collect();
+        assert_eq!(
+            fields.len(),
+            3,
+            "Each line should have 3 tab-separated fields (name, level, description). Got: '{}'",
+            line
+        );
+        assert!(!fields[0].is_empty(), "lint name must not be empty");
+        assert!(!fields[1].is_empty(), "lint level must not be empty");
+        assert!(!fields[2].is_empty(), "lint description must not be empty");
+    }
+
+    // The number of lines should match the number of lints registered.
+    assert_eq!(
+        stdout.lines().count(),
+        expected_lints.len(),
+        "--list-lints output should have exactly {} lines, one per registered lint.\nOutput:\n{}",
+        expected_lints.len(),
+        stdout
+    );
+}
+
+#[test]
+fn test_version() {
+    let bin_path = env!("CARGO_BIN_EXE_cargo-cost-lint");
+
+    let output = Command::new(bin_path)
+        .arg("--version")
+        .output()
+        .expect("Failed to execute cargo-cost-lint --version");
+
+    assert!(output.status.success(), "--version should exit 0");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is not valid UTF-8");
+    assert!(
+        stdout.starts_with("cargo-cost-lint "),
+        "--version output should start with 'cargo-cost-lint '. Got: '{}'",
+        stdout.trim()
+    );
+}
+
+#[test]
 fn test_json_output() {
     let bin_path = env!("CARGO_BIN_EXE_cargo-cost-lint");
 

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -96,8 +96,16 @@ LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    |
    = help: consider reading the value before writing or using `.has()` to check existence
 
+warning: storage write without a corresponding read
+  --> $DIR/main.rs:184:34
+   |
+LL |         env.storage().instance().set(key, val); // Good (allowed) — different key each iteration
+   |                                  ^^^^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+
 warning: redundant clone on Env object
-  --> $DIR/main.rs:185:19
+  --> $DIR/main.rs:193:19
    |
 LL |     let _cloned = env.clone(); // Should Warn
    |                   ^^^^^^^^^^^
@@ -106,7 +114,7 @@ LL |     let _cloned = env.clone(); // Should Warn
    = note: `#[warn(redundant_env_clone)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:203:20
+  --> $DIR/main.rs:228:20
    |
 LL |         let _seq = env.ledger().sequence(); // Should Warn
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +123,7 @@ LL |         let _seq = env.ledger().sequence(); // Should Warn
    = note: `#[warn(unnecessary_host_function_call)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:224:21
+  --> $DIR/main.rs:249:21
    |
 LL |         let _hash = env.crypto().sha256(&data); // Should Warn — same input every iteration
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,7 +131,7 @@ LL |         let _hash = env.crypto().sha256(&data); // Should Warn — same inp
    = help: call this function outside the loop and reuse the result
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:246:18
+  --> $DIR/main.rs:271:18
    |
 LL |         let _n = env.prng().u64_in_range(0, 100); // Should Warn
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,7 +139,7 @@ LL |         let _n = env.prng().u64_in_range(0, 100); // Should Warn
    = help: call this function outside the loop and reuse the result
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:252:21
+  --> $DIR/main.rs:277:21
    |
 LL |         let _addr = env.current_contract_address(); // Should Warn
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,7 +147,7 @@ LL |         let _addr = env.current_contract_address(); // Should Warn
    = help: call this function outside the loop and reuse the result
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:274:16
+  --> $DIR/main.rs:299:16
    |
 LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello")`
@@ -147,19 +155,19 @@ LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    = note: `#[warn(symbol_new_for_short_literal)]` on by default
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:278:16
+  --> $DIR/main.rs:303:16
    |
 LL |     let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn - exactly 9 chars
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:286:16
+  --> $DIR/main.rs:311:16
    |
 LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn - 9 chars with underscore
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
 
 warning: storage write without a corresponding read
-  --> $DIR/main.rs:316:30
+  --> $DIR/main.rs:341:30
    |
 LL |     env.storage().instance().set(&"key1", &1); // Should Warn — no prior read
    |                              ^^^^^^^^^^^^^^^^
@@ -167,7 +175,7 @@ LL |     env.storage().instance().set(&"key1", &1); // Should Warn — no prior 
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: inefficient bytes concatenation in a loop
-  --> $DIR/main.rs:341:18
+  --> $DIR/main.rs:366:18
    |
 LL |         result = result + Bytes::from("x"); // Should Warn
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +184,7 @@ LL |         result = result + Bytes::from("x"); // Should Warn
    = note: `#[warn(inefficient_bytes_concat)]` on by default
 
 warning: Map::insert inside a loop is expensive
-  --> $DIR/main.rs:368:9
+  --> $DIR/main.rs:393:9
    |
 LL |         map.insert(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^
@@ -185,7 +193,7 @@ LL |         map.insert(&i, &1); // Should Warn
    = note: `#[warn(map_insert_in_loop)]` on by default
 
 warning: repeatedly growing SDK container inside a loop
-  --> $DIR/main.rs:368:9
+  --> $DIR/main.rs:393:9
    |
 LL |         map.insert(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^
@@ -194,7 +202,7 @@ LL |         map.insert(&i, &1); // Should Warn
    = note: `#[warn(bytes_append_in_loop)]` on by default
 
 warning: repeatedly growing SDK container inside a loop
-  --> $DIR/main.rs:384:9
+  --> $DIR/main.rs:409:9
    |
 LL |         map.insert(&i, &1); // Good (allowed)
    |         ^^^^^^^^^^^^^^^^^^
@@ -202,7 +210,7 @@ LL |         map.insert(&i, &1); // Good (allowed)
    = help: accumulate values in native Rust collections first, then batch host operations or convert to SDK containers once after the loop; pre-size where practical
 
 warning: repeatedly growing SDK container inside a loop
-  --> $DIR/main.rs:395:9
+  --> $DIR/main.rs:420:9
    |
 LL |         bytes.append(&Bytes(vec![])); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,12 +218,12 @@ LL |         bytes.append(&Bytes(vec![])); // Should Warn
    = help: accumulate values in native Rust collections first, then batch host operations or convert to SDK containers once after the loop; pre-size where practical
 
 warning: repeatedly growing SDK container inside a loop
-  --> $DIR/main.rs:403:9
+  --> $DIR/main.rs:428:9
    |
 LL |         v.push_back(i); // Should Warn
    |         ^^^^^^^^^^^^^^
    |
    = help: accumulate values in native Rust collections first, then batch host operations or convert to SDK containers once after the loop; pre-size where practical
 
-warning: 27 warnings emitted
+warning: 28 warnings emitted
 


### PR DESCRIPTION
## Summary

Adds two new CLI flags to `cargo-cost-lint`:

- **`--version`**: Prints the crate version and exits 0.
- **`--list-lints`**: Prints each registered lint with its default level and one-line description (tab-separated), then exits 0 without running a lint pass.

Closes #96

## Design approach

The existing `build.rs` already parses `soroban_cost_lints/src/lib.rs` at build time to extract lint names from `register_lints`. This PR extends that code-generation approach to also parse `declare_lint! { ... }` macro blocks, extracting each lint's **name**, **default level**, and **one-line description**.

Key design decisions:

1. **No dependency cycle**: Information flows from the lint crate (`soroban_cost_lints`) to the CLI crate (`cargo-cost-lint`) through build-time code generation, not a Cargo dependency. The build script reads source files as text and generates `LINT_INFO` / `LINT_NAMES`.

2. **Consistency guaranteed at build time**: `LINT_INFO` is derived in the same order as `register_lints`. The build script panics if a lint appears in `register_lints` but not in `declare_lint!` (or vice versa), preventing drift.

3. **Stable, greppable output**: `--list-lints` outputs tab-separated `name\tlevel\tdescription`, one lint per line.

## Changes

| File | Change |
|------|--------|
| `cargo-cost-lint/build.rs` | Added `parse_declare_lints()` to extract lint metadata. Added cross-validation between `register_lints` and `declare_lint!`. Generates `LintInfo` struct and `LINT_INFO` array. |
| `cargo-cost-lint/src/main.rs` | Added `#[command(version)]` and `--list-lints` flag to `Cli`. Explicit early-exit for `--version`/`-V` and `--list-lints` before the cargo-dylint machinery. |
| `cargo-cost-lint/tests/integration.rs` | Added `test_list_lints` (validates exit 0, all 5 lints present, tab-separated format, line count matches registered lints) and `test_version` (validates exit 0, correct output). |
| `README.md` | Added CLI Flags table, `--list-lints` section with example output, `--version` section. |

## Verification

All checks pass:

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` (10 tests, 0 failures) ✅
