### PR TITLE
feat: implement extend_ttl_in_loop lint (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning.
 - New lint `inefficient_bytes_concat` detecting repeated `Bytes` concatenation using `+` inside loops, which creates unnecessary per-iteration allocations.
 - New lint `map_insert_in_loop` detecting `Map::insert()` calls inside loop bodies.
 - New lint `signature_verification_in_loop` detecting `env.crypto().ed25519_verify()`/`secp256k1_recover()`/`secp256r1_verify()` calls inside loop bodies, suggesting batch/aggregate signature verification or a bulk callee entrypoint instead.
+- New lint `extend_ttl_in_loop` detecting `extend_ttl` calls on instance/persistent/temporary storage inside loop bodies, suggesting batching the TTL extension (or extending once with a generously-sized threshold) instead of refreshing per-entry per-iteration.
 - `--fix` flag for `cargo-cost-lint` to automatically apply machine-applicable lint suggestions in-place.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The linter hooks into the Rust compiler's AST to catch specific Soroban anti-pat
 *   **[`symbol_new_for_short_literal`](docs/lints/symbol_new_for_short_literal.md):** Flags `Symbol::new` calls with short literal arguments that could use `symbol_short!()`.
 *   **[`signature_verification_in_loop`](docs/lints/signature_verification_in_loop.md):** Flags `env.crypto().ed25519_verify`/`secp256k1_recover`/`secp256r1_verify` calls made inside loop bodies, suggesting batch/aggregate verification instead.
 *   **[`vec_where_slice_could_be_used`](docs/lints/vec_where_slice_could_be_used.md):** Flags `soroban_sdk::Vec` passed by value where a native Rust `&[T]` slice would be sufficient for read-only access.
+*   **[`extend_ttl_in_loop`](docs/lints/extend_ttl_in_loop.md):** Flags `extend_ttl` calls on instance/persistent/temporary storage made inside loop bodies, suggesting batching the TTL extension instead of refreshing per-entry per-iteration.
 
 ## How it Fits into Tollcraft
 
@@ -308,6 +309,7 @@ unnecessary_host_function_call = "warn"
 storage_write_without_read = "warn"
 inefficient_bytes_concat = "warn"
 map_insert_in_loop = "warn"
+extend_ttl_in_loop = "warn"
 
 ```
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,6 +22,7 @@
   * [symbol\_new\_for\_short\_literal](lints/symbol_new_for_short_literal.md)
   * [bytes\_append\_in\_loop](lints/bytes_append_in_loop.md)
   * [vec\_where\_slice\_could\_be\_used](lints/vec_where_slice_could_be_used.md)
+  * [extend\_ttl\_in\_loop](lints/extend_ttl_in_loop.md)
 
 ## Branding
 

--- a/docs/cost_rationale.md
+++ b/docs/cost_rationale.md
@@ -118,6 +118,7 @@ Each lint in this repository targets a specific resource dimension:
 | [`signature_verification_in_loop`](lints/signature_verification_in_loop.md) | **CPU** (elliptic-curve cryptographic host functions) | Signature verification is one of the most expensive host functions available; verifying one at a time in a loop is a sign that a batch/aggregate scheme should be used instead. |
 | [`redundant_env_clone`](lints/redundant_env_clone.md) | **CPU** (memory + dispatch overhead) | Cloning `Env` triggers `MemAlloc`/`MemCpy` and unnecessary object visits; the clone is never needed. |
 | [`excessive_vec_capacity`](lints/excessive_vec_capacity.md) | **Memory** (guest linear memory, hard-capped) | A large hard-coded capacity is charged against the guest's memory cap the moment it's allocated, whether or not it's ever filled. |
+| [`extend_ttl_in_loop`](lints/extend_ttl_in_loop.md) | **Storage** (ledger space rent) | `extend_ttl` is a metered host call that also pays rent; calling it once per iteration multiplies both costs by the loop count instead of batching the extension. |
 
 ---
 

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -38,6 +38,12 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | [`symbol_new_for_short_literal`](symbol_new_for_short_literal.md)     | `warn`           | `Symbol::new` with short literal arguments |
 | [`storage_key_construction_in_loop`](storage_key_construction_in_loop.md) | `warn`           | Loop-invariant `Symbol::new` key construction inside loops |
 
+## Entry Lifecycle
+
+| Lint                                                                  | Default Severity | Catches                                    |
+| --------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
+| [`extend_ttl_in_loop`](extend_ttl_in_loop.md)                         | `warn`           | `extend_ttl` calls on instance/persistent/temporary storage inside loops |
+
 {% hint style="info" %}
 Severities can be adjusted per-workspace via `budget.toml` — see the [Integration Guide](../integration.md).
 {% endhint %}

--- a/docs/lints/extend_ttl_in_loop.md
+++ b/docs/lints/extend_ttl_in_loop.md
@@ -1,0 +1,96 @@
+# `extend_ttl_in_loop`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [Storage — ledger space rent (TTL extension)](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Flags a call to `extend_ttl` on instance, persistent, or temporary storage
+(`env.storage().instance().extend_ttl(...)`,
+`env.storage().persistent().extend_ttl(&key, ...)`,
+`env.storage().temporary().extend_ttl(&key, ...)`) when the call site sits
+directly inside a loop body (`for`, `while`, or `loop`).
+
+## Why is this bad?
+
+{% hint style="danger" %}
+`extend_ttl` is a metered host call that *also* writes ledger state — it is
+not a read-only query. Extending an entry's TTL incurs a rent payment (see
+[Cost Rationale — Ledger Space Rent](../cost_rationale.md#6-ledger-space-rent)),
+priced dynamically based on ledger size. Issuing one `extend_ttl` call per
+iteration — the natural shape when refreshing the TTL of a set of entries —
+multiplies both the host-call dispatch cost and the rent cost by the
+iteration count, exactly the same structural problem
+[`soroban_storage_in_loop`](soroban_storage_in_loop.md) flags for `get` /
+`has` / `set`.
+{% endhint %}
+
+## Example
+
+```rust
+// ❌ Bad: one extend_ttl host call (and rent payment) per iteration
+for key in keys.iter() {
+    env.storage().persistent().extend_ttl(&key, 100, 1000);
+}
+```
+
+```rust
+// ✅ Good: collect the keys first, then extend once per key outside the
+// loop (or, if the SDK/contract design allows it, size the threshold
+// generously enough that a single extension up front covers the whole
+// batch instead of refreshing per-entry per-iteration)
+let keys: Vec<_> = collect_keys();
+for key in keys.iter() {
+    env.storage().persistent().extend_ttl(&key, 100, 1000);
+}
+// (the call above still runs once per key, but only after the set of
+// keys needing extension has been determined — see "Suggested Fix" for
+// batching the extension itself where the storage accessor allows it)
+```
+
+## Suggested Fix
+
+{% hint style="success" %}
+Batch the extension instead of refreshing per-entry per-iteration:
+
+- Collect the keys/entries that need a TTL refresh first (in memory), then
+  issue the `extend_ttl` calls after the loop that determines which entries
+  need it, rather than intermixing the decision loop with the host call.
+- If the entries share one accessor (e.g. multiple keys under
+  `Persistent`), look for opportunities to extend fewer, larger entries
+  instead of many small ones — fewer entries means fewer `extend_ttl` calls
+  are needed in the first place.
+- Extend once with a threshold sized generously enough to cover the whole
+  batch's expected lifetime, instead of issuing a tight, frequently-refreshed
+  extension per entry per iteration.
+{% endhint %}
+
+## What is not reported
+
+- `extend_ttl` calls outside of a loop body.
+- Calls on receivers that are not `soroban_sdk::storage::{Instance,
+  Persistent, Temporary}` (or `Storage` itself).
+- Calls suppressed with `#[allow(extend_ttl_in_loop)]`.
+- Whether the TTL threshold/extend-to values passed to `extend_ttl` are
+  sensible — this lint only looks at the structural in-loop pattern, not
+  the argument values.
+
+## Relationship to `soroban_storage_in_loop`
+
+[`soroban_storage_in_loop`](soroban_storage_in_loop.md) has two detection
+arms. Its **direct** in-loop check only treats a method call as a storage
+access when the method name is `get`, `has`, or `set` — `extend_ttl` is not
+in that allowlist, so the direct arm never fires on it. This lint owns the
+direct in-loop `extend_ttl` diagnostic instead, and there is no overlap
+between the two: the same call is never reported twice.
+
+`soroban_storage_in_loop` also has a second, inter-procedural arm that walks
+into callees reachable from a loop and flags *any* method call on a
+storage-typed receiver found inside them, without a method-name filter. A
+callee containing `env.storage().instance().extend_ttl(...)` and invoked
+from a loop could in principle be caught by that arm — this is a distinct,
+already-existing code path unrelated to the direct check this lint adds, and
+is out of scope for this lint, which only targets the syntactic, direct
+in-loop call (mirroring how [`map_insert_in_loop`](map_insert_in_loop.md)
+and [`bytes_append_in_loop`](bytes_append_in_loop.md) are scoped).

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -437,6 +437,9 @@ pub const LINT_METADATA: &[LintMetadata] = &[
     },
     LintMetadata {
         lint: LOOP_INVARIANT_STORAGE_ACCESS,
+        category: LintCategory::StorageOperations,
+    },
+    LintMetadata {
         lint: UNBOUNDED_INPUT_LOOP,
         category: LintCategory::StorageOperations,
     },
@@ -484,6 +487,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: VEC_WHERE_SLICE_COULD_BE_USED,
         category: LintCategory::Memory,
     },
+    LintMetadata {
+        lint: EXTEND_TTL_IN_LOOP,
+        category: LintCategory::EntryLifecycle,
+    },
 ];
 
 /// Dylint entry point: registers every lint and its late pass with the
@@ -510,6 +517,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         SIGNATURE_VERIFICATION_IN_LOOP,
         STORAGE_KEY_CONSTRUCTION_IN_LOOP,
         VEC_WHERE_SLICE_COULD_BE_USED,
+        EXTEND_TTL_IN_LOOP,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(LoopInvariantStorageAccess));
@@ -526,6 +534,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(SignatureVerificationInLoop));
     lint_store.register_late_pass(|_| Box::new(StorageKeyConstructionInLoop));
     lint_store.register_late_pass(|_| Box::new(VecWhereSliceCouldBeUsed));
+    lint_store.register_late_pass(|_| Box::new(ExtendTtlInLoop));
 }
 
 rustc_session::declare_lint! {
@@ -1684,6 +1693,65 @@ impl<'tcx> LateLintPass<'tcx> for VecWhereSliceCouldBeUsed {
                     None,
                     "consider using native Rust types (e.g. `&[T]`) instead of \
                      `soroban_sdk::Vec` for read-only access to reduce host-side operations",
+                );
+            }
+        }
+    }
+}
+
+// =======================================================================
+// extend_ttl_in_loop — Lint
+// =======================================================================
+
+rustc_session::declare_lint! {
+    pub EXTEND_TTL_IN_LOOP,
+    Warn,
+    "extend_ttl called inside a loop"
+}
+pub struct ExtendTtlInLoop;
+rustc_session::impl_lint_pass!(ExtendTtlInLoop => [EXTEND_TTL_IN_LOOP]);
+
+impl<'tcx> LateLintPass<'tcx> for ExtendTtlInLoop {
+    /// Flags a call to `extend_ttl` on instance, persistent, or temporary
+    /// storage when the call site sits directly inside a loop body.
+    ///
+    /// Each `extend_ttl` call is its own metered host call that *also*
+    /// writes ledger state (a rent payment — see
+    /// `docs/cost_rationale.md`, "Ledger Space Rent"), so issuing one per
+    /// iteration multiplies both costs by the iteration count.
+    ///
+    /// This is deliberately narrower than [`SOROBAN_STORAGE_IN_LOOP`]'s
+    /// direct in-loop check: that pass only treats `get`/`has`/`set` as a
+    /// storage access before checking the loop, so `extend_ttl` never
+    /// reaches it and there is no risk of double-reporting the same call.
+    /// This lint owns the `extend_ttl`-in-loop diagnostic.
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind
+            && path_segment.ident.name.as_str() == "extend_ttl"
+        {
+            let receiver_ty = cx.typeck_results().expr_ty(receiver);
+            let peeled_ty = receiver_ty.peel_refs();
+
+            let is_storage = if let rustc_middle::ty::Adt(adt_def, _) = peeled_ty.kind() {
+                matches_any_path(cx, adt_def.did(), SOROBAN_STORAGE_TYPES)
+            } else {
+                false
+            };
+
+            if is_storage && enclosing_loop(cx, expr).is_some() {
+                span_lint_and_help(
+                    cx,
+                    EXTEND_TTL_IN_LOOP,
+                    expr.span,
+                    "extend_ttl called inside a loop",
+                    None,
+                    "each extend_ttl call is a separate metered host call that also writes \
+                     ledger state, so calling it once per iteration multiplies both costs by \
+                     the iteration count; batch the extension by collecting the keys/entries \
+                     first and making a single extend_ttl call after the loop (if the entries \
+                     share one accessor, e.g. multiple keys under Persistent), or extend once \
+                     with a threshold sized generously enough to cover the whole batch instead \
+                     of refreshing per-entry per-iteration",
                 );
             }
         }

--- a/soroban_cost_lints/ui/extend_ttl_in_loop.rs
+++ b/soroban_cost_lints/ui/extend_ttl_in_loop.rs
@@ -1,0 +1,88 @@
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+            pub fn persistent(&self) -> Persistent { Persistent }
+            pub fn temporary(&self) -> Temporary { Temporary }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+            pub fn extend_ttl(&self, _threshold: u32, _extend_to: u32) {}
+        }
+
+        pub struct Persistent;
+        impl Persistent {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+            pub fn extend_ttl<K: ?Sized>(&self, _key: &K, _threshold: u32, _extend_to: u32) {}
+        }
+
+        pub struct Temporary;
+        impl Temporary {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+            pub fn extend_ttl<K: ?Sized>(&self, _key: &K, _threshold: u32, _extend_to: u32) {}
+        }
+    }
+}
+
+use soroban_sdk::Env;
+
+// =======================================================================
+// extend_ttl_in_loop — Fixtures
+// =======================================================================
+
+fn bad_instance_extend_ttl_in_for_loop(env: Env) {
+    for _ in 0..10 {
+        env.storage().instance().extend_ttl(100, 1000); // Should Warn
+    }
+}
+
+fn bad_persistent_extend_ttl_in_while_loop(env: Env, keys: [u32; 3]) {
+    let mut i = 0;
+    while i < keys.len() {
+        env.storage().persistent().extend_ttl(&keys[i], 100, 1000); // Should Warn
+        i += 1;
+    }
+}
+
+fn bad_temporary_extend_ttl_in_loop_loop(env: Env, key: u32) {
+    let mut count = 0;
+    loop {
+        env.storage().temporary().extend_ttl(&key, 100, 1000); // Should Warn
+        count += 1;
+        if count >= 5 {
+            break;
+        }
+    }
+}
+
+fn good_extend_ttl_outside_loop(env: Env, key: u32) {
+    env.storage().persistent().extend_ttl(&key, 100, 1000); // Good
+}
+
+#[allow(extend_ttl_in_loop)]
+fn allowed_extend_ttl_in_loop(env: Env) {
+    for _ in 0..10 {
+        env.storage().instance().extend_ttl(100, 1000); // Good (allowed)
+    }
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/extend_ttl_in_loop.rs
+++ b/soroban_cost_lints/ui/extend_ttl_in_loop.rs
@@ -49,12 +49,19 @@ use soroban_sdk::Env;
 // extend_ttl_in_loop — Fixtures
 // =======================================================================
 
+// `loop_invariant_storage_access` also matches these calls (any storage
+// method call in a loop whose operands don't depend on loop state) — it's
+// suppressed here so this fixture's `.stderr` stays focused on
+// `extend_ttl_in_loop`'s own diagnostic; both lints firing on the same call
+// is expected, not a bug (they recommend different fixes: hoist vs. batch).
+#[allow(loop_invariant_storage_access)]
 fn bad_instance_extend_ttl_in_for_loop(env: Env) {
     for _ in 0..10 {
         env.storage().instance().extend_ttl(100, 1000); // Should Warn
     }
 }
 
+#[allow(loop_invariant_storage_access)]
 fn bad_persistent_extend_ttl_in_while_loop(env: Env, keys: [u32; 3]) {
     let mut i = 0;
     while i < keys.len() {
@@ -63,6 +70,7 @@ fn bad_persistent_extend_ttl_in_while_loop(env: Env, keys: [u32; 3]) {
     }
 }
 
+#[allow(loop_invariant_storage_access)]
 fn bad_temporary_extend_ttl_in_loop_loop(env: Env, key: u32) {
     let mut count = 0;
     loop {
@@ -78,7 +86,7 @@ fn good_extend_ttl_outside_loop(env: Env, key: u32) {
     env.storage().persistent().extend_ttl(&key, 100, 1000); // Good
 }
 
-#[allow(extend_ttl_in_loop)]
+#[allow(extend_ttl_in_loop, loop_invariant_storage_access)]
 fn allowed_extend_ttl_in_loop(env: Env) {
     for _ in 0..10 {
         env.storage().instance().extend_ttl(100, 1000); // Good (allowed)

--- a/soroban_cost_lints/ui/extend_ttl_in_loop.stderr
+++ b/soroban_cost_lints/ui/extend_ttl_in_loop.stderr
@@ -1,0 +1,27 @@
+warning: extend_ttl called inside a loop
+  --> $DIR/extend_ttl_in_loop.rs:54:9
+   |
+LL |         env.storage().instance().extend_ttl(100, 1000); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: each extend_ttl call is a separate metered host call that also writes ledger state, so calling it once per iteration multiplies both costs by the iteration count; batch the extension by collecting the keys/entries first and making a single extend_ttl call after the loop (if the entries share one accessor, e.g. multiple keys under Persistent), or extend once with a threshold sized generously enough to cover the whole batch instead of refreshing per-entry per-iteration
+   = note: `#[warn(extend_ttl_in_loop)]` on by default
+
+warning: extend_ttl called inside a loop
+  --> $DIR/extend_ttl_in_loop.rs:61:9
+   |
+LL |         env.storage().persistent().extend_ttl(&keys[i], 100, 1000); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: each extend_ttl call is a separate metered host call that also writes ledger state, so calling it once per iteration multiplies both costs by the iteration count; batch the extension by collecting the keys/entries first and making a single extend_ttl call after the loop (if the entries share one accessor, e.g. multiple keys under Persistent), or extend once with a threshold sized generously enough to cover the whole batch instead of refreshing per-entry per-iteration
+
+warning: extend_ttl called inside a loop
+  --> $DIR/extend_ttl_in_loop.rs:69:9
+   |
+LL |         env.storage().temporary().extend_ttl(&key, 100, 1000); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: each extend_ttl call is a separate metered host call that also writes ledger state, so calling it once per iteration multiplies both costs by the iteration count; batch the extension by collecting the keys/entries first and making a single extend_ttl call after the loop (if the entries share one accessor, e.g. multiple keys under Persistent), or extend once with a threshold sized generously enough to cover the whole batch instead of refreshing per-entry per-iteration
+
+warning: 3 warnings emitted
+

--- a/soroban_cost_lints/ui/extend_ttl_in_loop.stderr
+++ b/soroban_cost_lints/ui/extend_ttl_in_loop.stderr
@@ -1,5 +1,5 @@
 warning: extend_ttl called inside a loop
-  --> $DIR/extend_ttl_in_loop.rs:54:9
+  --> $DIR/extend_ttl_in_loop.rs:60:9
    |
 LL |         env.storage().instance().extend_ttl(100, 1000); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         env.storage().instance().extend_ttl(100, 1000); // Should Warn
    = note: `#[warn(extend_ttl_in_loop)]` on by default
 
 warning: extend_ttl called inside a loop
-  --> $DIR/extend_ttl_in_loop.rs:61:9
+  --> $DIR/extend_ttl_in_loop.rs:68:9
    |
 LL |         env.storage().persistent().extend_ttl(&keys[i], 100, 1000); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         env.storage().persistent().extend_ttl(&keys[i], 100, 1000); // Shou
    = help: each extend_ttl call is a separate metered host call that also writes ledger state, so calling it once per iteration multiplies both costs by the iteration count; batch the extension by collecting the keys/entries first and making a single extend_ttl call after the loop (if the entries share one accessor, e.g. multiple keys under Persistent), or extend once with a threshold sized generously enough to cover the whole batch instead of refreshing per-entry per-iteration
 
 warning: extend_ttl called inside a loop
-  --> $DIR/extend_ttl_in_loop.rs:69:9
+  --> $DIR/extend_ttl_in_loop.rs:77:9
    |
 LL |         env.storage().temporary().extend_ttl(&key, 100, 1000); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes #109

## Summary

Implements the `extend_ttl_in_loop` lint: flags calls to `extend_ttl` on instance, persistent, or temporary Soroban storage when the call site sits directly inside a loop body (`for`/`while`/`loop`).

`extend_ttl` is a metered host call that also writes ledger state (a rent payment). Issuing one call per iteration — the natural shape when refreshing the TTL of a set of entries — multiplies both the dispatch cost and the rent cost by the iteration count. The diagnostic's help text explains the batching alternative: collect the keys/entries first and extend once after the loop, or extend once with a threshold sized generously enough to cover the whole batch, instead of refreshing per-entry per-iteration.

Registered under a new `LintCategory::EntryLifecycle` category (previously unused — this is the first lint assigned to it).

## Why there's no double-report with `soroban_storage_in_loop`

`SorobanStorageInLoop`'s **direct** in-loop check (the arm structurally identical to what this new lint adds) only treats a method call as a storage access when the method name is `get`, `has`, or `set`:

```rust
let is_terminal_storage_op = matches!(method_name, "get" | "has" | "set");
```

`extend_ttl` is not in that allowlist, so the direct arm never fires on it — there is no risk of the two lints reporting the same call site. `extend_ttl_in_loop` owns the direct in-loop `extend_ttl` diagnostic.

(`SorobanStorageInLoop` also has a *second*, inter-procedural arm that walks into callees reached from a loop and flags *any* method call on a storage-typed receiver inside them, without a method-name filter — a callee containing `env.storage().instance().extend_ttl(...)` invoked from a loop could in principle be caught by that pre-existing arm too. That's an existing, unrelated code path; this PR only adds the direct syntactic in-loop check, matching how `map_insert_in_loop` and `bytes_append_in_loop` are scoped, per the issue's "what done looks like.")

This reasoning is also documented in `docs/lints/extend_ttl_in_loop.md` under "Relationship to `soroban_storage_in_loop`".

## New files

- `soroban_cost_lints/ui/extend_ttl_in_loop.rs` — standalone UI fixture (self-contained local `soroban_sdk` stub, following the `soroban_storage_in_loop.rs` convention). Covers:
  - `extend_ttl` on `Instance` inside a `for` loop (bad)
  - `extend_ttl` on `Persistent` inside a `while` loop (bad)
  - `extend_ttl` on `Temporary` inside a `loop` (bad)
  - `extend_ttl` called once, outside a loop (good, no warning)
  - `extend_ttl` inside a loop under `#[allow(extend_ttl_in_loop)]` (suppressed, no warning)
- `soroban_cost_lints/ui/extend_ttl_in_loop.stderr` — expected diagnostic output, generated by running the fixture through the actual lint and copying the harness's own rendered output (see "How to test locally" — this harness does not support `TRYBUILD=overwrite`/`BLESS=1` auto-blessing; the `.stderr` was captured from the failing test's "Actual stderr saved to ..." file and reviewed by hand).
- `docs/lints/extend_ttl_in_loop.md` — full lint documentation (What it does / Why is this bad / Example / Suggested Fix / What is not reported / Relationship to `soroban_storage_in_loop`).

## Modified files

- `soroban_cost_lints/src/lib.rs` — new `EXTEND_TTL_IN_LOOP` lint declaration, `ExtendTtlInLoop` marker struct + `LateLintPass` impl, `LintMetadata` entry (`LintCategory::EntryLifecycle`), and registration in `register_lints`. Purely additive — no existing lint logic was touched.
- `docs/lints/README.md` — new "Entry Lifecycle" section/table (first lint in this category).
- `docs/SUMMARY.md` — new bullet under `## Lints`.
- `docs/cost_rationale.md` — new row in the "Per-Lint Resource Summary" table (Storage / ledger space rent).
- `README.md` — new bullet under `## Features`, and `extend_ttl_in_loop = "warn"` added to the example `budget.toml` block.
- `CHANGELOG.md` — new entry under `## [Unreleased]` → `### Added`.

## Implementation details

Detection rule (`soroban_cost_lints/src/lib.rs`, `ExtendTtlInLoop::check_expr`):
- Matches a `MethodCall` expression named `extend_ttl`.
- Whose receiver's type (peeled of refs) resolves via ADT to any of the existing `SOROBAN_STORAGE_TYPES` (`Storage`, `Instance`, `Persistent`, `Temporary`) via the existing `matches_any_path` helper.
- And sits inside a syntactic loop per the existing `enclosing_loop` helper (same restriction as `MapInsertInLoop`/`BytesAppendInLoop`/`SorobanStorageInLoop`'s direct arm — closures are not covered).

No new helpers were added; the lint reuses `SOROBAN_STORAGE_TYPES`, `matches_any_path`, and `enclosing_loop` exactly as instructed.

One implementation note: the help text originally used the word "issuing", which triggered a pre-existing quirk in this repo's UI-test harness (`compiletest_rs` via `dylint_testing`) — it does a naive substring replace of the literal test-source directory name (`"ui"`) with `$DIR` anywhere in the diagnostic text, which corrupted "issuing" into `iss$DIRng`. Reworded to "making a single extend_ttl call" to avoid the substring `"ui"` and keep the `.stderr` clean/stable.

## Tests added

- `soroban_cost_lints/ui/extend_ttl_in_loop.rs` + `.stderr` (see above) — passes (`test [ui] ui/extend_ttl_in_loop.rs ... ok`).

## How to test locally

```bash
cd soroban_cost_lints
cargo test --lib ui
```

(Note: `cargo test --test ui` does not work in this crate — there is no `[[test]]` target or `tests/ui.rs`; the UI harness is a `#[test] fn ui()` unit test inside `src/lib.rs` itself, so it must be run via `--lib`.)

From the repo root:

```bash
cargo fmt --all -- --check
cargo clippy -p soroban_cost_lints --all-targets -- -D warnings
cargo test -p soroban_cost_lints
```

## Pre-existing, unrelated failures (not introduced by this PR)

Confirmed by stashing this branch's changes and re-running against plain `main`:

- `soroban_cost_lints/ui/main.rs` — known duplicate-function-definition drift vs. `main.stderr` (called out explicitly in the task/issue as out of scope).
- `soroban_cost_lints/ui/redundant_val_conversion.rs` — the `redundant_val_conversion` lint referenced by this fixture is not currently registered (`unknown lint` warning), pre-existing on `main`.
- `soroban_cost_lints/ui/soroban_storage_in_loop.rs` — its checked-in `.stderr` no longer matches current `SorobanStorageInLoop`/`StorageWriteWithoutRead` output (both diagnostics fire together now), pre-existing on `main`.
- `cargo-cost-lint/src/main.rs` — pre-existing compile errors (`cannot find type BudgetConfig`, `cannot find type HashMap` — missing imports) block `cargo clippy --workspace --all-targets` and `cargo test --workspace`. Confirmed present on `main` via `git show main:cargo-cost-lint/src/main.rs`. This is why the clippy/test commands above are scoped to `-p soroban_cost_lints`.

None of these are touched by this PR's diff, which is purely additive to `soroban_cost_lints/src/lib.rs` plus new/doc files.
