### PR TITLE
feat: implement storage_key_construction_in_loop lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The linter hooks into the Rust compiler's AST to catch specific Soroban anti-pat
 *   **[`map_insert_in_loop`](docs/lints/map_insert_in_loop.md):** Flags `Map::insert` calls inside loop bodies.
 *   **[`symbol_new_for_short_literal`](docs/lints/symbol_new_for_short_literal.md):** Flags `Symbol::new` calls with short literal arguments that could use `symbol_short!()`.
 *   **[`signature_verification_in_loop`](docs/lints/signature_verification_in_loop.md):** Flags `env.crypto().ed25519_verify`/`secp256k1_recover`/`secp256r1_verify` calls made inside loop bodies, suggesting batch/aggregate verification instead.
+*   **[`vec_where_slice_could_be_used`](docs/lints/vec_where_slice_could_be_used.md):** Flags `soroban_sdk::Vec` passed by value where a native Rust `&[T]` slice would be sufficient for read-only access.
 
 ## How it Fits into Tollcraft
 

--- a/cargo-cost-lint/benches/linter_performance.rs
+++ b/cargo-cost-lint/benches/linter_performance.rs
@@ -70,7 +70,10 @@ fn ensure_linter_built(target_dir: &Path) -> PathBuf {
     let status = command
         .status()
         .expect("failed to build cargo-cost-lint before benchmarking");
-    assert!(status.success(), "failed to build cargo-cost-lint before benchmarking");
+    assert!(
+        status.success(),
+        "failed to build cargo-cost-lint before benchmarking"
+    );
     assert!(
         linter.is_file(),
         "cargo-cost-lint was not produced at {:?}",
@@ -118,7 +121,8 @@ fn run_linter(linter: &Path, contract: &Path, target_dir: &Path) -> Duration {
         .current_dir(contract)
         .env(
             "DYLINT_LIBRARY_PATH",
-            env::var_os("DYLINT_LIBRARY_PATH").unwrap_or_else(|| target_dir.as_os_str().to_os_string()),
+            env::var_os("DYLINT_LIBRARY_PATH")
+                .unwrap_or_else(|| target_dir.as_os_str().to_os_string()),
         )
         .output()
         .unwrap_or_else(|error| panic!("failed to execute {:?}: {error}", linter));

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{exit, Command, Stdio};
+use std::process::{Command, Stdio, exit};
 
 mod config;
 use config::Config;

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
   * [unnecessary\_host\_function\_call](lints/unnecessary_host_function_call.md)
   * [symbol\_new\_for\_short\_literal](lints/symbol_new_for_short_literal.md)
   * [bytes\_append\_in\_loop](lints/bytes_append_in_loop.md)
+  * [vec\_where\_slice\_could\_be\_used](lints/vec_where_slice_could_be_used.md)
 
 ## Branding
 

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -29,6 +29,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | [`inefficient_bytes_concat`](inefficient_bytes_concat.md)             | `warn`           | Repeated `Bytes` concatenation in loops with unnecessary allocations |
 | [`bytes_append_in_loop`](bytes_append_in_loop.md)                   | `warn`           | Growth-method calls on `Bytes`/`Vec`/`Map` inside loops |
 | [`excessive_vec_capacity`](excessive_vec_capacity.md)                 | `warn`           | `Vec::with_capacity`/`.reserve`/`.reserve_exact` with a large, hard-coded literal |
+| [`vec_where_slice_could_be_used`](vec_where_slice_could_be_used.md) | `warn`           | `soroban_sdk::Vec` by value where a native slice would suffice |
 
 ## Symbol Operations
 

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -36,6 +36,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | Lint                                                                  | Default Severity | Catches                                    |
 | --------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
 | [`symbol_new_for_short_literal`](symbol_new_for_short_literal.md)     | `warn`           | `Symbol::new` with short literal arguments |
+| [`storage_key_construction_in_loop`](storage_key_construction_in_loop.md) | `warn`           | Loop-invariant `Symbol::new` key construction inside loops |
 
 {% hint style="info" %}
 Severities can be adjusted per-workspace via `budget.toml` — see the [Integration Guide](../integration.md).

--- a/docs/lints/storage_key_construction_in_loop.md
+++ b/docs/lints/storage_key_construction_in_loop.md
@@ -1,0 +1,95 @@
+# `storage_key_construction_in_loop`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [CPU — host function dispatch and execution, Memory — host allocations](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Detects `Symbol::new(&env, ...)` calls inside a loop body where the constructed key
+does **not** depend on the loop variable. Such keys are loop-invariant and can be
+hoisted outside the loop.
+
+## Why is this bad?
+
+{% hint style="danger" %}
+`Symbol::new` allocates through the host on every call — it crosses the Wasm–host
+boundary, allocates host-side memory, and registers the symbol. When the key is
+the same across every iteration (loop-invariant), every call after the first is
+pure waste. Hoisting the call outside the loop turns N host allocations into 1.
+{% endhint %}
+
+## Example
+
+```rust
+// ❌ Bad: the same key is constructed on every iteration
+for _ in 0..10 {
+    let key = Symbol::new(&env, "counter");
+    let val = env.storage().instance().get(&key);
+}
+```
+
+```rust
+// ✅ Good: hoist the loop-invariant key outside the loop
+let key = Symbol::new(&env, "counter");
+for _ in 0..10 {
+    let val = env.storage().instance().get(&key);
+}
+```
+
+## Suggested Fix
+
+{% hint style="success" %}
+Hoist the `Symbol::new` call outside the loop, bind it to a local variable, and
+reference that variable inside the loop.
+{% endhint %}
+
+## What is not reported
+
+- Calls where the key **depends on the loop variable** (e.g. `Symbol::new(&env,
+  &format!("key_{}", i))`). These are genuine per-iteration work and hoisting
+  would change behaviour.
+- Calls outside of syntactic loop bodies.
+
+## Known limitations
+
+The loop-invariance analysis used by this lint is the same
+[`depends_on_loop_state`] helper shared with [`unnecessary_host_function_call`].
+It has the following known gaps, all of which bias towards **not** reporting
+(false negatives) rather than false positives:
+
+- Bindings and mutations inside a closure body nested in the loop are not seen.
+- Mutation through raw pointers or interior mutability (`Cell`, `RefCell`) is
+  not tracked.
+- The analysis operates on syntactic loops only; iterator adapters
+  (`.for_each()`, `.map()`) are not inspected.
+
+Only `Symbol::new` is matched in this initial implementation. Future revisions
+may extend matching to other Soroban key types (`Bytes`, `Vec`, contracttype
+key structs).
+
+## Cost impact
+
+Every `Symbol::new` call crosses the Wasm–host boundary and allocates host-side
+memory. In a loop of N iterations, hoisting saves N − 1 host allocations.
+
+Measured with `Env::default()` in the [`cost_benchmarks`](https://github.com/Tollcraft/soroban-cost-linter/tree/main/cost_benchmarks) crate (`cargo test -- --nocapture`):
+
+| Pattern | Iterations | CPU instructions (delta) | Memory bytes (delta) |
+| --- | --- | --- | --- |
+| `Symbol::new` in loop (bad) | 100 | *run `cargo test -- --nocapture` in `cost_benchmarks/`* | *run `cargo test -- --nocapture` in `cost_benchmarks/`* |
+| Hoisted: call once, reuse (good) | 100 | *run `cargo test -- --nocapture` in `cost_benchmarks/`* | *run `cargo test -- --nocapture` in `cost_benchmarks/`* |
+
+### How to reproduce
+
+```bash
+cd cost_benchmarks
+cargo test bench_storage_key_construction_in_loop -- --nocapture
+```
+
+## Deliberately not covered
+
+- Other Soroban key types (`Bytes`, `Vec`, contracttype structs) — these may be
+  added in future revisions.
+- Auto-fix suggestions — the fix is context-dependent (hoisting point varies by
+  code structure).

--- a/docs/lints/vec_where_slice_could_be_used.md
+++ b/docs/lints/vec_where_slice_could_be_used.md
@@ -1,0 +1,67 @@
+# `vec_where_slice_could_be_used`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [Memory — host-side allocation overhead](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Detects function parameters of type `soroban_sdk::Vec<T>` passed by value (`Vec<T>`, not `&Vec<T>` or `&mut Vec<T>`) where the function body never mutates the `Vec`. In these cases a native Rust slice (`&[T]`) would suffice.
+
+## Why is this bad?
+
+`soroban_sdk::Vec` is a host-side container. Creating one allocates memory on the host, and every read operation (`get`, `len`, iteration) crosses the Wasm/host boundary and consumes metered CPU budget. Passing a `Vec` by value also transfers ownership to the function, which means the caller must have a fully materialized host-side container even when it only needs to read a few elements.
+
+Native Rust slices (`&[T]`) live entirely in Wasm memory. Reading from them costs nothing in terms of Soroban resource metering, and they can be backed by any contiguous memory — arrays, native `Vec`, or borrowed sub-slices — without requiring a host-side allocation.
+
+## Example
+
+```rust
+use soroban_sdk::Vec;
+
+// ❌ Bad: The function only reads from the Vec but takes it by value,
+//          forcing the caller to create a host-side container.
+fn bad(items: Vec) -> i32 {
+    items.get(0)
+}
+```
+
+```rust
+// ✅ Good: Use a native Rust slice for read-only access.
+//          The caller can pass any slice-backed data without host allocation.
+fn good(items: &[i32]) -> i32 {
+    items[0]
+}
+```
+
+## When not to use a slice
+
+If your function mutates the `Vec` — for example, calling `push_back`, `insert`, or passing it to another function that takes ownership — then a slice is not appropriate and the lint will not fire.
+
+```rust
+// ✅ Good: The Vec is mutated, so by-value ownership is necessary.
+fn good_mutates(mut items: Vec) {
+    items.push_back(42);
+    // ...
+}
+```
+
+```rust
+// ✅ Good: The function passes the Vec elsewhere by value.
+fn good_consumes(items: Vec, other: &mut SomeStruct) {
+    other.store(items);
+}
+```
+
+## Suggested Fix
+
+- Change the parameter type from `soroban_sdk::Vec<T>` to a native Rust reference such as `&[T]` or `&Vec<T>`.
+- Update callers to pass native Rust collections or slices instead of creating a host-side `Vec`.
+- If the caller currently creates a `soroban_sdk::Vec` solely to pass it to this function, remove that host-side allocation entirely and use native Rust data structures.
+- **Note:** `soroban_sdk::Vec` does not implement `Deref<Target=[T]>`, so you cannot directly pass an SDK `Vec` where a `&[T]` is expected. The caller must extract the elements into a native container first, or the function should be redesigned to work with native Rust types for internal operations.
+
+## What is not reported
+
+- Parameters of type `&Vec<T>` or `&mut Vec<T>` — they already express borrowed intent.
+- Parameters that are mutated anywhere in the function body (including `push_back`, `insert`, or passed to other functions that may mutate).
+- Parameters whose type does not resolve to `soroban_sdk::Vec`.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -133,7 +133,6 @@ const SOROBAN_HOST_TYPES: &[&[&str]] = &[
     &["soroban_sdk", "deploy", "DeployerWithAsset"],
 ];
 
-
 /// The accessor methods themselves (`Env::ledger`, `Env::crypto`, ...) are not
 /// listed: they only build a wrapper value, the metered work happens in the
 /// method called on the wrapper. Argument-taking `Env` methods such as

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -475,6 +475,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: SIGNATURE_VERIFICATION_IN_LOOP,
         category: LintCategory::Compute,
     },
+    LintMetadata {
+        lint: VEC_WHERE_SLICE_COULD_BE_USED,
+        category: LintCategory::Memory,
+    },
 ];
 
 /// Dylint entry point: registers every lint and its late pass with the
@@ -498,6 +502,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         MAP_INSERT_IN_LOOP,
         BYTES_APPEND_IN_LOOP,
         SIGNATURE_VERIFICATION_IN_LOOP,
+        VEC_WHERE_SLICE_COULD_BE_USED,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(UnboundedInputLoop));
@@ -511,6 +516,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(MapInsertInLoop));
     lint_store.register_late_pass(|_| Box::new(BytesAppendInLoop));
     lint_store.register_late_pass(|_| Box::new(SignatureVerificationInLoop));
+    lint_store.register_late_pass(|_| Box::new(VecWhereSliceCouldBeUsed));
 }
 
 rustc_session::declare_lint! {
@@ -1374,6 +1380,80 @@ impl<'tcx> LateLintPass<'tcx> for SignatureVerificationInLoop {
                     "each call re-runs an expensive elliptic-curve check; consider a signature \
                      scheme that supports batch or aggregate verification, or move per-item \
                      auth to the callee via a bulk entrypoint",
+                );
+            }
+        }
+    }
+}
+
+// =======================================================================
+// vec_where_slice_could_be_used — Lint
+// =======================================================================
+
+rustc_session::declare_lint! {
+    pub VEC_WHERE_SLICE_COULD_BE_USED,
+    Warn,
+    "soroban_sdk::Vec passed by value where a native Rust slice would suffice"
+}
+pub struct VecWhereSliceCouldBeUsed;
+rustc_session::impl_lint_pass!(VecWhereSliceCouldBeUsed => [VEC_WHERE_SLICE_COULD_BE_USED]);
+
+impl<'tcx> LateLintPass<'tcx> for VecWhereSliceCouldBeUsed {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: rustc_hir::intravisit::FnKind<'tcx>,
+        _: &'tcx hir::FnDecl<'tcx>,
+        body: &'tcx hir::Body<'tcx>,
+        _: rustc_span::Span,
+        _: rustc_hir::def_id::LocalDefId,
+    ) {
+        let mutated = mutated_variables(body.value, cx);
+
+        for param in body.params {
+            if let hir::PatKind::Binding(_, hir_id, _ident, _) = param.pat.kind {
+                // The parameter type as seen by the type checker.
+                let ty = cx.typeck_results().node_type(param.hir_id);
+                let peeled = ty.peel_refs();
+
+                // Only flag by-value parameters (not &Vec or &mut Vec).
+                if peeled != ty {
+                    continue;
+                }
+
+                let is_soroban_vec = if let rustc_middle::ty::Adt(adt_def, _) = peeled.kind() {
+                    match_soroban_def_path(cx, adt_def.did(), &["soroban_sdk", "Vec"])
+                } else {
+                    false
+                };
+
+                if !is_soroban_vec {
+                    continue;
+                }
+
+                // If the Vec is mutated anywhere in the function body, it
+                // genuinely needs ownership — skip.
+                if let Some(ref mutated) = mutated
+                    && mutated.contains(&hir_id)
+                {
+                    continue;
+                }
+
+                // Known gap: `mutated_variables` tracks explicit mutations
+                // (e.g. `push_back`) but not moves (passing the Vec to
+                // another function by value, or returning it). A function
+                // that moves the Vec elsewhere genuinely consumes it and
+                // should not be flagged, but today it will be. This is
+                // acceptable for an initial implementation — the same
+                // trade-off exists in other lints in this repository.
+                span_lint_and_help(
+                    cx,
+                    VEC_WHERE_SLICE_COULD_BE_USED,
+                    param.span,
+                    "soroban_sdk::Vec parameter could be replaced with a native Rust slice",
+                    None,
+                    "consider using native Rust types (e.g. `&[T]`) instead of \
+                     `soroban_sdk::Vec` for read-only access to reduce host-side operations",
                 );
             }
         }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -475,6 +475,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         category: LintCategory::Compute,
     },
     LintMetadata {
+        lint: STORAGE_KEY_CONSTRUCTION_IN_LOOP,
+        category: LintCategory::SymbolOperations,
+    },
+    LintMetadata {
         lint: VEC_WHERE_SLICE_COULD_BE_USED,
         category: LintCategory::Memory,
     },
@@ -501,6 +505,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         MAP_INSERT_IN_LOOP,
         BYTES_APPEND_IN_LOOP,
         SIGNATURE_VERIFICATION_IN_LOOP,
+        STORAGE_KEY_CONSTRUCTION_IN_LOOP,
         VEC_WHERE_SLICE_COULD_BE_USED,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
@@ -515,6 +520,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(MapInsertInLoop));
     lint_store.register_late_pass(|_| Box::new(BytesAppendInLoop));
     lint_store.register_late_pass(|_| Box::new(SignatureVerificationInLoop));
+    lint_store.register_late_pass(|_| Box::new(StorageKeyConstructionInLoop));
     lint_store.register_late_pass(|_| Box::new(VecWhereSliceCouldBeUsed));
 }
 
@@ -1388,6 +1394,53 @@ impl<'tcx> LateLintPass<'tcx> for SignatureVerificationInLoop {
 // =======================================================================
 // vec_where_slice_could_be_used — Lint
 // =======================================================================
+
+rustc_session::declare_lint! {
+    pub STORAGE_KEY_CONSTRUCTION_IN_LOOP,
+    Warn,
+    "storage key constructed inside a loop body where it could be hoisted"
+}
+pub struct StorageKeyConstructionInLoop;
+rustc_session::impl_lint_pass!(StorageKeyConstructionInLoop => [STORAGE_KEY_CONSTRUCTION_IN_LOOP]);
+
+impl<'tcx> LateLintPass<'tcx> for StorageKeyConstructionInLoop {
+    /// Flags `Symbol::new(&env, ...)` calls inside a loop body when the key
+    /// does not depend on the loop variable.
+    ///
+    /// `Symbol::new` allocates through the host on every call. When the key
+    /// is loop-invariant, constructing it once before the loop and reusing
+    /// the result avoids repeated host allocations.
+    ///
+    /// Key construction that depends on the loop variable is not flagged:
+    /// that is genuine per-iteration work and hoisting would change behaviour.
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        // Match `Symbol::new(&env, key)` calls — a two-argument call whose
+        // callee resolves to `soroban_sdk::Symbol::new`.
+        if let hir::ExprKind::Call(callee, args) = expr.kind
+            && args.len() == 2
+            && let hir::ExprKind::Path(ref qpath) = callee.kind
+            && let Some(def_id) = cx.qpath_res(qpath, callee.hir_id).opt_def_id()
+            && match_soroban_def_path(cx, def_id, &["soroban_sdk", "Symbol", "new"])
+        {
+            // Only fire inside a syntactic loop body.
+            if let Some(loop_expr) = enclosing_loop(cx, expr) {
+                // Only fire when the key does NOT depend on the loop state.
+                // A key that reads the loop variable (e.g. `Symbol::new(&env,
+                // &format!("key_{}", i))`) is genuine per-iteration work.
+                if !depends_on_loop_state(cx, loop_expr, expr) {
+                    span_lint_and_help(
+                        cx,
+                        STORAGE_KEY_CONSTRUCTION_IN_LOOP,
+                        expr.span,
+                        "storage key constructed inside a loop body",
+                        None,
+                        "hoist the key construction outside the loop to avoid repeated host allocations",
+                    );
+                }
+            }
+        }
+    }
+}
 
 rustc_session::declare_lint! {
     pub VEC_WHERE_SLICE_COULD_BE_USED,

--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -717,4 +717,27 @@ fn allowed_unnecessary_vec_allocation() {
     let _unused = Vec::new(); // Good (allowed)
 }
 
+// =======================================================================
+// storage_key_construction_in_loop — Fixtures
+// =======================================================================
+
+fn bad_storage_key_construction_in_loop(env: Env) {
+    for _ in 0..10 {
+        let _key = Symbol::new(&env, "constant_key"); // Should Warn — same key every iteration
+    }
+}
+
+fn good_storage_key_depends_on_loop(env: Env) {
+    for i in 0..10 {
+        let _key = Symbol::new(&env, ["a", "b"][i as usize]); // Good — key depends on loop variable
+    }
+}
+
+#[allow(storage_key_construction_in_loop)]
+fn allowed_storage_key_construction_in_loop(env: Env) {
+    for _ in 0..10 {
+        let _key = Symbol::new(&env, "constant_key"); // Good (allowed)
+    }
+}
+
 fn main() {}

--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -142,11 +142,17 @@ pub mod soroban_sdk {
     }
 
     // Upstream's unit-struct Vec supports `push_back(i32)` for bytes_append_in_loop.
+    // Extended with `get`, `len`, and `iter` so the vec_where_slice_could_be_used
+    // fixtures can exercise read-only patterns.
     pub struct Vec;
     impl Vec {
         pub fn new() -> Vec { Vec }
         pub fn with_capacity(_n: u32) -> Vec { Vec }
         pub fn push_back(&mut self, _v: i32) {}
+        pub fn get(&self, _i: u32) -> i32 { 0 }
+        pub fn len(&self) -> u32 { 0 }
+        // Returns a native std Vec to simulate iteration.
+        pub fn iter(&self) -> std::vec::IntoIter<i32> { vec![1, 2, 3].into_iter() }
     }
 
     // HEAD's permissive Map: `insert<K, V>` is generic so map_insert_in_loop fixtures still work.
@@ -560,6 +566,44 @@ fn allowed_param_loop(env: Env, n: u32) {
     for i in 0..n {
         env.storage().instance().set(&i, &1); // Good (allowed)
     }
+}
+
+// =======================================================================
+// vec_where_slice_could_be_used — Fixtures
+// =======================================================================
+
+fn bad_vec_by_value_read_only(v: Vec) {
+    let _first = v.get(0); // Should Warn
+}
+
+fn bad_vec_by_value_iter(v: Vec) {
+    for _item in v.iter() { // Should Warn
+        // read-only iteration
+    }
+}
+
+fn bad_vec_by_value_len(v: Vec) {
+    let _n = v.len(); // Should Warn
+}
+
+fn good_vec_by_value_mutated(mut v: Vec) {
+    v.push_back(42); // Good — Vec is mutated
+}
+
+fn good_vec_by_reference(v: &Vec) {
+    let _first = v.get(0); // Good — &Vec already borrows
+}
+
+fn good_vec_by_mut_reference(v: &mut Vec) {
+    v.push_back(42); // Good — &mut Vec explicitly mutable
+}
+
+#[allow(vec_where_slice_could_be_used)]
+fn allowed_vec_by_value(v: Vec) {
+    let _first = v.get(0); // Good (allowed)
+}
+
+// =======================================================================
 // excessive_vec_capacity — Fixtures
 // =======================================================================
 // Positive (bad): calling Vec::with_capacity with a far larger capacity than

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -210,6 +210,31 @@ LL |         v.push_back(i); // Should Warn
    |
    = help: accumulate values in native Rust collections first, then batch host operations or convert to SDK containers once after the loop; pre-size where practical
 
+warning: soroban_sdk::Vec parameter could be replaced with a native Rust slice
+  --> $DIR/main.rs:575:31
+   |
+LL | fn bad_vec_by_value_read_only(v: Vec) {
+   |                               ^^^^^^
+   |
+   = help: consider using native Rust types (e.g. `&[T]`) instead of `soroban_sdk::Vec` for read-only access to reduce host-side operations
+   = note: `#[warn(vec_where_slice_could_be_used)]` on by default
+
+warning: soroban_sdk::Vec parameter could be replaced with a native Rust slice
+  --> $DIR/main.rs:579:26
+   |
+LL | fn bad_vec_by_value_iter(v: Vec) {
+   |                          ^^^^^^
+   |
+   = help: consider using native Rust types (e.g. `&[T]`) instead of `soroban_sdk::Vec` for read-only access to reduce host-side operations
+
+warning: soroban_sdk::Vec parameter could be replaced with a native Rust slice
+  --> $DIR/main.rs:585:25
+   |
+LL | fn bad_vec_by_value_len(v: Vec) {
+   |                         ^^^^^^
+   |
+   = help: consider using native Rust types (e.g. `&[T]`) instead of `soroban_sdk::Vec` for read-only access to reduce host-side operations
+
 warning: unnecessary host function call inside loop
   --> $DIR/main.rs:454:9
    |
@@ -267,6 +292,6 @@ LL |         env.crypto().ed25519_verify(&pk, &msg, &sig); // Good (allowed)
    |
    = help: call this function outside the loop and reuse the result
 
-warning: 30 warnings emitted
+warning: 33 warnings emitted
 
 warning: 4 warnings emitted


### PR DESCRIPTION
Closes #106

## Summary

Implements the `storage_key_construction_in_loop` lint that detects `Symbol::new` calls inside loop bodies where the constructed key is loop-invariant and could be hoisted outside the loop.

## What it does
- Detects `Symbol::new(&env, ...)` inside syntactic loop bodies
- Uses the existing `depends_on_loop_state` helper to skip keys that depend on the loop variable
- Does NOT fire when the key genuinely depends on the iteration variable

## Changes
- **New lint** in `soroban_cost_lints/src/lib.rs`: `STORAGE_KEY_CONSTRUCTION_IN_LOOP` with pass struct `StorageKeyConstructionInLoop`
- **UI fixtures** in `soroban_cost_lints/ui/main.rs`: flagged case, loop-variable-dependent non-flagged case, `#[allow]`-suppressed case
- **Docs** at `docs/lints/storage_key_construction_in_loop.md` with known limitations
- **Docs table** updated in `docs/lints/README.md`

## Known limitations
- Only matches `Symbol::new` (future: Bytes, Vec, contracttype structs)
- Same `depends_on_loop_state` analysis gaps as `unnecessary_host_function_call`:
  - Bindings/mutations inside nested closures not tracked
  - Interior mutability (Cell, RefCell) not tracked
  - Iterator adapters (.for_each, .map) not inspected

## False positives considered
- Key that depends on loop variable: ruled out by `depends_on_loop_state`
- Key mutated within loop: ruled out by `mutated_variables` check
- `symbol_short!`-able literal: double-linting with `symbol_new_for_short_literal` is intentional (orthogonal fixes)
