### PR TITLE
#110 docs: write the nightly toolchain upgrade runbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,23 +91,9 @@ Follow the patterns already used in the codebase: `soroban_cost_lints` uses edit
 
 ### 5. Upgrading the Nightly Toolchain
 
-The pinned nightly is declared once in `rust-toolchain` (the single source of truth) and must stay in sync across four files and the `clippy_utils` git rev in `soroban_cost_lints/Cargo.toml`.
+The pinned nightly is declared once in `rust-toolchain` (the single source of truth) and must stay in sync across multiple files. Upgrading is a multi-step, order-dependent process. The complete procedure—including identification of the matching `clippy_utils` revision, common breakages, and how to verify success—is documented in the [Nightly Upgrade Runbook](./docs/NIGHTLY_UPGRADE_RUNBOOK.md).
 
-**Procedure to upgrade:**
-
-1. Update `rust-toolchain` with the new nightly date (e.g. `nightly-2026-05-01`).
-2. Find the matching `clippy_utils` commit from the [`rust-lang/rust-clippy`](https://github.com/rust-lang/rust-clippy) repository's `rustup` branch on that date, and update the `rev` field in `soroban_cost_lints/Cargo.toml`.
-3. Update `.github/workflows/lint.yml`, `templates/github-action.yml`, and `docs/integration.md` with the new nightly date.
-4. Run the drift guard to confirm everything agrees:
-   ```bash
-   bash .github/scripts/validate-toolchain-pins.sh
-   ```
-5. Run the full test suite:
-   ```bash
-   cargo test --workspace
-   ```
-
-If any file is out of sync, the drift guard will print an error naming the file, the mismatched value, and the expected one.
+**TL;DR:** The critical relationship is between the nightly channel in `rust-toolchain` and the `clippy_utils` git revision in `soroban_cost_lints/Cargo.toml`. See the runbook for guidance on finding the matching revision from the `rust-lang/rust-clippy` repository's `rustup` branch.
 
 ### 6. Releasing a New Lint
 

--- a/docs/NIGHTLY_UPGRADE_RUNBOOK.md
+++ b/docs/NIGHTLY_UPGRADE_RUNBOOK.md
@@ -1,0 +1,295 @@
+# Nightly Toolchain Upgrade Runbook
+
+Upgrading the pinned Rust nightly is a multi-file, order-dependent operation. This runbook documents the procedure, common issues, and how to verify success.
+
+## Why This Matters
+
+The project depends on `rustc` internals—specifically `rustc_hir`, `rustc_middle`, `rustc_session`—which change frequently between nightly releases. To keep up with Rust development and receive new compiler features and bug fixes, the nightly pin must be upgraded periodically. A mismatched `clippy_utils` revision can introduce API incompatibilities that are difficult to debug without knowing the relationship between them.
+
+## The Single Source of Truth
+
+The nightly channel is declared once in [`rust-toolchain`](../rust-toolchain). This is the source of truth. All other files—workflows, templates, documentation—should reflect this same date.
+
+**Note on #104:** Issue #104 proposes making the `clippy_utils` revision single-sourced from the nightly date (automatically rather than manually). When that lands, this runbook will simplify significantly. For now, you must update them together.
+
+---
+
+## Upgrade Procedure
+
+### Step 1: Identify the Target Nightly
+
+Upgrade to a nightly published in the last 1–2 weeks, not an arbitrary future date. Rust's nightly channel publishes once per day, and older nightlies eventually become unavailable in toolchain registries.
+
+A reasonable upgrade target is something like `nightly-2026-05-15` if today is late May 2026 and the current pin is `nightly-2026-04-16`.
+
+### Step 2: Find the Matching `clippy_utils` Revision
+
+This is where most mismatches happen. The `clippy_utils` crate lives in the `rust-clippy` repository, and the revision pin must match a commit that was published on (or before) your target nightly date.
+
+**Procedure:**
+
+1. Open the [rust-clippy repository](https://github.com/rust-lang/rust-clippy) on GitHub.
+
+2. Switch to the `rustup` branch (not `master` or `main`):
+
+   ![Click "Branch: master" dropdown and select "rustup"](https://user-images.githubusercontent.com/example/image.png)
+
+3. In the `rustup` branch, view the commit history of the repository root (or any file):
+
+   - Example URL: `https://github.com/rust-lang/rust-clippy/commits/rustup/`
+
+4. Find a commit date matching your target nightly. For `nightly-2026-05-15`, look for a commit dated **May 15, 2026** (or the closest date prior).
+
+5. Click into that commit and copy its SHA (the long hexadecimal string):
+
+   ```
+   f6d310692116e9a527ce6d0b3526c965d9c5d7b9   <- This is the rev
+   ```
+
+**Why the `rustup` branch?**
+
+The `rustup` branch contains commits that are synchronized with `rustc` releases. The `master` branch of rust-clippy moves faster and independently. Commits from `master` may reference a different (incompatible) version of `rustc_hir` or other internals.
+
+### Step 3: Update `rust-toolchain`
+
+Open [`rust-toolchain`](../rust-toolchain) and update the `channel` field:
+
+```toml
+[toolchain]
+channel = "nightly-2026-05-15"  # <- New date
+components = ["llvm-tools-preview", "rustc-dev", "rustfmt", "clippy"]
+```
+
+### Step 4: Update `soroban_cost_lints/Cargo.toml`
+
+Open [`soroban_cost_lints/Cargo.toml`](../soroban_cost_lints/Cargo.toml) and update the `clippy_utils` dependency:
+
+```toml
+[dependencies]
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "YOUR_NEW_REV_HERE" }
+dylint_linting = "6.0.1"
+openssl = { version = "0.10", features = ["vendored"] }
+```
+
+Replace `YOUR_NEW_REV_HERE` with the SHA you copied from step 2.
+
+### Step 5: Update Workflow Files
+
+Update the nightly pin in two CI workflow files. Both should match the channel you set in `rust-toolchain`.
+
+**File 1: `.github/workflows/lint.yml`**
+
+```yaml
+- name: Install Rust
+  uses: dtolnay/rust-toolchain@master
+  with:
+    toolchain: nightly-2026-05-15  # <- Update this
+    components: rustc-dev, llvm-tools-preview, rustfmt, clippy
+```
+
+**File 2: `templates/github-action.yml`**
+
+```yaml
+- name: Install Rust
+  uses: dtolnay/rust-toolchain@master
+  with:
+    toolchain: nightly-2026-05-15  # <- Update this
+    components: rustc-dev, llvm-tools-preview
+```
+
+### Step 6: Update Documentation
+
+Update the example in [`docs/integration.md`](../docs/integration.md):
+
+Look for the section mentioning the toolchain pin and update the date there as well. (Example reference: search for the template's URL or the date in the file.)
+
+### Step 7: Validate Pin Consistency
+
+The repository includes a validation script to check that all pin references agree. Run:
+
+```bash
+bash .github/scripts/validate-toolchain-pins.sh
+```
+
+If any file is out of sync, the script will print an error naming the file, the mismatched value, and the expected one. **Do not proceed until all pins match.**
+
+---
+
+## Testing the Upgrade
+
+### Step 8: Run the Full Test Suite
+
+```bash
+cargo test --workspace
+```
+
+This invokes the test suite under the new nightly. Watch for errors related to:
+
+1. **`clippy_utils` API changes:** If a function signature changed or was removed, you'll see a compile error like:
+   ```
+   error[E0425]: cannot find function `get_enclosing_block` in module `clippy_utils`
+   ```
+   See [Common Breakages](#common-breakages) below for guidance.
+
+2. **`rustc_hir` shape changes:** If the HIR structure changed, you might see:
+   ```
+   error: no field `kind` on type `Expr`
+   ```
+   The new nightly may have renamed or restructured HIR types.
+
+3. **UI test failures:** If the compiler's error message format changed, expected output won't match. See [Blessing UI Tests](#blessing-ui-tests) below.
+
+### Step 9: Blessing UI Tests
+
+UI tests verify that lint diagnostics are emitted correctly. They store **expected** compiler output in `.stderr` files and compare against actual output when the tests run.
+
+After a nightly upgrade, compiler diagnostic formatting sometimes changes (e.g., spans, colors, or message phrasing). The UI tests may fail even though the lints still work correctly. You must "bless" (re-approve) the output:
+
+1. Run the UI test with the `BLESS` environment variable set:
+
+   ```bash
+   BLESS=1 cargo test --workspace
+   ```
+
+2. This regenerates all `.stderr` files to match the current nightly's output format.
+
+3. Review the git diff carefully:
+
+   ```bash
+   git diff soroban_cost_lints/ui/
+   ```
+
+   Look for:
+   - Line number changes (expected if spans shifted)
+   - Message text changes (usually safe, but verify the meaning didn't change)
+   - Missing or new warnings (may indicate a lint broke or a new one appeared)
+
+4. If the changes look reasonable, stage and commit them:
+
+   ```bash
+   git add soroban_cost_lints/ui/main.stderr
+   git commit -m "blessing: Update UI tests for nightly-2026-05-15"
+   ```
+
+---
+
+## Common Breakages
+
+### Breakage #1: `clippy_utils` API Changed or Was Removed
+
+**Symptom:**
+
+```
+error[E0425]: cannot find function `get_enclosing_x` in module `clippy_utils`
+```
+
+**How to Fix:**
+
+1. Check the [rust-clippy GitHub repository](https://github.com/rust-lang/rust-clippy) for the matching commit (the rev you picked in Step 2).
+2. Search the commit's `clippy_utils/` directory for an alternative function name or migration guide in comments.
+3. Look at recent clippy PRs or the file history for the breaking change. GitHub often links to issues or PRs in commit messages.
+4. Update the lint code in `soroban_cost_lints/src/lib.rs` to use the new API.
+
+**Example:** If `get_enclosing_block` was removed and replaced with `get_enclosing_block_or_loop`, update the import and call site.
+
+### Breakage #2: `rustc_hir` Structure Changed
+
+**Symptom:**
+
+```
+error: `Expr` has no field named `kind`; available fields: `hir_id`, `span`, ...
+```
+
+or
+
+```
+error: function or associated item `Path` not found
+```
+
+**How to Fix:**
+
+1. The HIR structure likely evolved. Re-read the field names or enum variants in the new nightly's `rustc_hir` definition.
+2. Use `rustc` docs or the source code to understand the new shape.
+3. Update pattern matches and field accesses in the lint implementation.
+
+**Example:** Older nightly might have `expr.kind`, but newer ones might use `expr.as_ref().kind` or a different accessor.
+
+### Breakage #3: Required Crate Features or `feature(rustc_private)` Not Available
+
+**Symptom:**
+
+```
+error: the feature `rustc_private` is not available in this edition
+```
+
+**How to Fix:**
+
+1. Confirm that the feature is still enabled in `lib.rs`:
+   ```rust
+   #![feature(rustc_private)]
+   ```
+2. If it's enabled but the error persists, the nightly may have removed the feature. This is rare; check the nightly release notes.
+3. If the issue is a different feature, search the lint code for the feature gate and update as needed.
+
+### Breakage #4: Compiler Diagnostic Output Format Changed
+
+**Symptom:**
+
+UI tests fail, but the lints seem to fire correctly:
+
+```
+thread 'ui::tests' panicked at 'assertion failed: ... expected output != actual output'
+```
+
+**How to Fix:**
+
+This is expected after a nightly upgrade. Follow the [Blessing UI Tests](#blessing-ui-tests) section above to re-bless the output.
+
+---
+
+## Verification Checklist
+
+After completing all steps:
+
+- [ ] `rust-toolchain` channel updated
+- [ ] `soroban_cost_lints/Cargo.toml` clippy_utils rev updated
+- [ ] `.github/workflows/lint.yml` toolchain pin updated
+- [ ] `templates/github-action.yml` toolchain pin updated
+- [ ] `docs/integration.md` documentation updated
+- [ ] `validate-toolchain-pins.sh` passes without errors
+- [ ] `cargo test --workspace` passes
+- [ ] (If needed) UI tests blessed with `BLESS=1 cargo test --workspace`
+- [ ] No new compiler warnings or errors introduced
+- [ ] `cargo fmt --all` and `cargo clippy` pass
+
+---
+
+## If You Get Stuck
+
+1. **Check the git history:** Look at previous nightly upgrade commits to see patterns:
+
+   ```bash
+   git log --grep="nightly" --oneline
+   ```
+
+2. **Review the rust-clippy repository:** The rust-clippy commits often note what changed. Start with the commit message of the rev you selected.
+
+3. **Ask on the project Discord or Telegram:** The maintainers can help debug API changes or point you to resources.
+
+---
+
+## Future Simplification
+
+Issue #104 proposes deriving the `clippy_utils` revision automatically from the nightly date. Once that lands, the number of manual update points will shrink, and this runbook's mechanical steps will simplify. For now, keep all four files (rust-toolchain, Cargo.toml, two workflows) in sync.
+
+---
+
+## Notes for Reviewers
+
+When reviewing a PR that upgrades the nightly:
+
+1. Verify that all four pin locations were updated to the same date.
+2. Run the validation script locally to confirm consistency.
+3. Spot-check the UI test diff to ensure no unexpected lints disappeared or were added.
+4. Confirm that no new compiler warnings were introduced in the lint code.
+5. If there are API changes, review the migrations in the lint code to ensure they are sound.


### PR DESCRIPTION
Closes #110 # Pull Request: Nightly Toolchain Upgrade Runbook

## Description

This PR introduces a comprehensive runbook for upgrading the pinned Rust nightly toolchain across the `soroban-cost-linter` repository. Upgrading the nightly is currently a multi-file, order-dependent operation that has historically been under-documented, causing the pin to age until something forces the issue. This runbook makes the procedure explicit, discoverable, and repeatable.

## What's Included

### New Documentation: `docs/NIGHTLY_UPGRADE_RUNBOOK.md`

A complete, step-by-step guide covering:

1. **9-Step Upgrade Procedure**
   - How to identify a target nightly (published within 1–2 weeks)
   - **How to find the matching `clippy_utils` revision** from the `rust-lang/rust-clippy` repository's `rustup` branch (the critical step where mismatches historically occur)
   - Where to update each of four pin locations: `rust-toolchain`, `soroban_cost_lints/Cargo.toml`, `.github/workflows/lint.yml`, `templates/github-action.yml`, and doc examples
   - How to validate consistency using `validate-toolchain-pins.sh`

2. **Common Breakages & Recognition**
   - `clippy_utils` API changes (with error patterns and resolution guidance)
   - `rustc_hir` structure changes (HIR field/type renames and reshaping)
   - Missing or incompatible rustc features
   - Compiler diagnostic format changes

3. **Testing & Verification**
   - Running the full test suite under the new nightly
   - How to "bless" UI tests when compiler output format changes
   - Complete verification checklist

4. **Future Simplification**
   - Notes on Issue #104, which will single-source the `clippy_utils` revision automatically

### Updated: `CONTRIBUTING.md`

Section 5 ("Upgrading the Nightly Toolchain") now:
- Concisely explains why syncing is required
- Points contributors to the runbook for the full procedure
- Highlights the `clippy_utils` revision-to-nightly relationship as the critical detail

## Rationale

**Problem:** Without documented procedure, nightly upgrades are opaque. Contributors cannot easily understand the order of operations, how to find the correct `clippy_utils` revision, or how to verify success. The pin ages until a breaking change forces an upgrade, creating a large, risky change.

**Solution:** The runbook centralizes all procedural knowledge in one place, making it:
- **Discoverable:** Listed in `CONTRIBUTING.md` for anyone considering an upgrade
- **Repeatable:** Step-by-step guidance ensures consistency across upgrade attempts
- **Resilient:** Common errors are pre-documented with examples and fixes
- **Maintainable:** Notes on Issue #104 will guide future simplifications

## How to Verify

1. Read the runbook at `docs/NIGHTLY_UPGRADE_RUNBOOK.md`
2. Confirm that all four pin update locations are documented
3. Verify that the `clippy_utils` revision-to-nightly relationship is clearly explained
4. Check that common build errors and their fixes are present
5. Confirm the link in `CONTRIBUTING.md` resolves correctly

## Notes for Reviewers

- The runbook is written against the repository as it currently stands (before Issue #104 lands). It notes where #104 will simplify things.
- The runbook does not perform an upgrade—it documents the procedure for others to follow.
- The `rustup` branch guidance is the most critical section, as it addresses the most common source of mismatches.
- UI test blessing is covered because it is often the last hurdle when upgrading.
