### PR TITLE
docs: update outdated links in README (#200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" />
   </p>
   <p>
-    <a href="https://tollcraft.gitbook.io/docs"><strong>Documentation</strong></a> ·
-    <a href="https://asciinema.org/a/1DpqHMqqOOXoZzMI"><strong>Demo</strong></a>
+    <a href="https://tollcraft.gitbook.io/docs"><strong>Documentation</strong></a>
   </p>
 </div>
 


### PR DESCRIPTION
## Description

This PR updates the README to remove outdated and broken links as part of issue #200.

## Changes Made

- **Removed broken asciinema demo link**: The demo link (https://asciinema.org/a/1DpqHMqqOOXoZzMI) was timing out and appears to be inaccessible. This link has been removed from the README header.
- **Verified all remaining links**: Tested all external and internal documentation links to ensure they are still valid
  - ✓ Documentation link: https://tollcraft.gitbook.io/docs (200 OK)
  - ✓ GitHub repository links (all valid)
  - ✓ Community links: Discord (301 redirect, working), Telegram (200 OK)
  - ✓ All internal documentation links point to existing files

## Code Quality Checks

- ✓ `cargo fmt --all -- --check` (passed - no formatting issues)
- Documentation links verified with curl testing

## Closes

Closes #200