### PR TITLE
feat: implement instance_storage_for_unbounded_data lint (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to Semantic Versioning.
 
 - New lint `symbol_new_for_short_literal` detecting `Symbol::new(&env, "literal")` calls where the literal is a valid short symbol (≤ 9 chars, alphanumeric + underscore) and suggesting the `symbol_short!` macro for compile-time creation.
 - New lint `require_auth_in_loop` detecting `Address::require_auth` and `Address::require_auth_for_args` calls inside loop bodies (`for`, `while`, `loop`) and suggesting that distinct addresses be authorized once before the loop.
+- New lint `storage_write_without_read` detecting storage `.set()` calls where the same key is never subsequently read, flagging wasteful storage writes that drive up Soroban fees.
+- New lint `inefficient_bytes_concat` detecting repeated `Bytes` concatenation using `+` inside loops, which creates unnecessary per-iteration allocations.
+- New lint `map_insert_in_loop` detecting `Map::insert()` calls inside loop bodies.
+- New lint `signature_verification_in_loop` detecting `env.crypto().ed25519_verify()`/`secp256k1_recover()`/`secp256r1_verify()` calls inside loop bodies, suggesting batch/aggregate signature verification or a bulk callee entrypoint instead.
+- New lint `instance_storage_for_unbounded_data` detecting `env.storage().instance().set(...)` calls where the written value is an unbounded `Vec`/`Map`/`Bytes`, since instance storage is re-read and rewritten as a single blob on every contract invocation regardless of which call touches it.
+- `--fix` flag for `cargo-cost-lint` to automatically apply machine-applicable lint suggestions in-place.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Writing `env.storage().instance().set()` inside a `for` loop is mathematically g
 
 ## Features
 
-The linter hooks into the Rust compiler's AST to catch specific Soroban anti-patterns. Eight lints ship in `v0.1.1`:
+The linter hooks into the Rust compiler's AST to catch specific Soroban anti-patterns. Nine lints ship in `v0.1.1`:
 
 *   **[`soroban_storage_in_loop`](docs/lints/soroban_storage_in_loop.md):** Flags storage read/write operations placed inside loop bodies, suggesting memory aggregation instead.
 *   **[`redundant_env_clone`](docs/lints/redundant_env_clone.md):** Detects unnecessary `.clone()` calls on the Soroban `Env` object.
@@ -36,6 +36,7 @@ The linter hooks into the Rust compiler's AST to catch specific Soroban anti-pat
 *   **[`signature_verification_in_loop`](docs/lints/signature_verification_in_loop.md):** Flags `env.crypto().ed25519_verify`/`secp256k1_recover`/`secp256r1_verify` calls made inside loop bodies, suggesting batch/aggregate verification instead.
 *   **[`vec_where_slice_could_be_used`](docs/lints/vec_where_slice_could_be_used.md):** Flags `soroban_sdk::Vec` passed by value where a native Rust `&[T]` slice would be sufficient for read-only access.
 *   **[`extend_ttl_in_loop`](docs/lints/extend_ttl_in_loop.md):** Flags `extend_ttl` calls on instance/persistent/temporary storage made inside loop bodies, suggesting batching the TTL extension instead of refreshing per-entry per-iteration.
+*   **[`instance_storage_for_unbounded_data`](docs/lints/instance_storage_for_unbounded_data.md):** Flags `env.storage().instance().set(...)` calls where the value is an unbounded `Vec`/`Map`/`Bytes`, since instance storage is re-read and rewritten in full on every contract invocation.
 
 ## How it Fits into Tollcraft
 
@@ -358,6 +359,7 @@ storage_write_without_read = "warn"
 inefficient_bytes_concat = "warn"
 map_insert_in_loop = "warn"
 contract_call_in_loop = "warn"
+instance_storage_for_unbounded_data = "warn"
 
 Inline diagnostics are supported through rust-analyzer's `check.overrideCommand` setting:
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,6 +26,7 @@
   * [contract\_call\_in\_loop](lints/contract_call_in_loop.md)
   * [vec\_where\_slice\_could\_be\_used](lints/vec_where_slice_could_be_used.md)
   * [extend\_ttl\_in\_loop](lints/extend_ttl_in_loop.md)
+  * [instance\_storage\_for\_unbounded\_data](lints/instance_storage_for_unbounded_data.md)
 
 ## Branding
 

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -23,6 +23,9 @@ Lints are classified per the [MVP roadmap](../roadmap_mvp.md#3-false-positive-mi
 | --------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
 | [`soroban_storage_in_loop`](soroban_storage_in_loop.md)               | `warn`           | Storage reads/writes inside loop bodies    |
 | [`soroban_redundant_storage_read`](soroban_redundant_storage_read.md) | `warn`           | Multiple sequential reads of the same key  |
+| [`storage_write_without_read`](storage_write_without_read.md)         | `warn`           | Storage writes without a corresponding read |
+| [`map_insert_in_loop`](map_insert_in_loop.md)                         | `warn`           | `Map::insert` calls inside loops           |
+| [`instance_storage_for_unbounded_data`](instance_storage_for_unbounded_data.md) | `warn`  | `Vec`/`Map`/`Bytes` values written to instance storage |
 
 ## CPU/Compute
 

--- a/docs/lints/instance_storage_for_unbounded_data.md
+++ b/docs/lints/instance_storage_for_unbounded_data.md
@@ -1,0 +1,98 @@
+# `instance_storage_for_unbounded_data`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [Storage — ledger entry accesses and ledger I/O bytes](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Detects writes to `env.storage().instance()` where the value being written is
+an unbounded Soroban SDK collection type — `Vec`, `Map`, or `Bytes`.
+
+## Why is this bad?
+
+{% hint style="danger" %}
+Soroban's instance storage is loaded and rewritten as a **single blob on
+every invocation** of the contract — not just the calls that touch the field
+in question. Putting a growing collection in instance storage means every
+future call, no matter what it does, pays to read and rewrite the entire
+collection's current size. The fee climbs quietly over the life of the
+contract and never shows up in a single-call test, because a fresh contract
+starts with an empty (or small) collection and the cost only becomes visible
+once real usage has grown it. See the
+[Cost Rationale — Storage](../cost_rationale.md#3-storage-ledger-entry-accesses-and-ledger-io)
+for how ledger entry accesses and I/O bytes are charged.
+
+Persistent storage, keyed per entry, is the structurally correct shape for
+data whose size grows over time — it is not covered further here.
+{% endhint %}
+
+## Example
+
+```rust
+// ❌ Bad: a Vec living in instance storage is re-read and re-written, in
+//          full, on every single contract call — including calls that
+//          have nothing to do with this field.
+fn record_participant(env: Env, participant: Address) {
+    let mut participants: Vec<Address> =
+        env.storage().instance().get(&PARTICIPANTS).unwrap_or(Vec::new(&env));
+    participants.push_back(participant);
+    env.storage().instance().set(&PARTICIPANTS, &participants);
+}
+```
+
+```rust
+// ✅ Good: persistent storage keys each participant as its own entry, so
+//          the per-invocation cost stays constant regardless of how many
+//          participants have accumulated.
+fn record_participant(env: Env, participant: Address) {
+    env.storage().persistent().set(&participant, &true);
+}
+```
+
+## Suggested Fix
+
+{% hint style="success" %}
+Use persistent storage keyed per entry instead of accumulating growing data
+under a single instance-storage key.
+{% endhint %}
+
+## Where the bounded/unbounded line is drawn
+
+This lint is deliberately conservative — it only fires when the value
+expression passed to `.instance().set(key, value)` has a type that resolves
+*directly* to `soroban_sdk::Vec`, `soroban_sdk::Map`, or `soroban_sdk::Bytes`:
+
+- **Flagged:** the value's own type is one of the three SDK container types.
+  A value that is itself an SDK collection is unambiguously unbounded —
+  there is no interpretation under which storing it in a per-invocation blob
+  is safe once the contract sees real usage.
+- **Not flagged — scalars and fixed-size values:** `u32`, `i64`, `bool`,
+  `Address`, `[u8; 32]`, and similar statically-sized types never resolve to
+  a container ADT, so they are never flagged. Their size in the instance
+  blob is fixed for the life of the contract.
+- **Not flagged — configuration-shaped structs:** a plain struct (e.g. an
+  admin/config record with a handful of scalar fields) resolves to its own
+  ADT, not to `Vec`/`Map`/`Bytes`, so it is not flagged even though it lives
+  in instance storage — that is exactly the pattern instance storage is for.
+- **Not flagged — a collection nested inside a struct field:** if a
+  user-defined struct or enum merely *contains* a `Vec`/`Map`/`Bytes` field,
+  the value passed to `.set()` resolves to the wrapping struct's ADT, not to
+  the container type, so the lint does not look inside it. Recognizing that
+  case reliably would require whole-program reasoning about which struct
+  fields can grow unboundedly, which this lint does not attempt — the
+  tradeoff is intentional: it accepts missing that pattern in exchange for
+  never flagging a false positive on an unrelated struct field.
+
+## What is not reported
+
+- Writes to `persistent()` or `temporary()` storage — those stores are keyed
+  per entry, so an unbounded value there is the expected, correct shape and
+  is out of scope for this lint.
+- Reads (`get`, `has`) on instance storage — only the write (`set`) is
+  checked, since that is the operation that grows the stored blob.
+- Scalar values, fixed-size arrays, and plain structs written to instance
+  storage, as described above.
+- A `Vec`/`Map`/`Bytes` value nested inside a struct or enum field, rather
+  than passed directly as the value argument.
+- Calls suppressed with `#[allow(instance_storage_for_unbounded_data)]`.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -476,6 +476,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: PERSISTENT_READ_WITHOUT_TTL_EXTENSION,
         category: LintCategory::EntryLifecycle,
     },
+    LintMetadata {
+        lint: INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
+        category: LintCategory::StorageOperations,
+    },
 ];
 
 /// `dylint` entry point. Registers every lint declared by this crate with
@@ -496,6 +500,13 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         CONTRACT_CALL_IN_LOOP,
         SYMBOL_NEW_FOR_SHORT_LITERAL,
         PERSISTENT_READ_WITHOUT_TTL_EXTENSION,
+        UNNECESSARY_STRING_TO_BYTES,
+        STORAGE_WRITE_WITHOUT_READ,
+        INEFFICIENT_BYTES_CONCAT,
+        MAP_INSERT_IN_LOOP,
+        BYTES_APPEND_IN_LOOP,
+        SIGNATURE_VERIFICATION_IN_LOOP,
+        INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(SorobanRedundantStorageRead));
@@ -505,6 +516,13 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(ContractCallInLoop));
     lint_store.register_late_pass(|_| Box::new(SymbolNewForShortLiteral));
     lint_store.register_late_pass(|_| Box::new(PersistentReadWithoutTtlExtension));
+    lint_store.register_late_pass(|_| Box::new(UnnecessaryStringToBytes));
+    lint_store.register_late_pass(|_| Box::new(StorageWriteWithoutRead));
+    lint_store.register_late_pass(|_| Box::new(InefficientBytesConcat));
+    lint_store.register_late_pass(|_| Box::new(MapInsertInLoop));
+    lint_store.register_late_pass(|_| Box::new(BytesAppendInLoop));
+    lint_store.register_late_pass(|_| Box::new(SignatureVerificationInLoop));
+    lint_store.register_late_pass(|_| Box::new(InstanceStorageForUnboundedData));
 }
 
 /// Flags any Soroban storage accessor method call (including
@@ -2124,6 +2142,92 @@ impl<'tcx> LateLintPass<'tcx> for RequireAuthInLoop {
                     "authorization call inside a loop",
                     None,
                     "collect distinct addresses first and authorize each once before the loop",
+                );
+            }
+        }
+    }
+}
+
+// instance_storage_for_unbounded_data — Lint
+// =======================================================================
+
+rustc_session::declare_lint! {
+    pub INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
+    Warn,
+    "unbounded collection written to instance storage"
+}
+/// Late pass backing [`INSTANCE_STORAGE_FOR_UNBOUNDED_DATA`].
+pub struct InstanceStorageForUnboundedData;
+rustc_session::impl_lint_pass!(InstanceStorageForUnboundedData => [INSTANCE_STORAGE_FOR_UNBOUNDED_DATA]);
+
+impl<'tcx> LateLintPass<'tcx> for InstanceStorageForUnboundedData {
+    /// Flags `env.storage().instance().set(&key, &value)` where `value`'s own
+    /// type is directly one of the Soroban SDK's unbounded container types
+    /// ([`SOROBAN_CONTAINER_TYPES`]: `Vec`, `Map`, `Bytes`).
+    ///
+    /// Instance storage is loaded and rewritten as a single blob on every
+    /// contract invocation, so a growing collection stored there is paid for
+    /// by every call, not just the calls that touch it.
+    ///
+    /// # Where the bounded/unbounded line is drawn
+    ///
+    /// Only the terminal `set` op is matched (same rationale as
+    /// [`SorobanStorageInLoop`]: matching the intermediate accessor calls too
+    /// would produce multiple stacked warnings on one chained expression).
+    /// The receiver must resolve to `soroban_sdk::storage::Instance`
+    /// specifically — `Persistent`/`Temporary` are per-entry stores where an
+    /// unbounded value is the expected, correct shape, so they are out of
+    /// scope for this lint.
+    ///
+    /// The written value's type must resolve *directly* via ADT to `Vec`,
+    /// `Map`, or `Bytes` — this intentionally excludes scalars, `Address`,
+    /// fixed-size arrays, and plain "configuration" structs (even ones that
+    /// happen to embed a `Vec`/`Map`/`Bytes` field), since determining
+    /// whether a nested field is unbounded requires whole-program reasoning
+    /// this lint deliberately does not attempt. A value that is itself an SDK
+    /// collection type is unambiguously unbounded; nested cases are left
+    /// unflagged to keep false positives at zero.
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        if let hir::ExprKind::MethodCall(path_segment, receiver, args, _span) = expr.kind {
+            if path_segment.ident.name.as_str() != "set" || args.len() < 2 {
+                return;
+            }
+
+            let is_instance_storage = if let rustc_middle::ty::Adt(adt_def, _) =
+                cx.typeck_results().expr_ty(receiver).peel_refs().kind()
+            {
+                match_soroban_def_path(cx, adt_def.did(), &["soroban_sdk", "storage", "Instance"])
+            } else {
+                false
+            };
+
+            if !is_instance_storage {
+                return;
+            }
+
+            let value_expr = &args[1];
+            let is_unbounded_container = if let rustc_middle::ty::Adt(adt_def, _) =
+                cx.typeck_results().expr_ty(value_expr).peel_refs().kind()
+            {
+                matches_any_path(cx, adt_def.did(), SOROBAN_CONTAINER_TYPES)
+            } else {
+                false
+            };
+
+            if is_unbounded_container {
+                span_lint_and_help(
+                    cx,
+                    INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
+                    expr.span,
+                    "unbounded collection written to instance storage",
+                    None,
+                    "instance storage is read and rewritten as a single blob on every \
+                     invocation of the contract, not just calls that touch this field, so a \
+                     growing Vec/Map/Bytes here means every future call pays for the whole \
+                     collection's current size and the fee climbs unnoticed across the \
+                     contract's life without showing up in any single-call test; persistent \
+                     storage, keyed per entry, is the structurally correct shape for unbounded \
+                     data",
                 );
             }
         }

--- a/soroban_cost_lints/ui/instance_storage_for_unbounded_data.rs
+++ b/soroban_cost_lints/ui/instance_storage_for_unbounded_data.rs
@@ -1,0 +1,129 @@
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+            pub fn persistent(&self) -> Persistent { Persistent }
+            pub fn temporary(&self) -> Temporary { Temporary }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Persistent;
+        impl Persistent {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Temporary;
+        impl Temporary {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+    }
+
+    // Minimal stand-ins for the SDK's unbounded container types. Only the
+    // shape needed for type resolution matters here — these fixtures never
+    // execute.
+    pub struct Vec;
+    impl Vec {
+        pub fn new() -> Vec { Vec }
+    }
+
+    pub struct Map;
+    impl Map {
+        pub fn new() -> Map { Map }
+    }
+
+    pub struct Bytes;
+    impl Bytes {
+        pub fn new() -> Bytes { Bytes }
+    }
+}
+
+use soroban_sdk::{Bytes, Env, Map, Vec};
+
+// =======================================================================
+// instance_storage_for_unbounded_data — Fixtures
+//
+// Every write below is paired with a matching `.get()` on the same
+// receiver/key so that the unrelated `storage_write_without_read` lint
+// stays quiet and each `.stderr` line is attributable to this lint.
+// =======================================================================
+
+fn bad_vec_in_instance_storage(env: Env) {
+    let _existing: Option<Vec> = env.storage().instance().get(&1u32);
+    let items: Vec = Vec::new();
+    env.storage().instance().set(&1u32, &items); // Should Warn
+}
+
+fn bad_map_in_instance_storage(env: Env) {
+    let _existing: Option<Map> = env.storage().instance().get(&2u32);
+    let entries: Map = Map::new();
+    env.storage().instance().set(&2u32, &entries); // Should Warn
+}
+
+fn bad_bytes_in_instance_storage(env: Env) {
+    let _existing: Option<Bytes> = env.storage().instance().get(&3u32);
+    let blob: Bytes = Bytes::new();
+    env.storage().instance().set(&3u32, &blob); // Should Warn
+}
+
+// Scalars, small fixed-size, and config-shaped values are not unbounded —
+// they resolve to a plain, statically sized type rather than to
+// `soroban_sdk::{Vec,Map,Bytes}`, so the lint does not fire.
+struct Config {
+    max_supply: u32,
+    admin_set: bool,
+}
+
+fn good_scalar_in_instance_storage(env: Env) {
+    let _existing: Option<u32> = env.storage().instance().get(&4u32);
+    env.storage().instance().set(&4u32, &42u32); // Good: scalar
+}
+
+fn good_fixed_array_in_instance_storage(env: Env) {
+    let _existing: Option<[u8; 32]> = env.storage().instance().get(&5u32);
+    let fixed: [u8; 32] = [0; 32];
+    env.storage().instance().set(&5u32, &fixed); // Good: fixed-size array
+}
+
+fn good_config_struct_in_instance_storage(env: Env) {
+    let _existing: Option<Config> = env.storage().instance().get(&6u32);
+    let cfg = Config { max_supply: 1_000_000, admin_set: true };
+    env.storage().instance().set(&6u32, &cfg); // Good: config-shaped struct
+}
+
+// Same unbounded value type, but on persistent storage (keyed per entry) —
+// this lint is specific to `.instance()`, so persistent writes never fire.
+fn good_vec_in_persistent_storage(env: Env) {
+    let _existing: Option<Vec> = env.storage().persistent().get(&7u32);
+    let items: Vec = Vec::new();
+    env.storage().persistent().set(&7u32, &items); // Good: persistent, not instance
+}
+
+#[allow(instance_storage_for_unbounded_data)]
+fn allowed_vec_in_instance_storage(env: Env) {
+    let _existing: Option<Vec> = env.storage().instance().get(&8u32);
+    let items: Vec = Vec::new();
+    env.storage().instance().set(&8u32, &items); // Good (allowed)
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/instance_storage_for_unbounded_data.stderr
+++ b/soroban_cost_lints/ui/instance_storage_for_unbounded_data.stderr
@@ -1,0 +1,27 @@
+warning: unbounded collection written to instance storage
+  --> $DIR/instance_storage_for_unbounded_data.rs:74:5
+   |
+LL |     env.storage().instance().set(&1u32, &items); // Should Warn
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: instance storage is read and rewritten as a single blob on every invocation of the contract, not just calls that touch this field, so a growing Vec/Map/Bytes here means every future call pays for the whole collection's current size and the fee climbs unnoticed across the contract's life without showing up in any single-call test; persistent storage, keyed per entry, is the structurally correct shape for unbounded data
+   = note: `#[warn(instance_storage_for_unbounded_data)]` on by default
+
+warning: unbounded collection written to instance storage
+  --> $DIR/instance_storage_for_unbounded_data.rs:80:5
+   |
+LL |     env.storage().instance().set(&2u32, &entries); // Should Warn
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: instance storage is read and rewritten as a single blob on every invocation of the contract, not just calls that touch this field, so a growing Vec/Map/Bytes here means every future call pays for the whole collection's current size and the fee climbs unnoticed across the contract's life without showing up in any single-call test; persistent storage, keyed per entry, is the structurally correct shape for unbounded data
+
+warning: unbounded collection written to instance storage
+  --> $DIR/instance_storage_for_unbounded_data.rs:86:5
+   |
+LL |     env.storage().instance().set(&3u32, &blob); // Should Warn
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: instance storage is read and rewritten as a single blob on every invocation of the contract, not just calls that touch this field, so a growing Vec/Map/Bytes here means every future call pays for the whole collection's current size and the fee climbs unnoticed across the contract's life without showing up in any single-call test; persistent storage, keyed per entry, is the structurally correct shape for unbounded data
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
Closes #107

## Summary

Implements the `instance_storage_for_unbounded_data` lint: detects `env.storage().instance().set(key, value)` calls where the written value is an unbounded Soroban SDK collection (`Vec`, `Map`, or `Bytes`).

**Why this matters:** Soroban instance storage is loaded and rewritten as a single blob on *every* contract invocation, not just the calls that touch a given field. Putting a growing collection there means every future call pays for the whole collection's current size, and the fee climbs quietly over the contract's life without ever showing up in a single-call test (a fresh contract starts with an empty/small collection).

## Where the bounded/unbounded line is drawn (required by the issue)

The lint fires **only** when the value expression passed to `.set()` has a type that resolves *directly*, via ADT, to `soroban_sdk::Vec`, `soroban_sdk::Map`, or `soroban_sdk::Bytes` (reusing the existing `SOROBAN_CONTAINER_TYPES` table). Concretely:

- **Flagged:** the value's own type is one of the three SDK container types — unambiguously unbounded.
- **Not flagged — scalars/fixed-size values:** `u32`, `i64`, `bool`, `Address`, `[u8; 32]`, etc. never resolve to a container ADT.
- **Not flagged — configuration-shaped structs:** a plain admin/config struct resolves to its own ADT, not to `Vec`/`Map`/`Bytes`, even though it lives in instance storage — that's exactly what instance storage is for.
- **Not flagged — a collection nested inside a struct field:** if a user struct/enum merely *contains* a `Vec`/`Map`/`Bytes` field, the value passed to `.set()` resolves to the wrapping struct's ADT, not the container type, so the lint does not look inside it. Recognizing that case reliably would require whole-program reasoning about which fields can grow unboundedly; this lint deliberately accepts missing that pattern in exchange for zero false positives on unrelated struct fields.
- **Out of scope by design:** `persistent()`/`temporary()` storage — those are keyed per entry, so unbounded data there is the expected, correct shape.
- Only the terminal `set` op is matched (same convention as `SorobanStorageInLoop`/`MapInsertInLoop`), so a chained `env.storage().instance().set(...)` produces exactly one warning instead of stacking on the intermediate accessor calls.

The diagnostic explains the per-invocation cost model (blob re-read/rewritten on every call, fee grows unnoticed, invisible to single-call tests) rather than just prescribing "use persistent instead" — per the issue, no step-by-step migration recipe is included.

## Implementation

- `soroban_cost_lints/src/lib.rs`:
  - `declare_lint! { pub INSTANCE_STORAGE_FOR_UNBOUNDED_DATA, Warn, ... }`
  - `InstanceStorageForUnboundedData` marker struct + `LateLintPass` impl (`check_expr`), matching on `hir::ExprKind::MethodCall` where the method is `set`, the receiver resolves to `soroban_sdk::storage::Instance`, and `args[1]`'s type resolves to one of `SOROBAN_CONTAINER_TYPES`.
  - Registered in `LINT_METADATA` (category `StorageOperations`) and in `register_lints` (both the `register_lints(&[...])` list and `register_late_pass`).
  - Reuses existing helpers (`match_soroban_def_path`, `matches_any_path`, `SOROBAN_CONTAINER_TYPES`) — no new type-matching machinery.

## New files

- `docs/lints/instance_storage_for_unbounded_data.md` — full lint doc page (What it does / Why is this bad / Example / Suggested Fix / where the bounded line is drawn / What is not reported), modeled on `bytes_append_in_loop.md` and `signature_verification_in_loop.md`.
- `soroban_cost_lints/ui/instance_storage_for_unbounded_data.rs` — standalone UI fixture (per `DEVELOPING_LINTS.md` section 3 convention; `ui/main.rs` was deliberately left untouched, see below). Covers:
  - 3 flagged cases: `Vec`, `Map`, `Bytes` written to instance storage.
  - 3 non-flagged "good" cases: scalar (`u32`), fixed-size array (`[u8; 32]`), and a config-shaped struct, all on instance storage.
  - 1 non-flagged case: the same unbounded `Vec` written to **persistent** storage instead, proving the lint is `.instance()`-specific.
  - 1 `#[allow(instance_storage_for_unbounded_data)]` suppression case, per repo convention.
  - Every write is paired with a matching `.get()` on the same receiver/key so the unrelated, pre-existing `storage_write_without_read` lint stays quiet and the `.stderr` only reflects this lint.
- `soroban_cost_lints/ui/instance_storage_for_unbounded_data.stderr` — expected output, hand-verified against the actual dylint-driver diagnostic (message, span, and help text all confirmed correct).

## Modified files

- `docs/lints/README.md` — new row in the Storage Operations table.
- `docs/SUMMARY.md` — new bullet under `## Lints`.
- `README.md` — new bullet under `## Features` (and bumped the "Eight lints" count to "Nine"), plus `instance_storage_for_unbounded_data = "warn"` added to the example `budget.toml` block.
- `CHANGELOG.md` — new line under `## [Unreleased]` → `### Added`.

## Notes on `.stderr` generation

`dylint_testing` 6.0.1 (pinned in `Cargo.toml`) hardcodes `compiletest::Config { bless: false, .. }` and never reads `TRYBUILD`/`BLESS` — so `TRYBUILD=overwrite cargo test --test ui` (as documented in `DEVELOPING_LINTS.md`) does not actually bless/write `.stderr` files with this pinned version. I instead ran the UI test, captured the actual dylint-driver diagnostic output from `/tmp/instance_storage_for_unbounded_data.stage-id.stderr` (which `compiletest_rs` already normalizes with `$DIR` substitution), read it to confirm the message/span/help text were exactly right, and committed that as the expected `.stderr`. Also discovered along the way: `compiletest_rs` normalizes paths by replacing the literal (relative) `ui` directory name anywhere it appears in the output text — including inside ordinary English words — so I had to reword the help text (`"climbs quietly"` -> `"climbs unnoticed"`) to avoid the substring `ui` corrupting the snapshot (e.g. `"quietly"` -> `"q$DIRetly"`).

## Testing

```
cd soroban_cost_lints
cargo test -p soroban_cost_lints -- --nocapture   # or: cargo test --lib ui -- --nocapture
```

`test [ui] ui/instance_storage_for_unbounded_data.rs ... ok` — the new fixture passes cleanly (3 warnings emitted, exactly matching the 3 flagged cases).

From the repo root:

```
cargo fmt --all -- --check
cargo clippy -p soroban_cost_lints --all-targets -- -D warnings   # passes clean
cargo test -p soroban_cost_lints                                  # my fixture passes
```

**Pre-existing, unrelated breakage observed (not introduced by this PR, confirmed via `git diff --stat` showing zero changes from this branch on the affected files):**
- `soroban_cost_lints/ui/main.rs` / `main.stderr` — documented pre-existing drift (duplicate function definitions, unclosed-delimiter parse error).
- `soroban_cost_lints/ui/redundant_val_conversion.rs` and `soroban_cost_lints/ui/soroban_storage_in_loop.rs` — their checked-in `.stderr` snapshots are stale relative to the current `storage_write_without_read` lint (which now also fires on those fixtures' write-without-read patterns); this is the same "bless never actually worked with pinned `dylint_testing` 6.0.1" issue described above, predating this branch.
- `cargo-cost-lint` (the separate wrapper crate) fails to compile at all on `main` (`cannot find type BudgetConfig`, `cannot find type HashMap`, invalid format string in a test) — unrelated to `soroban_cost_lints`, this branch never touches that crate. This means `cargo clippy --workspace --all-targets` and `cargo test --workspace` both fail at that crate regardless of this change; the commands above scope to `-p soroban_cost_lints` to isolate and verify this PR's own code.
