### PR TITLE
feat: implement formatted_panic_payload lint (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning.
 - New lint `signature_verification_in_loop` detecting `env.crypto().ed25519_verify()`/`secp256k1_recover()`/`secp256r1_verify()` calls inside loop bodies, suggesting batch/aggregate signature verification or a bulk callee entrypoint instead.
 - New lint `instance_storage_for_unbounded_data` detecting `env.storage().instance().set(...)` calls where the written value is an unbounded `Vec`/`Map`/`Bytes`, since instance storage is re-read and rewritten as a single blob on every contract invocation regardless of which call touches it.
 - `--fix` flag for `cargo-cost-lint` to automatically apply machine-applicable lint suggestions in-place.
+- New lint `formatted_panic_payload` detecting `format!(...)`, `panic!(...)` with formatting arguments, and `.expect(&format!(...))`, all of which pull `core::fmt` string-formatting machinery into a `#![no_std]` contract; the diagnostic points at `panic_with_error!` with a `#[contracterror]` enum as the cheap alternative. Skips `#[cfg(test)]` code.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The linter hooks into the Rust compiler's AST to catch specific Soroban anti-pat
 *   **[`vec_where_slice_could_be_used`](docs/lints/vec_where_slice_could_be_used.md):** Flags `soroban_sdk::Vec` passed by value where a native Rust `&[T]` slice would be sufficient for read-only access.
 *   **[`extend_ttl_in_loop`](docs/lints/extend_ttl_in_loop.md):** Flags `extend_ttl` calls on instance/persistent/temporary storage made inside loop bodies, suggesting batching the TTL extension instead of refreshing per-entry per-iteration.
 *   **[`instance_storage_for_unbounded_data`](docs/lints/instance_storage_for_unbounded_data.md):** Flags `env.storage().instance().set(...)` calls where the value is an unbounded `Vec`/`Map`/`Bytes`, since instance storage is re-read and rewritten in full on every contract invocation.
+*   **[`formatted_panic_payload`](docs/lints/formatted_panic_payload.md):** Flags `format!`, a formatted `panic!`, or `.expect(&format!(..))`, all of which pull `core::fmt` into the contract in place of a cheap `panic_with_error!` + `#[contracterror]`.
 
 ## How it Fits into Tollcraft
 
@@ -369,6 +370,7 @@ map_insert_in_loop = "warn"
 ```
 contract_call_in_loop = "warn"
 instance_storage_for_unbounded_data = "warn"
+formatted_panic_payload = "warn"
 
 Inline diagnostics are supported through rust-analyzer's `check.overrideCommand` setting:
 

--- a/cargo-cost-lint/build.rs
+++ b/cargo-cost-lint/build.rs
@@ -38,21 +38,11 @@ impl From<std::io::Error> for Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-fn main() {
-    if let Err(e) = run() {
-        eprintln!("error: {}", e);
-        std::process::exit(1);
-    }
-}
-
-fn run() -> Result<()> {
-    println!("cargo:rerun-if-changed=../soroban_cost_lints/src/lib.rs");
-
-    let content = fs::read_to_string("../soroban_cost_lints/src/lib.rs")?;
+/// A single lint's metadata parsed from `declare_lint!`.
 struct LintMeta {
-    name: String,
-    level: String,
-    description: String,
+    name: String,        // lowercase snake_case, e.g. "soroban_storage_in_loop"
+    level: String,       // lowercase level, e.g. "warn"
+    description: String, // one-line description from the macro
 }
 
 fn rust_string(value: &str) -> String {
@@ -61,7 +51,7 @@ fn rust_string(value: &str) -> String {
 
 /// Parse lint names from the `register_lints` call, returning lowercase names
 /// in the order they appear.
-fn parse_register_lints(content: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+fn parse_register_lints(content: &str) -> Result<Vec<String>> {
     let start_marker = "lint_store.register_lints(&[";
     let start = content
         .find(start_marker)
@@ -70,11 +60,6 @@ fn parse_register_lints(content: &str) -> Result<Vec<String>, Box<dyn std::error
     let end = content_after
         .find("]);")
         .ok_or_else(|| Error::Parse("Could not find end of register_lints".into()))?;
-        .ok_or("Could not find register_lints in lib.rs")?;
-    let content_after = &content[start..];
-    let end = content_after
-        .find("]);")
-        .ok_or("Could not find end of register_lints")?;
 
     let list_str = &content_after[start_marker.len()..end];
 
@@ -136,8 +121,6 @@ fn parse_declare_lints(content: &str) -> Vec<LintMeta> {
                 .trim();
             let name = raw_name.to_lowercase();
 
-    let out_dir = env::var_os("OUT_DIR").ok_or(Error::MissingEnv)?;
-    let dest_path = Path::new(&out_dir).join("lint_names.rs");
             // Line 1: "Warn," -> "warn"
             let level = lines[1].trim_end_matches(',').to_lowercase();
 
@@ -157,7 +140,8 @@ fn parse_declare_lints(content: &str) -> Vec<LintMeta> {
     results
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// Wraps `s` in the shortest raw string literal (`r"..."`, `r#"..."#`, ...)
+/// that can hold it verbatim.
 fn raw_string_literal(s: &str) -> String {
     // Find the smallest n such that " followed by n # signs does not appear
     // in the string, so r###"..."### is a valid raw string literal.
@@ -175,16 +159,22 @@ fn raw_string_literal(s: &str) -> String {
 }
 
 fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     println!("cargo:rerun-if-changed=../soroban_cost_lints/src/lib.rs");
 
-    let content = fs::read_to_string("../soroban_cost_lints/src/lib.rs")
-        .map_err(|e| format!("Failed to read soroban_cost_lints/src/lib.rs: {}", e))?;
+    let content = fs::read_to_string("../soroban_cost_lints/src/lib.rs")?;
 
     let names = parse_register_lints(&content)?;
     let declared = parse_declare_lints(&content);
 
-    // Build a name\u2192metadata lookup from the declare_lint! blocks.
-    let metadata_by_name: std::collections::HashMap<&str, &LintMeta> =
+    // Build a name→metadata lookup from the declare_lint! blocks.
+    let metadata_by_name: HashMap<&str, &LintMeta> =
         declared.iter().map(|m| (m.name.as_str(), m)).collect();
 
     // Derive LINT_INFO in the same order as register_lints, so the two
@@ -295,21 +285,21 @@ fn main() {
         }
     }
 
-    let out_dir = env::var_os("OUT_DIR").ok_or("OUT_DIR environment variable not set")?;
+    let out_dir = env::var_os("OUT_DIR").ok_or(Error::MissingEnv)?;
     let names_path = Path::new(&out_dir).join("lint_names.rs");
     let metadata_path = Path::new(&out_dir).join("lint_metadata.rs");
-
-    let mut out = String::new();
+    let info_path = Path::new(&out_dir).join("lint_info.rs");
+    let explanations_path = Path::new(&out_dir).join("lint_explanations.rs");
 
     // Emit LINT_NAMES (used by the filter logic in main.rs).
-    out.push_str("pub const LINT_NAMES: &[&str] = &[\n");
     let mut names_out = String::new();
     names_out.push_str("pub const LINT_NAMES: &[&str] = &[\n");
     for name in &names {
         names_out.push_str(&format!("    \"{}\",\n", name));
     }
     names_out.push_str("];\n");
-    fs::write(&names_path, names_out).expect("Failed to write lint_names.rs");
+    fs::write(&names_path, names_out)
+        .map_err(|e| Error::Parse(format!("Failed to write lint_names.rs: {}", e)))?;
 
     let mut metadata_out = String::new();
     metadata_out.push_str("#[derive(Serialize, Debug)]\npub struct LintInventoryEntry {\n");
@@ -363,42 +353,47 @@ fn main() {
             metadata_out.push_str("        },\n");
         }
     }
-
-    fs::write(&dest_path, out)?;
-    fs::write(&names_path, out).map_err(|e| format!("Failed to write lint_names.rs: {}", e))?;
-
-    let mut metadata_out = String::new();
-    metadata_out.push_str("#[derive(Serialize, Debug)]\npub struct LintInventoryEntry {\n");
-    metadata_out.push_str("    pub name: &'static str,\n");
-    metadata_out.push_str("    pub default_level: &'static str,\n");
-    metadata_out.push_str("    pub description: &'static str,\n");
-    metadata_out.push_str("    pub category: &'static str,\n");
-    metadata_out.push_str("    pub documentation_url: &'static str,\n");
-    metadata_out.push_str("}\n\n");
-    metadata_out.push_str("#[derive(Serialize, Debug)]\npub struct LintInventory {\n");
-    metadata_out.push_str("    pub version: &'static str,\n");
-    metadata_out.push_str("    pub schema: &'static str,\n");
-    metadata_out.push_str("    pub lints: &'static [LintInventoryEntry],\n");
-    metadata_out.push_str("}\n\n");
-    metadata_out.push_str("pub const LINT_INVENTORY: LintInventory = LintInventory {\n");
-    metadata_out.push_str("    version: \"1.0\",\n");
-    metadata_out.push_str("    schema: \"https://github.com/Tollcraft/soroban-cost-linter/blob/main/docs/lints/README.md#lint-inventory-schema\",\n");
-    metadata_out.push_str("    lints: &[\n");
-    for lint in &ordered {
-        let cat = category_map
-            .get(&lint.name)
-            .map(|c| c.as_str())
-            .unwrap_or("Unknown");
-        metadata_out.push_str(&format!(
-            "        LintInventoryEntry {{ name: \"{}\", default_level: \"{}\", description: \"{}\", category: \"{}\", documentation_url: \"\" }},\n",
-            lint.name, lint.level, lint.description, cat
-        ));
-    }
     metadata_out.push_str("    ],\n");
     metadata_out.push_str("};\n");
-
     fs::write(&metadata_path, metadata_out)
-        .map_err(|e| format!("Failed to write lint_metadata.rs: {}", e))?;
+        .map_err(|e| Error::Parse(format!("Failed to write lint_metadata.rs: {}", e)))?;
+
+    // Emit LintInfo/LINT_INFO for --list-lints (included by main.rs).
+    let mut info_out = String::new();
+    info_out.push_str("pub struct LintInfo {\n");
+    info_out.push_str("    pub name: &'static str,\n");
+    info_out.push_str("    pub level: &'static str,\n");
+    info_out.push_str("    pub description: &'static str,\n");
+    info_out.push_str("}\n\n");
+    info_out.push_str("pub const LINT_INFO: &[LintInfo] = &[\n");
+    for lint in &ordered {
+        info_out.push_str("    LintInfo {\n");
+        info_out.push_str(&format!("        name: \"{}\",\n", lint.name));
+        info_out.push_str(&format!("        level: \"{}\",\n", lint.level));
+        info_out.push_str(&format!("        description: \"{}\",\n", lint.description));
+        info_out.push_str("    },\n");
+    }
+    info_out.push_str("];\n");
+    fs::write(&info_path, info_out)
+        .map_err(|e| Error::Parse(format!("Failed to write lint_info.rs: {}", e)))?;
+
+    // --- Write lint_explanations.rs with embedded doc content as raw string literals ---
+    let mut explanations_out = String::new();
+    explanations_out.push_str("pub struct LintExplanation {\n");
+    explanations_out.push_str("    pub name: &'static str,\n");
+    explanations_out.push_str("    pub markdown: &'static str,\n");
+    explanations_out.push_str("}\n\n");
+    explanations_out.push_str("pub const LINT_EXPLANATIONS: &[LintExplanation] = &[\n");
+    for (name, doc_content) in &explanations {
+        let escaped = raw_string_literal(doc_content);
+        explanations_out.push_str("    LintExplanation {\n");
+        explanations_out.push_str(&format!("        name: \"{}\",\n", name));
+        explanations_out.push_str(&format!("        markdown: {},\n", escaped));
+        explanations_out.push_str("    },\n");
+    }
+    explanations_out.push_str("];\n");
+    fs::write(&explanations_path, explanations_out)
+        .map_err(|e| Error::Parse(format!("Failed to write lint_explanations.rs: {}", e)))?;
 
     Ok(())
 }

--- a/cargo-cost-lint/src/config.rs
+++ b/cargo-cost-lint/src/config.rs
@@ -64,6 +64,10 @@ impl Config {
             flags.push(format!("{} {}", prefix, lint_name.to_lowercase()));
         }
         flags
+    }
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct BudgetConfig {
     pub lints: Option<HashMap<String, String>>,
 }

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -1,26 +1,15 @@
 mod config;
+mod error;
 mod module_13;
 mod module_15;
 
 use clap::{Parser, ValueEnum};
-use ignore::WalkBuilder;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::fmt;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio, exit};
 
-mod config;
-mod error;
-
-use config::Config;
-use error::{LinterError, LinterResult};
-
-/// Output format for lint results.
 #[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
 enum OutputFormat {
     Text,
@@ -44,97 +33,6 @@ struct LintFinding {
     message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     help: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    suggestion: Option<String>,
-}
-
-/// SARIF 2.1.0 report root.
-#[derive(Serialize)]
-struct SarifReport {
-    #[serde(rename = "$schema")]
-    schema: String,
-    version: String,
-    runs: Vec<SarifRun>,
-}
-
-/// A single SARIF run (one invocation of the linter).
-#[derive(Serialize)]
-struct SarifRun {
-    tool: SarifTool,
-    results: Vec<SarifResult>,
-}
-
-/// Tool metadata for SARIF output.
-#[derive(Serialize)]
-struct SarifTool {
-    driver: SarifToolDriver,
-}
-
-/// Tool-driver metadata for SARIF output.
-#[allow(non_snake_case)]
-#[derive(Serialize)]
-struct SarifToolDriver {
-    name: String,
-    version: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "informationUri")]
-    information_uri: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    rules: Vec<serde_json::Value>,
-}
-
-/// A single SARIF result (one lint finding).
-#[derive(Serialize)]
-struct SarifResult {
-    #[serde(rename = "ruleId")]
-    rule_id: String,
-    level: String,
-    message: SarifMessage,
-    locations: Vec<SarifLocation>,
-}
-
-/// SARIF message text.
-#[derive(Serialize)]
-struct SarifMessage {
-    text: String,
-}
-
-/// SARIF location referencing a physical file.
-#[derive(Serialize)]
-struct SarifLocation {
-    #[serde(rename = "physicalLocation")]
-    physical_location: SarifPhysicalLocation,
-}
-
-/// SARIF physical location in a file.
-#[derive(Serialize)]
-struct SarifPhysicalLocation {
-    #[serde(rename = "artifactLocation")]
-    artifact_location: SarifArtifactLocation,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    region: Option<SarifRegion>,
-}
-
-/// SARIF artifact location (file URI).
-#[derive(Serialize)]
-struct SarifArtifactLocation {
-    uri: String,
-}
-
-/// SARIF region (line/column range within a file).
-#[derive(Serialize)]
-struct SarifRegion {
-    #[serde(rename = "startLine")]
-    start_line: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "startColumn")]
-    start_column: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "endLine")]
-    end_line: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "endColumn")]
-    end_column: Option<usize>,
 }
 
 #[derive(Parser, Debug)]
@@ -145,13 +43,22 @@ struct Cli {
     #[arg(long, help = "Path to budget.toml")]
     config: Option<String>,
 
+    #[arg(long, help = "Emit the lint inventory and exit")]
+    list_lints: bool,
+
     #[arg(long, value_enum, default_value_t = OutputFormat::Text, help = "Output format")]
     format: OutputFormat,
+}
+
+#[derive(Deserialize, Debug)]
+struct BudgetConfig {
+    lints: Option<std::collections::HashMap<String, String>>,
 }
 
 include!(concat!(env!("OUT_DIR"), "/lint_names.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_metadata.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_info.rs"));
+include!(concat!(env!("OUT_DIR"), "/lint_explanations.rs"));
 
 fn validate_and_build_flags(config: &BudgetConfig) -> Result<Vec<String>, String> {
     let mut lint_flags = Vec::new();
@@ -181,18 +88,6 @@ fn validate_and_build_flags(config: &BudgetConfig) -> Result<Vec<String>, String
     Ok(lint_flags)
 }
 
-/// Budget config deserialized from budget.toml — used by the
-/// `parse_budget_config` test helper and `load_budget_config`.
-#[derive(Deserialize, Debug)]
-#[allow(dead_code)]
-struct BudgetConfig {
-    lints: Option<HashMap<String, String>>,
-}
-
-#[allow(dead_code)]
-fn load_budget_config(config_path: &Path) -> Option<BudgetConfig> {
-    if !config_path.exists() {
-        return None;
 fn resolve_config(config: Option<&str>) -> Option<PathBuf> {
     if let Some(path) = config {
         let p = PathBuf::from(path);
@@ -207,26 +102,13 @@ fn resolve_config(config: Option<&str>) -> Option<PathBuf> {
     None
 }
 
-#[allow(dead_code)]
 /// Loads `path` as a validated `BudgetConfig` and formats its `[lints]`
 /// entries into `-A`/`-W`/`-D` flags for `DYLINT_RUSTFLAGS`. Validation
 /// (unknown lint names, invalid levels) is handled by
 /// `BudgetConfig::from_file_validated`, the single canonical config parser.
 fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
-    let config = BudgetConfig::from_file_validated(Path::new(path), LINT_NAMES)?;
+    let config = config::BudgetConfig::from_file_validated(Path::new(path), LINT_NAMES)?;
 
-/// Walks `root`, respecting `.gitignore` and `.lintignore`, and returns the
-/// canonicalized set of files that are allowed to be linted (i.e. not
-/// excluded by either ignore file).
-fn allowed_files(root: &Path) -> HashSet<PathBuf> {
-    WalkBuilder::new(root)
-        .git_ignore(true)
-        .add_custom_ignore_filename(".lintignore")
-        .build()
-        .filter_map(std::result::Result::ok)
-        .filter(|entry| entry.file_type().map(|t| t.is_file()).unwrap_or(false))
-        .filter_map(|entry| entry.path().canonicalize().ok())
-        .collect()
     let mut lint_flags = Vec::new();
     if let Some(lints) = config.lints {
         for (lint, level) in lints {
@@ -269,96 +151,19 @@ fn try_parse_budget_config(path: &str) -> Result<Vec<String>, String> {
     }
 }
 
-// ── Error type ──────────────────────────────────────────────────────────
-
-#[derive(Debug)]
-enum Error {
-    Io(std::io::Error),
-    Dylint(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::Io(e) => write!(f, "I/O error: {}", e),
-            Error::Dylint(msg) => write!(f, "{}", msg),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Error::Io(e) => Some(e),
-            Error::Dylint(_) => None,
-        }
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(e: std::io::Error) -> Self {
-        Error::Io(e)
-    }
-}
-
-type Result<T> = std::result::Result<T, Error>;
-
-// ── Main ────────────────────────────────────────────────────────────────
-
 #[allow(clippy::collapsible_if)]
 fn main() {
-    if let Err(e) = run() {
-        eprintln!("Error: {}", e);
-        exit(1);
-    }
-}
-
-/// Core logic extracted into a fallible function so that all error sites can
-/// use the `?` operator rather than a mix of `unwrap`, `expect`, and `exit`.
-fn run() -> LinterResult<()> {
     // Skip the first arg if it is "cost-lint" (when invoked as a cargo subcommand)
     let mut args = std::env::args().collect::<Vec<_>>();
     if args.len() > 1 && args[1] == "cost-lint" {
         args.remove(1);
     }
-    let cli = Cli::try_parse_from(args).unwrap_or_else(|e| {
-        let _ = e.print();
-        exit(1);
-    });
-
-    let allowed = allowed_files(Path::new("."));
-
-    match run(cli, allowed) {
-        Ok(code) => exit(code),
-        Err(e) => {
-            eprintln!("error: {}", e);
-            exit(1);
-        }
-    }
-}
-
-fn run(cli: Cli, allowed: HashSet<PathBuf>) -> Result<i32> {
-    let lint_flags: Vec<String> = Vec::new();
-    if let Some(config_path) = &cli.config {
-        if Path::new(config_path).exists() {
-            let config_str = fs::read_to_string(config_path)?;
-            if let Ok(config) = toml::from_str::<BudgetConfig>(&config_str) {
-                // ... validate (existing code)
-                let _ = config;
-
-    // Handle --version / -V explicitly: clap 4.0's #[command(version)]
-    // displays the version but does not auto-exit, so we must check early
-    // and exit 0 before falling through to the cargo-dylint machinery.
-    if args.iter().any(|a| a == "--version" || a == "-V") {
-        println!("cargo-cost-lint {}", env!("CARGO_PKG_VERSION"));
-        return Ok(());
-    }
 
     let cli = match Cli::try_parse_from(args) {
         Ok(c) => c,
         Err(e) => {
-            e.print()?;
-            return Err(LinterError::Other("argument parsing failed".into()));
+            e.print().unwrap();
+            exit(1);
         }
     };
 
@@ -374,32 +179,10 @@ fn run(cli: Cli, allowed: HashSet<PathBuf>) -> Result<i32> {
                 );
             }
         }
-        return Ok(());
+        return;
     }
 
     let mut lint_flags = Vec::new();
-
-    let lint_flags = if let Some(config_path) = &cli.config {
-        let config = Config::from_file_or_default(Path::new(config_path))?;
-        config.to_lint_flags()
-    } else {
-        Vec::new()
-    };
-
-    let preflight = Command::new("cargo")
-        .arg("dylint")
-        .arg("--version")
-        .output();
-
-    match preflight {
-        Ok(output) if output.status.success() => {}
-        _ => {
-            eprintln!("Error: cargo-dylint is not installed or not available in PATH.");
-            eprintln!("Please install it by running:");
-            eprintln!("    cargo install cargo-dylint dylint-link");
-            exit(1);
-        }
-    }
 
     if let Some(ref path) = resolve_config(cli.config.as_deref()) {
         eprintln!("Using config: {}", path.display());
@@ -442,157 +225,6 @@ fn run(cli: Cli, allowed: HashSet<PathBuf>) -> Result<i32> {
         cmd.stdout(Stdio::piped());
     }
 
-    let mut child = cmd.spawn().map_err(|e| {
-        Error::Dylint(format!(
-        LinterError::MissingPrerequisite(format!(
-            "Failed to execute cargo dylint: {}. Is cargo-dylint installed?",
-            e
-        ))
-    })?;
-
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| Error::Dylint("Failed to capture stdout from cargo dylint".into()))?;
-        .ok_or_else(|| LinterError::Other("Failed to capture stdout".into()))?;
-    let reader = BufReader::new(stdout);
-    let mut highest_exit_code = 0;
-    let mut lint_counts: HashMap<String, usize> = HashMap::new();
-
-    let mut findings: Vec<LintFinding> = Vec::new();
-
-    for line_str in reader.lines().map_while(std::result::Result::ok) {
-        if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&line_str) {
-            if msg.get("reason").and_then(|r| r.as_str()) == Some("compiler-message") {
-                if let Some(message) = msg.get("message") {
-                    if let Some(code) = message.get("code") {
-                        if let Some(lint_name) = code.get("code").and_then(|c| c.as_str()) {
-                            if LINT_NAMES.contains(&lint_name) {
-                                let level = message
-                                    .get("level")
-                                    .and_then(|l| l.as_str())
-                                    .unwrap_or("unknown");
-
-                                let msg_text = message
-                                    .get("message")
-                                    .and_then(|m| m.as_str())
-                                    .unwrap_or("");
-                                let mut file = String::new();
-                                let mut span_obj = Span {
-                                    line_start: 0,
-                                    line_end: 0,
-                                    column_start: 0,
-                                    column_end: 0,
-                                };
-
-                                if let Some(spans) = message.get("spans").and_then(|s| s.as_array())
-                                {
-                                    for s in spans {
-                                        if s.get("is_primary")
-                                            .and_then(|p| p.as_bool())
-                                            .unwrap_or(false)
-                                        {
-                                            file = s
-                                                .get("file_name")
-                                                .and_then(|f| f.as_str())
-                                                .unwrap_or("")
-                                                .to_string();
-                                            span_obj.line_start = s
-                                                .get("line_start")
-                                                .and_then(|l| l.as_u64())
-                                                .unwrap_or(0)
-                                                as usize;
-                                            span_obj.line_end = s
-                                                .get("line_end")
-                                                .and_then(|l| l.as_u64())
-                                                .unwrap_or(0)
-                                                as usize;
-                                            span_obj.column_start = s
-                                                .get("column_start")
-                                                .and_then(|c| c.as_u64())
-                                                .unwrap_or(0)
-                                                as usize;
-                                            span_obj.column_end = s
-                                                .get("column_end")
-                                                .and_then(|c| c.as_u64())
-                                                .unwrap_or(0)
-                                                as usize;
-                                            break;
-                                        }
-    for line_str in reader.lines().map_while(Result::ok) {
-        if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&line_str)
-            && msg.get("reason").and_then(|r| r.as_str()) == Some("compiler-message")
-            && let Some(message) = msg.get("message")
-            && let Some(code) = message.get("code")
-            && let Some(lint_name) = code.get("code").and_then(|c| c.as_str())
-            && LINT_NAMES.contains(&lint_name)
-        {
-            let level = message
-                .get("level")
-                .and_then(|l| l.as_str())
-                .unwrap_or("unknown");
-
-            let diagnostic_message = message
-                .get("message")
-                .and_then(|m| m.as_str())
-                .unwrap_or("");
-            let mut file = String::new();
-            let mut primary_span = Span {
-                line_start: 0,
-                line_end: 0,
-                column_start: 0,
-                column_end: 0,
-            };
-
-            if let Some(spans) = message.get("spans").and_then(|s| s.as_array()) {
-                for span in spans {
-                    if span
-                        .get("is_primary")
-                        .and_then(|p| p.as_bool())
-                        .unwrap_or(false)
-                    {
-                        file = span
-                            .get("file_name")
-                            .and_then(|f| f.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        primary_span.line_start =
-                            span.get("line_start").and_then(|l| l.as_u64()).unwrap_or(0) as usize;
-                        primary_span.line_end =
-                            span.get("line_end").and_then(|l| l.as_u64()).unwrap_or(0) as usize;
-                        primary_span.column_start =
-                            span.get("column_start")
-                                .and_then(|c| c.as_u64())
-                                .unwrap_or(0) as usize;
-                        primary_span.column_end =
-                            span.get("column_end").and_then(|c| c.as_u64()).unwrap_or(0) as usize;
-                        break;
-                    }
-                }
-            }
-
-            if !is_reportable(&file, &allowed) {
-                continue;
-            }
-
-            *lint_counts.entry(lint_name.to_string()).or_insert(0) += 1;
-
-            if level == "error" || level == "deny" {
-                highest_exit_code = 1;
-            }
-
-            let mut help_text = None;
-            let mut suggestion = None;
-            if let Some(children) = message.get("children").and_then(|c| c.as_array()) {
-                for child_item in children {
-                    if child_item.get("level").and_then(|l| l.as_str()) == Some("help") {
-                        let child_msg = child_item
-                            .get("message")
-                            .and_then(|m| m.as_str())
-                            .map(|s| s.to_string());
-                        help_text = child_msg.clone();
-                        if cli.fix {
-                            suggestion = extract_suggestion(&child_msg, lint_name);
     let mut child = cmd
         .spawn()
         .expect("Failed to execute cargo dylint. Is cargo-dylint installed?");
@@ -699,35 +331,8 @@ fn run(cli: Cli, allowed: HashSet<PathBuf>) -> Result<i32> {
                                 }
                             }
                         }
-                        break;
                     }
                 }
-            }
-
-            let finding = LintFinding {
-                name: lint_name.to_string(),
-                level: level.to_string(),
-                file: file.clone(),
-                span: primary_span,
-                message: diagnostic_message.to_string(),
-                help: help_text,
-                suggestion,
-            };
-
-            findings.push(finding);
-
-            if cli.format == OutputFormat::Json {
-                // Safe: we just pushed an element above.
-                let finding_json = findings.last().unwrap();
-                if let Ok(json_str) = serde_json::to_string(finding_json) {
-                    println!("{}", json_str);
-                }
-            } else if cli.format != OutputFormat::Sarif {
-                let rendered = message
-                    .get("rendered")
-                    .and_then(|r| r.as_str())
-                    .unwrap_or(diagnostic_message);
-                print!("{}", rendered);
             }
         }
 
@@ -745,37 +350,6 @@ fn run(cli: Cli, allowed: HashSet<PathBuf>) -> Result<i32> {
     }
 }
 
-    let status = child.wait()?;
-
-    // Print per-lint summary to stderr when there are findings
-    if !lint_counts.is_empty() {
-        eprintln!("lint summary:");
-        let mut sorted: Vec<_> = lint_counts.iter().collect();
-        sorted.sort_by_key(|(name, _)| *name);
-        for (name, count) in &sorted {
-            eprintln!("  {}: {}", name, count);
-        }
-        let total: usize = lint_counts.values().sum();
-        eprintln!("total: {}", total);
-    }
-
-    let status = child
-        .wait()
-        .map_err(|e| Error::Dylint(format!("Failed to wait on cargo dylint: {}", e)))?;
-    if !status.success() {
-        Ok(status.code().unwrap_or(1))
-    } else {
-        Ok(highest_exit_code)
-    if !status.success() {
-        return Err(LinterError::Subprocess {
-            code: status.code(),
-        });
-    } else if highest_exit_code != 0 {
-        exit(highest_exit_code);
-    }
-
-    Ok(())
-}
 /// Prints the explanation for a lint, or errors with valid lint names if not found.
 fn print_explanation(lint_name: &str) {
     let normalized = lint_name.to_lowercase();
@@ -822,29 +396,6 @@ fn clean_markdown_for_terminal(markdown: &str) -> String {
             continue;
         }
 
-    for (file_path, edits) in &file_edits {
-        match fs::read_to_string(file_path) {
-            Ok(content) => {
-                let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
-                for (line_idx, _message, suggestion) in edits {
-                    if *line_idx > 0 && *line_idx <= lines.len() {
-                        let line = &mut lines[*line_idx - 1];
-                        if let Some(start) = line.find("Symbol::new")
-                            && let Some(end) = line[start..].find(')')
-                        {
-                            let replace_end = start + end + 1;
-                            line.replace_range(start..replace_end, suggestion);
-                        }
-                    }
-                }
-                let new_content = lines.join("\n");
-                if let Err(e) = fs::write(file_path, new_content) {
-                    eprintln!("Failed to write {}: {}", file_path, e);
-                }
-            }
-            Err(e) => {
-                eprintln!("Failed to read {}: {}", file_path, e);
-            }
         // Strip GitBook hint tags and their content delimiters
         if trimmed.starts_with("{% hint")
             || trimmed.starts_with("{% endhint")
@@ -866,14 +417,6 @@ fn clean_markdown_for_terminal(markdown: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
-    use std::io::Write;
-
-    use super::*;
-
-    fn write_file(path: &Path, contents: &str) {
-        let mut f = File::create(path).unwrap();
-        f.write_all(contents.as_bytes()).unwrap();
     use super::*;
     use std::io::Write;
 
@@ -1039,7 +582,6 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("budget.toml");
         let mut file = fs::File::create(&path).unwrap();
-        writeln!(file, "this is not valid toml = {{{{").unwrap();
         writeln!(file, "this is not valid toml = {{{{{{").unwrap();
         drop(file);
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -27,6 +27,7 @@
   * [vec\_where\_slice\_could\_be\_used](lints/vec_where_slice_could_be_used.md)
   * [extend\_ttl\_in\_loop](lints/extend_ttl_in_loop.md)
   * [instance\_storage\_for\_unbounded\_data](lints/instance_storage_for_unbounded_data.md)
+  * [formatted\_panic\_payload](lints/formatted_panic_payload.md)
 
 ## Branding
 

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -31,8 +31,10 @@ Lints are classified per the [MVP roadmap](../../roadmap_mvp.md#3-false-positive
 
 | Lint                                                                  | Default Severity | Catches                                    |
 | --------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
-| [`unnecessary_host_function_call`](unnecessary_host_function_call.md) | `warn`           | Redundant host function calls inside loops |
+| [`unnecessary_host_function_call`](unnecessary_host_function_call.md) | `warn`           | `Ledger`, `Crypto`, `Prng`, `Events`, `Deployer` and `Env::current_contract_address` calls repeated inside loops with unchanged inputs |
 | [`host_in_loop`](host_in_loop.md)                                     | `warn`           | Host object usage inside loop bodies       |
+| [`signature_verification_in_loop`](signature_verification_in_loop.md) | `warn`           | `ed25519_verify`/`secp256k1_recover`/`secp256r1_verify` calls inside loops |
+| [`formatted_panic_payload`](formatted_panic_payload.md)               | `warn`           | `format!`, formatted `panic!`, and `.expect(&format!(..))` |
 
 ## Memory
 

--- a/docs/lints/formatted_panic_payload.md
+++ b/docs/lints/formatted_panic_payload.md
@@ -1,0 +1,118 @@
+# `formatted_panic_payload`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [CPU instructions on the failure path, and WASM binary size on every deploy](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Flags three call shapes that pull Rust's `core::fmt` string-formatting
+machinery into a `#![no_std]` Soroban contract:
+
+1. Any `format!(...)` invocation.
+2. `panic!(...)` when the macro call has at least one formatting argument
+   (e.g. `panic!("balance {} below {}", a, b)`). A zero-argument
+   `panic!("plain literal")` is **not** flagged — it never touches
+   `core::fmt`.
+3. `.expect(&format!(...))` — an `.expect()` call whose message argument is a
+   `format!(...)` call. A plain `.expect("literal")` is **not** flagged.
+
+## Why is this bad?
+
+{% hint style="danger" %}
+`format!` and a formatted `panic!` message both expand through
+`core::fmt::Arguments` and the associated `Display`/`Debug` formatting code
+paths. In a `#![no_std]` contract that machinery is not "free" the way it is
+in a hosted Rust program: pulling it in inflates the compiled WASM binary —
+a cost paid on **every deploy**, not just when the failure path runs — and
+running it also spends CPU instructions formatting the message on the
+failure path itself.
+{% endhint %}
+
+`panic_with_error!` combined with a `#[contracterror]` enum, by contrast,
+compiles down to returning a plain integer error code. It carries neither
+cost: no formatting machinery is linked in, and raising it is a single
+constant-time host call.
+
+Contract authors reach for `format!`/`panic!("...{}...")` reflexively
+because it's the idiomatic, "free" thing to do everywhere else in Rust. That
+habit is exactly what makes this a high-frequency, low-awareness cost
+mistake in a metered `no_std` context.
+
+## Example
+
+```rust
+// ❌ Bad: pulls in core::fmt for a message that's only useful in a debugger
+fn bad(env: &Env, balance: i128, amount: i128) {
+    if balance < amount {
+        panic!("balance {} below required {}", balance, amount);
+    }
+}
+```
+
+```rust
+// ✅ Good: a plain integer error code, no formatting machinery at all
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    InsufficientBalance = 1,
+}
+
+fn good(env: &Env, balance: i128, amount: i128) {
+    if balance < amount {
+        panic_with_error!(env, Error::InsufficientBalance);
+    }
+}
+```
+
+## Suggested Fix
+
+{% hint style="success" %}
+Replace the formatted message with a `#[contracterror]` enum variant and
+raise it via `panic_with_error!(env, Error::Variant)`. If the formatted
+detail is only useful for local debugging, gate it behind `#[cfg(test)]` or
+strip it entirely before shipping — this lint does not fire in
+`#[cfg(test)]` code (see below), so debug-only formatted panics in tests are
+unaffected.
+{% endhint %}
+
+## What is not reported
+
+- `panic!("plain literal")` — zero-argument `panic!`, no formatting
+  machinery involved.
+- `.expect("plain literal")` — a message that is not a `format!(...)` call.
+- `.expect(msg)` where `msg` is a local variable, even if it happens to hold
+  a `String` built elsewhere — this lint only follows the message argument
+  one hop, to keep the pattern precise and avoid chasing values across a
+  function.
+- Any of the three shapes above when the enclosing item is under
+  `#[cfg(test)]` — either directly on the function, or on an enclosing
+  `mod tests { .. }`.
+- Calls suppressed with `#[allow(formatted_panic_payload)]`.
+
+## Test-vs-contract code: the `#[cfg(test)]` signal
+
+The issue behind this lint asks for a way to tell contract code apart from
+test code, and specifically calls out both `#[cfg(test)]` and
+`#[contractimpl]` as candidate signals. This lint uses **`#[cfg(test)]`
+only** (via `clippy_utils::is_in_test`, which covers both a `#[test]`
+function and any parent marked `#[cfg(test)]`, including an enclosing
+`mod tests { .. }`).
+
+A `#[contractimpl]`-reachability analysis — proving an expression can only
+be reached from a contract's public entrypoints — was considered and
+rejected for a first version: it would require whole-crate call-graph
+reasoning that is both fragile (indirect calls, trait dispatch, and
+re-exports would need to be modeled or conservatively over-approximated)
+and invasive relative to the rest of this crate's lints, which stay
+single-function or bounded-depth. Staying with `#[cfg(test)]` keeps the
+lint's behavior easy to reason about and consistent with the project's
+stated preference for conservative, false-positive-averse checks.
+
+One consequence: this lint fires on `format!`/formatted `panic!`/`expect`
+usage in *any* non-test code compiled into the crate being checked, not
+only code reachable from a `#[contractimpl]` entrypoint. In practice this is
+rarely a problem because `cargo-cost-lint` is run against Soroban contract
+crates, whose non-test code is overwhelmingly on or reachable from the
+contract's execution paths.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -42,6 +42,9 @@
 //! - [`HOST_IN_LOOP`] — use of a `Host` object inside a loop.
 //! - [`SYMBOL_NEW_FOR_SHORT_LITERAL`] — `Symbol::new` on a literal short enough
 //!   for the compile-time `symbol_short!` macro.
+//! - [`FORMATTED_PANIC_PAYLOAD`] — `format!`, a formatted `panic!`, or
+//!   `.expect(&format!(..))`, all of which pull `core::fmt` into the
+//!   contract in place of a cheap `panic_with_error!` + `#[contracterror]`.
 //!
 //! Each lint is assigned a [`LintCategory`] and registered in [`LINT_METADATA`],
 //! the single source of truth the wrapper reads to describe available lints.
@@ -69,6 +72,7 @@
 //! [`LintCategory`].
 
 extern crate rustc_ast;
+extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_lint;
@@ -78,11 +82,13 @@ extern crate rustc_span;
 
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use clippy_utils::get_enclosing_loop_or_multi_call_closure;
+use clippy_utils::macros::{FormatArgsStorage, is_panic, root_macro_call_first_node};
 use clippy_utils::res::MaybeResPath;
 use clippy_utils::source::snippet_opt;
 use clippy_utils::ty::peel_and_count_ty_refs;
 use clippy_utils::usage::local_used_after_expr;
 use clippy_utils::usage::mutated_variables;
+use clippy_utils::{get_parent_expr, is_in_test};
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -90,7 +96,7 @@ use rustc_hir::HirIdSet;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::intravisit::{self, FnKind, Visitor};
 use rustc_hir::{FnDecl, HirId, HirIdSet};
-use rustc_lint::{LateContext, LateLintPass, LintStore};
+use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintStore};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::DefId;
 use std::cell::RefCell;
@@ -569,6 +575,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
         category: LintCategory::StorageOperations,
     },
+    LintMetadata {
+        lint: FORMATTED_PANIC_PAYLOAD,
+        category: LintCategory::Compute,
+    },
 ];
 
 /// `dylint` entry point. Registers every lint declared by this crate with
@@ -610,6 +620,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         BYTES_APPEND_IN_LOOP,
         SIGNATURE_VERIFICATION_IN_LOOP,
         INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
+        FORMATTED_PANIC_PAYLOAD,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(SorobanRedundantStorageRead));
@@ -640,6 +651,24 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(BytesAppendInLoop));
     lint_store.register_late_pass(|_| Box::new(SignatureVerificationInLoop));
     lint_store.register_late_pass(|_| Box::new(InstanceStorageForUnboundedData));
+
+    // `formatted_panic_payload` needs the AST-level `format_args!` nodes to
+    // tell a zero-argument `panic!("literal")` apart from a formatted
+    // `panic!("{} ...", x)` — the HIR only exposes the already-desugared,
+    // opaque `Arguments::new_v1(...)` call by the time a late pass runs, and
+    // pattern-matching that expanded shape is exactly the false-positive
+    // trap this lint is meant to avoid (see issue #108). `FormatArgsCollector`
+    // is an early pass that records the original AST nodes into a shared
+    // `FormatArgsStorage`, which the late pass then queries.
+    let format_args_storage = FormatArgsStorage::default();
+    lint_store.register_early_pass({
+        let format_args_storage = format_args_storage.clone();
+        move || Box::new(FormatArgsCollector::new(format_args_storage.clone()))
+    });
+    lint_store.register_late_pass({
+        let format_args_storage = format_args_storage.clone();
+        move |_| Box::new(FormattedPanicPayload::new(format_args_storage.clone()))
+    });
 }
 
 /// Flags any Soroban storage accessor method call (including
@@ -2354,6 +2383,206 @@ impl<'tcx> LateLintPass<'tcx> for InstanceStorageForUnboundedData {
                      contract's life without showing up in any single-call test; persistent \
                      storage, keyed per entry, is the structurally correct shape for unbounded \
                      data",
+                );
+            }
+        }
+    }
+}
+
+// =======================================================================
+// formatted_panic_payload — Lint
+// =======================================================================
+
+/// Populates a shared [`FormatArgsStorage`] with the AST-level `format_args!`
+/// nodes produced during macro expansion.
+///
+/// By the time a `LateLintPass` sees a `panic!(...)` or `format!(...)` call,
+/// the HIR has already desugared it into an opaque
+/// `core::panicking::panic_fmt(Arguments::new_v1(...))`-shaped call.
+/// Pattern-matching that expanded shape to recover the original argument
+/// count is exactly the false-positive trap issue #108 warns about, so
+/// instead this early pass (mirroring clippy's own
+/// `clippy_lints::utils::format_args_collector::FormatArgsCollector`, the
+/// exact mechanism named in the issue) records the pre-expansion AST
+/// [`FormatArgs`](rustc_ast::FormatArgs) node for every `format_args!`
+/// expansion, keyed by span. [`FormattedPanicPayload`] later looks these up
+/// through [`FormatArgsStorage::get`] to ask a much simpler, reliable
+/// question: "how many arguments did the original macro invocation have?"
+struct FormatArgsCollector {
+    format_args: rustc_data_structures::fx::FxHashMap<rustc_span::Span, rustc_ast::FormatArgs>,
+    storage: FormatArgsStorage,
+}
+
+impl FormatArgsCollector {
+    fn new(storage: FormatArgsStorage) -> Self {
+        Self {
+            format_args: rustc_data_structures::fx::FxHashMap::default(),
+            storage,
+        }
+    }
+}
+
+rustc_session::impl_lint_pass!(FormatArgsCollector => []);
+
+impl EarlyLintPass for FormatArgsCollector {
+    fn check_expr(&mut self, _cx: &EarlyContext<'_>, expr: &rustc_ast::Expr) {
+        if let rustc_ast::ExprKind::FormatArgs(args) = &expr.kind {
+            self.format_args
+                .insert(expr.span.with_parent(None), (**args).clone());
+        }
+    }
+
+    fn check_crate_post(&mut self, _cx: &EarlyContext<'_>, _krate: &rustc_ast::Crate) {
+        self.storage.set(std::mem::take(&mut self.format_args));
+    }
+}
+
+rustc_session::declare_lint! {
+    pub FORMATTED_PANIC_PAYLOAD,
+    Warn,
+    "format!, formatted panic!, or expect(&format!(..)) pulls string-formatting machinery into a contract"
+}
+
+/// Late pass backing [`FORMATTED_PANIC_PAYLOAD`]. Holds the [`FormatArgsStorage`]
+/// populated by [`FormatArgsCollector`] so it can distinguish a zero-argument
+/// `panic!("literal")` (cheap: no `core::fmt` machinery) from a formatted
+/// `panic!("{} ...", x)` (pulls in `core::fmt`, both inflating the compiled
+/// WASM and running formatting instructions on the failure path).
+pub struct FormattedPanicPayload {
+    format_args: FormatArgsStorage,
+}
+
+impl FormattedPanicPayload {
+    fn new(format_args: FormatArgsStorage) -> Self {
+        Self { format_args }
+    }
+}
+
+rustc_session::impl_lint_pass!(FormattedPanicPayload => [FORMATTED_PANIC_PAYLOAD]);
+
+const FORMATTED_PANIC_PAYLOAD_HELP: &str = "formatted messages pull core::fmt into the contract (binary size on every deploy) and run \
+     formatting instructions on the failure path; use panic_with_error!(env, Error::Variant) with \
+     a #[contracterror] enum instead, which compiles to a plain integer error code with neither cost";
+
+const FORMATTED_PANIC_PAYLOAD_MSG: &str =
+    "formatted panic payload pulls in string-formatting machinery";
+
+/// Strips any number of leading `&`s, returning the innermost referent.
+///
+/// Used to see through `.expect(&format!(...))`: the argument HIR node is the
+/// hand-written `&format!(...)` (`AddrOf`), not the `format!(...)` call
+/// itself, and only the latter's span actually originates from a macro
+/// expansion.
+fn peel_ref_expr<'tcx>(mut expr: &'tcx hir::Expr<'tcx>) -> &'tcx hir::Expr<'tcx> {
+    while let hir::ExprKind::AddrOf(_, _, inner) = expr.kind {
+        expr = inner;
+    }
+    expr
+}
+
+/// Whether `expr` — a `format!(...)` call — is, modulo any number of `&`
+/// wrappers, the message argument of an enclosing `.expect(...)` call.
+///
+/// Both the standalone-`format!` check and the `.expect(&format!(...))`
+/// check in [`FormattedPanicPayload::check_expr`] would otherwise fire on
+/// the same source expression (the HIR visitor calls `check_expr` on every
+/// node, including the nested `format!(...)` call), producing two warnings
+/// for one problem. When this returns `true`, the standalone-`format!`
+/// branch stays silent and lets the `.expect(...)` branch report a single
+/// warning pinned at the more actionable outer call.
+fn is_expect_format_message<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) -> bool {
+    let mut current = expr;
+    while let Some(parent) = get_parent_expr(cx, current) {
+        match parent.kind {
+            hir::ExprKind::AddrOf(_, _, _) => current = parent,
+            hir::ExprKind::MethodCall(path_segment, _receiver, args, _span) => {
+                return path_segment.ident.name.as_str() == "expect"
+                    && matches!(args, [message_arg] if message_arg.hir_id == current.hir_id);
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+impl<'tcx> LateLintPass<'tcx> for FormattedPanicPayload {
+    /// Flags three call shapes, all of which pull `core::fmt` formatting
+    /// machinery into the compiled contract:
+    ///
+    /// 1. Any `format!(...)` invocation.
+    /// 2. `panic!(...)` when the original macro call had at least one
+    ///    formatting argument (`panic!("plain literal")` — zero arguments —
+    ///    is cheap and is not flagged).
+    /// 3. `.expect(&format!(...))` — an `.expect()` call whose message
+    ///    argument's expansion root is a `format!` call.
+    ///
+    /// Each shape is identified by checking the expression's macro
+    /// *expansion site* via `clippy_utils::macros` (`root_macro_call_first_node`,
+    /// `is_panic`, and the `format_macro` diagnostic item), never by pattern-matching
+    /// the desugared HIR shape those macros expand to — see the module-level
+    /// docs on [`FormatArgsCollector`] for why that distinction matters here.
+    ///
+    /// Skipped entirely under `#[cfg(test)]` (on the enclosing function or an
+    /// enclosing `mod { .. }`), via `clippy_utils::is_in_test`. Distinguishing
+    /// contract code from test code more precisely (e.g. by proving an
+    /// expression is only reachable from a `#[contractimpl]` entrypoint)
+    /// would need a call-graph reachability analysis; that was considered and
+    /// rejected as too invasive/fragile for a first version — see the PR
+    /// description for the full rationale.
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        if let Some(macro_call) = root_macro_call_first_node(cx, expr) {
+            if cx
+                .tcx
+                .is_diagnostic_item(rustc_span::sym::format_macro, macro_call.def_id)
+            {
+                if !is_expect_format_message(cx, expr) && !is_in_test(cx.tcx, expr.hir_id) {
+                    span_lint_and_help(
+                        cx,
+                        FORMATTED_PANIC_PAYLOAD,
+                        macro_call.span,
+                        FORMATTED_PANIC_PAYLOAD_MSG,
+                        None,
+                        FORMATTED_PANIC_PAYLOAD_HELP,
+                    );
+                }
+                return;
+            }
+
+            if is_panic(cx, macro_call.def_id)
+                && let Some(format_args) = self.format_args.get(cx, expr, macro_call.expn)
+                && !format_args.arguments.all_args().is_empty()
+                && !is_in_test(cx.tcx, expr.hir_id)
+            {
+                span_lint_and_help(
+                    cx,
+                    FORMATTED_PANIC_PAYLOAD,
+                    macro_call.span,
+                    FORMATTED_PANIC_PAYLOAD_MSG,
+                    None,
+                    FORMATTED_PANIC_PAYLOAD_HELP,
+                );
+            }
+            return;
+        }
+
+        if let hir::ExprKind::MethodCall(path_segment, _receiver, args, _span) = expr.kind
+            && path_segment.ident.name.as_str() == "expect"
+            && let [message_arg] = args
+        {
+            let inner = peel_ref_expr(message_arg);
+            if let Some(macro_call) = root_macro_call_first_node(cx, inner)
+                && cx
+                    .tcx
+                    .is_diagnostic_item(rustc_span::sym::format_macro, macro_call.def_id)
+                && !is_in_test(cx.tcx, expr.hir_id)
+            {
+                span_lint_and_help(
+                    cx,
+                    FORMATTED_PANIC_PAYLOAD,
+                    expr.span,
+                    FORMATTED_PANIC_PAYLOAD_MSG,
+                    None,
+                    FORMATTED_PANIC_PAYLOAD_HELP,
                 );
             }
         }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -92,8 +92,6 @@ use clippy_utils::{get_parent_expr, is_in_test};
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
-use rustc_hir::HirIdSet;
-use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::intravisit::{self, FnKind, Visitor};
 use rustc_hir::{FnDecl, HirId, HirIdSet};
 use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintStore};
@@ -487,7 +485,6 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         category: LintCategory::StorageOperations,
     },
     LintMetadata {
-        lint: UNBOUNDED_INPUT_LOOP,
         lint: SOROBAN_REDUNDANT_STORAGE_READ,
         category: LintCategory::StorageOperations,
     },
@@ -613,12 +610,6 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         REQUIRE_AUTH_IN_LOOP,
         SYMBOL_NEW_FOR_SHORT_LITERAL,
         PERSISTENT_READ_WITHOUT_TTL_EXTENSION,
-        UNNECESSARY_STRING_TO_BYTES,
-        STORAGE_WRITE_WITHOUT_READ,
-        INEFFICIENT_BYTES_CONCAT,
-        MAP_INSERT_IN_LOOP,
-        BYTES_APPEND_IN_LOOP,
-        SIGNATURE_VERIFICATION_IN_LOOP,
         INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
         FORMATTED_PANIC_PAYLOAD,
     ]);
@@ -644,12 +635,6 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(RequireAuthInLoop));
     lint_store.register_late_pass(|_| Box::new(SymbolNewForShortLiteral));
     lint_store.register_late_pass(|_| Box::new(PersistentReadWithoutTtlExtension));
-    lint_store.register_late_pass(|_| Box::new(UnnecessaryStringToBytes));
-    lint_store.register_late_pass(|_| Box::new(StorageWriteWithoutRead));
-    lint_store.register_late_pass(|_| Box::new(InefficientBytesConcat));
-    lint_store.register_late_pass(|_| Box::new(MapInsertInLoop));
-    lint_store.register_late_pass(|_| Box::new(BytesAppendInLoop));
-    lint_store.register_late_pass(|_| Box::new(SignatureVerificationInLoop));
     lint_store.register_late_pass(|_| Box::new(InstanceStorageForUnboundedData));
 
     // `formatted_panic_payload` needs the AST-level `format_args!` nodes to
@@ -928,11 +913,7 @@ impl SorobanRedundantStorageRead {
                 key_arg
             };
 
-            let key_text = cx
-                .sess()
-                .source_map()
-                .span_to_snippet(key_inner.span)
-                .ok()?;
+            let key_text = snippet_opt(cx, key_inner.span)?;
 
             Some(StorageOp::Read {
                 storage_def_id,
@@ -961,7 +942,7 @@ impl<'tcx> LateLintPass<'tcx> for SorobanRedundantStorageRead {
             .stmts
             .iter()
             .filter_map(|stmt| match stmt.kind {
-                hir::StmtKind::Let(hir::LetStmt {
+                hir::StmtKind::Let(&hir::LetStmt {
                     init: Some(init), ..
                 }) => Some(init),
                 hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => Some(expr),
@@ -1024,7 +1005,9 @@ impl<'tcx> LateLintPass<'tcx> for RedundantEnvClone {
             expr.kind
             && path_segment.ident.name.as_str() == "clone"
         {
-            let is_env = if let Some(adt_def) = try_get_adt_def(cx, receiver) {
+            let is_env = if let Some(adt_def) =
+                ty_adt_def(cx.typeck_results().expr_ty(receiver).peel_refs())
+            {
                 match_soroban_def_path(cx, adt_def.did(), &["soroban_sdk", "Env"])
             } else {
                 false
@@ -1112,7 +1095,9 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryHostFunctionCall {
     /// change each iteration from being flagged.
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
         if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
-            let is_host_function = if let Some(adt_def) = try_get_adt_def(cx, receiver) {
+            let is_host_function = if let Some(adt_def) =
+                ty_adt_def(cx.typeck_results().expr_ty(receiver).peel_refs())
+            {
                 let did = adt_def.did();
                 matches_any_path(cx, did, SOROBAN_HOST_TYPES)
                     || (match_soroban_def_path(cx, did, &["soroban_sdk", "Env"])
@@ -1158,7 +1143,9 @@ impl<'tcx> LateLintPass<'tcx> for HostInLoop {
     /// help note suggesting the call be moved out where possible.
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
         if let hir::ExprKind::MethodCall(_path_segment, receiver, _args, _span) = expr.kind {
-            let is_host = if let Some(adt_def) = try_get_adt_def(cx, receiver) {
+            let is_host = if let Some(adt_def) =
+                ty_adt_def(cx.typeck_results().expr_ty(receiver).peel_refs())
+            {
                 match_soroban_def_path(cx, adt_def.did(), &["host", "Host"])
             } else {
                 false
@@ -1608,7 +1595,9 @@ impl<'tcx> LateLintPass<'tcx> for BytesAppendInLoop {
                 return;
             }
 
-            let is_container = if let Some(adt_def) = try_get_adt_def(cx, receiver) {
+            let is_container = if let Some(adt_def) =
+                ty_adt_def(cx.typeck_results().expr_ty(receiver).peel_refs())
+            {
                 matches_any_path(cx, adt_def.did(), SOROBAN_CONTAINER_TYPES)
             } else {
                 false
@@ -1675,7 +1664,6 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
         /// receiver-snippet and key-snippet for later cross-referencing.
         struct ReadVisitor<'a, 'tcx> {
             cx: &'a LateContext<'tcx>,
-            reads: std::collections::HashMap<String, std::collections::HashSet<String>>,
             reads: HashSet<(String, String)>,
         }
 
@@ -1684,7 +1672,9 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
             /// `has` call on a [`SOROBAN_STORAGE_TYPES`] receiver.
             fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
                 if let hir::ExprKind::MethodCall(path_segment, receiver, args, _span) = &expr.kind {
-                    let is_storage = if let Some(adt_def) = try_get_adt_def(self.cx, receiver) {
+                    let is_storage = if let Some(adt_def) =
+                        ty_adt_def(self.cx.typeck_results().expr_ty(receiver).peel_refs())
+                    {
                         matches_any_path(self.cx, adt_def.did(), SOROBAN_STORAGE_TYPES)
                     } else {
                         false
@@ -1698,10 +1688,6 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
                         let receiver_snippet =
                             snippet_opt(self.cx, receiver.span).unwrap_or_default();
                         let key_snippet = snippet_opt(self.cx, args[0].span).unwrap_or_default();
-                        self.reads
-                            .entry(receiver_snippet)
-                            .or_default()
-                            .insert(key_snippet);
                         self.reads.insert((receiver_snippet, key_snippet));
                     }
                 }
@@ -1721,7 +1707,9 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
             /// `set` call on a [`SOROBAN_STORAGE_TYPES`] receiver.
             fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
                 if let hir::ExprKind::MethodCall(path_segment, receiver, args, span) = &expr.kind {
-                    let is_storage = if let Some(adt_def) = try_get_adt_def(self.cx, receiver) {
+                    let is_storage = if let Some(adt_def) =
+                        ty_adt_def(self.cx.typeck_results().expr_ty(receiver).peel_refs())
+                    {
                         matches_any_path(self.cx, adt_def.did(), SOROBAN_STORAGE_TYPES)
                     } else {
                         false
@@ -1738,7 +1726,6 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
             }
         }
 
-        let reads = std::collections::HashMap::new();
         let reads = HashSet::new();
         let writes = Vec::new();
         let mut read_visitor = ReadVisitor { cx, reads };
@@ -1750,8 +1737,6 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
         for (w_receiver, w_key, w_span) in &write_visitor.writes {
             let has_read = read_visitor
                 .reads
-                .get(w_receiver)
-                .is_some_and(|keys| keys.contains(w_key));
                 .contains(&(w_receiver.clone(), w_key.clone()));
             if !has_read {
                 span_lint_and_help(
@@ -1821,7 +1806,7 @@ fn is_bytes_type<'tcx>(cx: &LateContext<'tcx>, ty: rustc_middle::ty::Ty<'tcx>) -
 /// Extracts the `AdtDef` from a `Ty`, without peeling references.
 fn ty_adt_def<'tcx>(ty: rustc_middle::ty::Ty<'tcx>) -> Option<rustc_middle::ty::AdtDef<'tcx>> {
     if let rustc_middle::ty::Adt(adt_def, _) = ty.kind() {
-        Some(adt_def)
+        Some(*adt_def)
     } else {
         None
     }
@@ -1854,7 +1839,9 @@ impl<'tcx> LateLintPass<'tcx> for MapInsertInLoop {
                 return;
             }
 
-            let is_map = if let Some(adt_def) = try_get_adt_def(cx, receiver) {
+            let is_map = if let Some(adt_def) =
+                ty_adt_def(cx.typeck_results().expr_ty(receiver).peel_refs())
+            {
                 match_soroban_def_path(cx, adt_def.did(), &["soroban_sdk", "Map"])
             } else {
                 false
@@ -2235,7 +2222,7 @@ impl<'tcx> LateLintPass<'tcx> for PersistentReadWithoutTtlExtension {
         _decl: &'tcx hir::FnDecl<'tcx>,
         body: &'tcx hir::Body<'tcx>,
         _span: rustc_span::Span,
-        _hir_id: rustc_hir::HirId,
+        _hir_id: rustc_hir::def_id::LocalDefId,
     ) {
         let mut visitor = PersistentReadVisitor {
             cx,

--- a/soroban_cost_lints/ui/formatted_panic_payload.rs
+++ b/soroban_cost_lints/ui/formatted_panic_payload.rs
@@ -1,0 +1,93 @@
+// UI test suite for the `formatted_panic_payload` lint rule.
+//
+// `format!`, formatted `panic!`, and `.expect(&format!(..))` are plain
+// core/std, not soroban_sdk-specific, so this fixture needs no SDK stub.
+
+// ===========================================================================
+//  Triggering cases — these MUST produce the formatted_panic_payload warning
+// ===========================================================================
+
+/// A bare `format!(...)` call always pulls in `core::fmt`.
+fn bad_format(a: u32, b: u32) -> String {
+    format!("balance {a} below {b}") //~ WARNING formatted panic payload pulls in string-formatting machinery
+}
+
+/// `format!(...)` with positional arguments (not just captured identifiers).
+fn bad_format_positional(a: u32, b: u32) -> String {
+    format!("balance {} below {}", a, b) //~ WARNING formatted panic payload pulls in string-formatting machinery
+}
+
+/// `panic!` with formatting arguments builds an `Arguments` value at the
+/// panic site.
+fn bad_panic_with_args(a: u32, b: u32) {
+    panic!("balance {} below {}", a, b); //~ WARNING formatted panic payload pulls in string-formatting machinery
+}
+
+/// `.expect(&format!(...))` builds the message eagerly through `format!`.
+fn bad_expect_format(value: Option<u32>, key: u32) -> u32 {
+    value.expect(&format!("missing {key}")) //~ WARNING formatted panic payload pulls in string-formatting machinery
+}
+
+// ===========================================================================
+//  Non-triggering cases — these MUST NOT produce a warning
+// ===========================================================================
+
+/// `panic!` with a plain literal and zero arguments never touches
+/// `core::fmt`.
+fn good_panic_plain_literal() {
+    panic!("balance too low");
+}
+
+/// `.expect("plain literal")` never touches `core::fmt`.
+fn good_expect_plain_literal(value: Option<u32>) -> u32 {
+    value.expect("missing value")
+}
+
+/// `.expect(msg)` where `msg` is just a `&str` local, not a `format!` call.
+fn good_expect_local_str(value: Option<u32>, msg: &str) -> u32 {
+    value.expect(msg)
+}
+
+/// Explicitly suppressed via the standard `#[allow(..)]` attribute.
+#[allow(formatted_panic_payload)]
+fn allowed_format(a: u32) -> String {
+    format!("value {a}")
+}
+
+// ===========================================================================
+//  Test code — none of the flagged patterns above should fire under
+//  `#[cfg(test)]`, whether on the function directly or on an enclosing
+//  `mod tests { .. }`.
+// ===========================================================================
+
+#[cfg(test)]
+fn cfg_test_fn_format(a: u32) -> String {
+    format!("value {a}")
+}
+
+#[cfg(test)]
+fn cfg_test_fn_panic(a: u32, b: u32) {
+    panic!("balance {} below {}", a, b);
+}
+
+#[cfg(test)]
+fn cfg_test_fn_expect(value: Option<u32>, key: u32) -> u32 {
+    value.expect(&format!("missing {key}"))
+}
+
+#[cfg(test)]
+mod tests {
+    fn in_test_module_format(a: u32) -> String {
+        format!("value {a}")
+    }
+
+    fn in_test_module_panic(a: u32, b: u32) {
+        panic!("balance {} below {}", a, b);
+    }
+
+    fn in_test_module_expect(value: Option<u32>, key: u32) -> u32 {
+        value.expect(&format!("missing {key}"))
+    }
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/formatted_panic_payload.stderr
+++ b/soroban_cost_lints/ui/formatted_panic_payload.stderr
@@ -1,0 +1,35 @@
+warning: formatted panic payload pulls in string-formatting machinery
+  --> $DIR/formatted_panic_payload.rs:12:5
+   |
+LL |     format!("balance {a} below {b}") //~ WARNING formatted panic payload pulls in string-formatting machinery
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: formatted messages pull core::fmt into the contract (binary size on every deploy) and run formatting instructions on the failure path; use panic_with_error!(env, Error::Variant) with a #[contracterror] enum instead, which compiles to a plain integer error code with neither cost
+   = note: `#[warn(formatted_panic_payload)]` on by default
+
+warning: formatted panic payload pulls in string-formatting machinery
+  --> $DIR/formatted_panic_payload.rs:17:5
+   |
+LL |     format!("balance {} below {}", a, b) //~ WARNING formatted panic payload pulls in string-formatting machinery
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: formatted messages pull core::fmt into the contract (binary size on every deploy) and run formatting instructions on the failure path; use panic_with_error!(env, Error::Variant) with a #[contracterror] enum instead, which compiles to a plain integer error code with neither cost
+
+warning: formatted panic payload pulls in string-formatting machinery
+  --> $DIR/formatted_panic_payload.rs:23:5
+   |
+LL |     panic!("balance {} below {}", a, b); //~ WARNING formatted panic payload pulls in string-formatting machinery
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: formatted messages pull core::fmt into the contract (binary size on every deploy) and run formatting instructions on the failure path; use panic_with_error!(env, Error::Variant) with a #[contracterror] enum instead, which compiles to a plain integer error code with neither cost
+
+warning: formatted panic payload pulls in string-formatting machinery
+  --> $DIR/formatted_panic_payload.rs:28:5
+   |
+LL |     value.expect(&format!("missing {key}")) //~ WARNING formatted panic payload pulls in string-formatting machinery
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: formatted messages pull core::fmt into the contract (binary size on every deploy) and run formatting instructions on the failure path; use panic_with_error!(env, Error::Variant) with a #[contracterror] enum instead, which compiles to a plain integer error code with neither cost
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
Closes #108

## Summary

Implements the `formatted_panic_payload` lint: `format!`, `panic!` with formatting arguments, and `.expect(&format!(..))` inflate compiled WASM size (core::fmt machinery, pulled in on every deploy) and spend CPU formatting a message on the failure path, where `panic_with_error!` + a `#[contracterror]` enum costs neither. The diagnostic points at that alternative.

## Call shapes covered (exactly three, as scoped by the issue)

1. Any `format!(...)` invocation â always flagged, since building a `String` via `core::fmt` is never free in `no_std`.
2. `panic!(...)` **only** when the macro call had at least one formatting argument. `panic!("plain literal")` (zero args) is not flagged â it never touches `core::fmt`.
3. `.expect(&format!(...))` â an `.expect()` call whose message argumentâs macro-expansion root is `format!`. A plain `.expect("literal")`, or `.expect(some_local_str)`, is not flagged. `.unwrap()` is argument-less so there is nothing to check on it directly, per the issueâs own note.

When `.expect(&format!(...))` fires, the nested `format!(...)` call is deliberately **not** independently reported a second time (both are visited as separate HIR nodes by the lint pass) â the pair collapses into one warning pinned at the more actionable `.expect(...)` call site. See `is_expect_format_message` in `soroban_cost_lints/src/lib.rs`.

## Detection approach

Per the issueâs explicit warning against pattern-matching desugared HIR (e.g. `Arguments::new_v1`), this uses `clippy_utils::macros`: `root_macro_call_first_node` + `is_panic` + the `format_macro` diagnostic item identify each macro by its expansion site, not by the shape it expands to.

The one wrinkle: telling `panic!("literal")` (0 args) apart from `panic!("{}", x)` (1+ args) needs the *original* argument count, which the HIR no longer has once `panic!` is desugared. `clippy_utils::macros::FormatArgsStorage` exists for exactly this (see `useless_format`/`format.rs` in the pinned clippy_utils revision for how clippy itself uses it), but it has to be populated by an early-pass AST visitor before the late pass runs. This PR adds a small `FormatArgsCollector` early lint pass (mirroring clippyâs own `clippy_lints::utils::format_args_collector::FormatArgsCollector`, trimmed of the proc-macro-span edge case clippy handles, which isnât relevant here) that records the AST `FormatArgs` nodes into a `FormatArgsStorage` shared with the late pass via `register_lints`.

## Test vs. contract code: the `#[cfg(test)]` signal

Per the issue, both `#[cfg(test)]` and `#[contractimpl]` were candidate signals for distinguishing contract code from test code. This PR uses **`#[cfg(test)]` only**, via `clippy_utils::is_in_test` (covers both a `#[test]` fn and any ancestor â function or module â marked `#[cfg(test)]`).

A `#[contractimpl]`-reachability analysis (proving an expression is only reachable from a contractâs public entrypoints) was considered and rejected for a first version: it would need whole-crate call-graph reasoning (indirect calls, trait dispatch, re-exports) that is fragile and invasive relative to this crateâs other lints, which stay single-function or bounded-depth. This means the lint fires on qualifying `format!`/`panic!`/`.expect()` usage anywhere in non-test code compiled into the checked crate, not only code reachable from a `#[contractimpl]` entrypoint â acceptable in practice since `cargo-cost-lint` is run against Soroban contract crates specifically. Full rationale is in `docs/lints/formatted_panic_payload.md`.

## Files

**New:**
- `soroban_cost_lints/ui/formatted_panic_payload.rs` / `.stderr` â standalone UI fixture (per `DEVELOPING_LINTS.md` Ã§3 convention, not touching `ui/main.rs`)
- `docs/lints/formatted_panic_payload.md`

**Modified:**
- `soroban_cost_lints/src/lib.rs` â lint + `FormatArgsCollector` early pass + registration (`LINT_METADATA` as `LintCategory::Compute`, `register_lints`)
- `docs/lints/README.md` (CPU/Compute table row), `docs/SUMMARY.md` (Lints entry), `README.md` (Features bullet + `budget.toml` example), `CHANGELOG.md` (Unreleased/Added)

## UI fixture coverage

- Flagged: `format!(...)` (captured-identifier and positional-arg forms), `panic!("...{}..." , a, b)`, `.expect(&format!(...))`
- Not flagged: `panic!("plain literal")` (0 args), `.expect("plain literal")`, `.expect(local_str)`
- `#[allow(formatted_panic_payload)]` suppression
- The same flagged patterns placed inside a `#[cfg(test)]` fn **and** inside an enclosing `mod tests { .. }` â confirmed not to fire in either case

The generated `.stderr` was reviewed by hand: exactly 4 warnings, each span covers the full macro/method call (not an inner sub-expression), and the `.expect(&format!(..))` case produces one warning at the `.expect(...)` call, not two.

## How to test locally

```bash
cd soroban_cost_lints
cargo test --lib ui   # note: NOT `cargo test --test ui` â there is no such target;
                       # the UI harness is the #[test] fn `ui()` inside src/lib.rs
```

From the repo root:
```bash
cargo fmt --all -- --check
cargo clippy -p soroban_cost_lints --all-targets -- -D warnings
cargo test -p soroban_cost_lints
```

## Known pre-existing failures (not introduced by this PR, not fixed by it)

- `soroban_cost_lints/ui/main.rs` fails to even parse (unclosed delimiter) against its `.stderr` â pre-existing on `main`, called out explicitly in the task as out of scope.
- `soroban_cost_lints/ui/redundant_val_conversion.rs` references a `redundant_val_conversion` lint that isnât currently registered in `lib.rs` at all (`unknown lint` warnings) â pre-existing drift, unrelated to this change.
- `soroban_cost_lints/ui/soroban_storage_in_loop.rs`âs `.stderr` has drifted against the (pre-existing) `storage_write_without_read` lintâs output â pre-existing drift, unrelated.
- `cargo-cost-lint/src/main.rs` currently fails to compile on `main` itself (undefined `BudgetConfig`/`HashMap`, an invalid format string in a test) â confirmed via `git diff main -- cargo-cost-lint/src/main.rs` showing zero difference. This means `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` cannot succeed at the workspace level right now, independent of this PR. `soroban_cost_lints` on its own is clean under both `cargo clippy -p soroban_cost_lints --all-targets -- -D warnings` and `cargo test -p soroban_cost_lints` (aside from the three pre-existing UI-fixture mismatches above).
