### PR TITLE
Fix: docs: document the release process for new lints (Auto-Generated)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ This tool leverages Dylint to hook into the Rust compiler's AST and High-Level I
 
    ```bash
    cargo test
-```
+   ```
 
 ### 3. Adding a New Lint
 - Read the [Scope: Clippy vs. soroban-cost-linter](../docs/scope_boundary.md) guide first. If a pattern is already covered by a Clippy lint and the Soroban cost story does not change the analysis, do not duplicate it here.
@@ -85,7 +85,7 @@ All PRs are checked by CI, and these checks must pass before a PR can be merged.
 
    ```bash
    cargo test --workspace
-```
+   ```
 
 Follow the patterns already used in the codebase: `soroban_cost_lints` uses edition 2024, so prefer let-chains (`if let ... && let ...`) over nested `if let` blocks, and match the structure of the existing lint passes when adding a new lint.
 
@@ -109,7 +109,13 @@ The pinned nightly is declared once in `rust-toolchain` (the single source of tr
 
 If any file is out of sync, the drift guard will print an error naming the file, the mismatched value, and the expected one.
 
-### 6. Submitting a Pull Request
+### 6. Releasing a New Lint
+
+A new lint is released as part of the next project version after its implementation has been merged. The release process is documented in [Releasing a New Lint](docs/release_process.md).
+
+Before a release, maintainers must confirm that the lint is complete, documented, registered, covered by UI tests, and included in the changelog. The lint name must remain stable after release because it is part of the public configuration and command-line interface.
+
+### 7. Submitting a Pull Request
 - Ensure your PR targets the `main` branch.
 - Make sure the checks in the section above (`cargo fmt`, `cargo clippy`, `cargo test`) all pass.
 - Provide a clear description of what the lint does and why it saves costs.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,0 +1,72 @@
+# Releasing a New Lint
+
+This guide describes how maintainers release a new lint in `soroban-cost-linter`. A lint is not ready for release until its implementation, tests, documentation, registry metadata, and changelog entry are all complete.
+
+## 1. Confirm release readiness
+
+Before preparing a release, verify that the lint:
+
+- Has a stable lowercase `snake_case` name.
+- Is registered in `soroban_cost_lints/src/lib.rs` and assigned to the correct cost category.
+- Has UI coverage in the `soroban_cost_lints/ui` test suite, including the expected diagnostic output and non-triggering cases where appropriate.
+- Has a lint reference page in `docs/lints/`.
+- Is listed in `docs/lints/README.md`, the project `README.md`, and `soroban_cost_lints/README.md` where applicable.
+- Explains the Soroban cost impact and, when useful, includes a compliant alternative.
+- Does not duplicate a Clippy lint covered by the project's scope rules.
+- Has no unexpected findings in the real-world corpus.
+
+Lint names are part of the public interface. Once released, do not rename or remove a lint without treating the change as a compatibility change and documenting it explicitly.
+
+## 2. Validate the change
+
+Run the same checks used by CI from the repository root:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+If the lint changes findings in the real-world corpus, review the new findings rather than blindly updating the baseline. Only regenerate the baseline after confirming that each new finding is expected:
+
+```bash
+BLESS=1 cargo test --test real_world_corpus --workspace
+```
+
+Review the resulting baseline change before committing it.
+
+## 3. Update the changelog
+
+Add a user-facing entry under the `Unreleased` section of `CHANGELOG.md`. The entry should include:
+
+- The lint name.
+- The pattern it detects.
+- The Soroban resource or cost category affected.
+- A short description of the recommended alternative, if one is available.
+
+Keep the entry in `Unreleased` until the release version is known. Do not describe an unreleased lint as available in a versioned section.
+
+## 4. Prepare the versioned release
+
+When the release is approved:
+
+1. Review all changes since the previous release and confirm that the new lint and its documentation are included.
+2. Update the package version according to the repository's versioning policy. Keep related package versions consistent when they are released together.
+3. Move the relevant `CHANGELOG.md` entries from `Unreleased` into a new versioned section with the release date.
+4. Run the complete validation commands again after changing the version or changelog.
+5. Commit the release preparation changes and create the release tag using the repository's established tag format.
+6. Publish the release through the repository's configured release workflow or hosting process.
+
+Do not publish a lint before its documentation and expected diagnostics are present in the same release. Downstream users should be able to discover the lint name, understand its diagnostic, and determine how to configure or suppress it from the released documentation.
+
+## 5. Verify the release
+
+After the release is published:
+
+- Confirm that the release notes mention the new lint and link to its documentation.
+- Confirm that the released source and documentation contain the same lint name and diagnostic behavior.
+- Verify the installation or integration path used by downstream users.
+- Check that the release workflow completed successfully.
+- Open a follow-up issue for any release-only problem instead of silently changing the released lint name or behavior.
+
+For pull requests that introduce a new lint, include `Closes #[issue number]` in the PR description when an issue is being resolved.


### PR DESCRIPTION
Closes #72

This PR was generated by the DripTide AI coder and scoped strictly to issue #72.

### Changes
Adds contributor guidance for adding and releasing new lints, including naming conventions, readiness requirements, validation commands, changelog updates, versioned release preparation, and post-release verification.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #72` so the Drips Wave bot resolves the issue on merge._