### PR TITLE
docs: clarify map_insert_in_loop closure-loop coverage (#50)

### DIFF
--- a/docs/lints/map_insert_in_loop.md
+++ b/docs/lints/map_insert_in_loop.md
@@ -46,3 +46,18 @@ fn populate(env: Env) {
 ## Fix
 
 Accumulate entries in a `Vec` or similar in-memory structure during the loop, then perform a single Map construction or batch insert after the loop.
+
+## Known limitations
+
+This lint only recognizes `Map::insert` calls sitting directly inside a
+syntactic `for`, `while`, or `loop` body (via the internal `enclosing_loop`
+helper). It does **not** flag a `Map::insert` call made inside a multi-call
+iterator closure such as `.for_each(|x| { map.insert(...) })` or an
+`.iter().map(...)` argument, even though that closure body runs once per
+element just like a loop and incurs the same repeated storage cost.
+
+This is a narrower scope than [`unnecessary_host_function_call`](unnecessary_host_function_call.md),
+which uses a closure-aware helper (`enclosing_loop_or_closure`) to also catch
+repeated host calls inside iterator closures. Extending `map_insert_in_loop`
+to cover the closure case is tracked as a possible follow-up rather than
+implemented here.


### PR DESCRIPTION
Closes #50

## Summary

Issue #50 asked for a lint that flags `Map::insert` calls inside loops.

**That lint already exists.** `MAP_INSERT_IN_LOOP` (`MapInsertInLoop` pass in `soroban_cost_lints/src/lib.rs`) was fully implemented, registered, tested (UI fixtures `bad_map_insert_in_loop` / `allowed_map_insert_in_loop` in `soroban_cost_lints/ui/main.rs`), and documented (`docs/lints/map_insert_in_loop.md`, plus rows in `docs/lints/README.md` and the top-level `README.md`) prior to this PR, merged via PR #225. This PR does not reimplement or duplicate that work.

## What this PR actually does

While verifying the lint's current behavior against the issue, I confirmed one real, documented gap worth recording: `MapInsertInLoop` uses the `enclosing_loop(cx, expr)` helper, which only recognizes a `Map::insert` call sitting directly inside a syntactic `for`/`while`/`loop` body. It does **not** flag a `Map::insert` call made inside a multi-call iterator closure such as `.for_each(|x| { map.insert(...) })`, even though that closure body runs once per element just like a loop and incurs the same repeated storage cost.

For contrast, `UnnecessaryHostFunctionCall` in the same file uses a different, closure-aware helper (`enclosing_loop_or_closure`) that does cover that case.

This PR adds a short "Known limitations" section to `docs/lints/map_insert_in_loop.md` recording this, in the same style as the existing "Deliberately not covered" section in `docs/lints/signature_verification_in_loop.md`.

## What this PR does NOT do

- No change to `MapInsertInLoop`'s implementation or runtime behavior.
- No new UI fixtures (none needed — no behavior changed).
- No `CHANGELOG.md` entry under Added, since nothing new is shipping.
- No duplicate lint registration or docs entries.

This is a documentation-only clarification of already-shipped behavior, opened to give issue #50 an honest, accurate closing record.
