### PR TITLE
refactor: consolidate budget.toml validation into BudgetConfig

### DIFF
--- a/cargo-cost-lint/build.rs
+++ b/cargo-cost-lint/build.rs
@@ -191,6 +191,7 @@ fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let names_path = Path::new(&out_dir).join("lint_names.rs");
     let metadata_path = Path::new(&out_dir).join("lint_metadata.rs");
+    let info_path = Path::new(&out_dir).join("lint_info.rs");
 
     let mut names_out = String::new();
     names_out.push_str("pub const LINT_NAMES: &[&str] = &[\n");
@@ -218,31 +219,24 @@ fn main() {
     metadata_out.push_str("    schema: \"https://github.com/Tollcraft/soroban-cost-linter/blob/main/docs/lints/README.md#lint-inventory-schema\",\n");
     metadata_out.push_str("    lints: &[\n");
 
-    let mut out = String::new();
+    // Emit LintInfo/LINT_INFO for --list-lints (included by main.rs).
+    let mut info_out = String::new();
+    info_out.push_str("pub struct LintInfo {\n");
+    info_out.push_str("    pub name: &'static str,\n");
+    info_out.push_str("    pub level: &'static str,\n");
+    info_out.push_str("    pub description: &'static str,\n");
+    info_out.push_str("}\n\n");
 
-    // Emit LINT_NAMES (used by the filter logic in main.rs).
-    out.push_str("pub const LINT_NAMES: &[&str] = &[\n");
-    for name in &names {
-        out.push_str(&format!("    \"{}\",\n", name));
-    }
-    out.push_str("];\n\n");
-
-    // Emit LINT_INFO for --list-lints.
-    out.push_str("pub struct LintInfo {\n");
-    out.push_str("    pub name: &'static str,\n");
-    out.push_str("    pub level: &'static str,\n");
-    out.push_str("    pub description: &'static str,\n");
-    out.push_str("}\n\n");
-
-    out.push_str("pub const LINT_INFO: &[LintInfo] = &[\n");
+    info_out.push_str("pub const LINT_INFO: &[LintInfo] = &[\n");
     for lint in &ordered {
-        out.push_str("    LintInfo {\n");
-        out.push_str(&format!("        name: \"{}\",\n", lint.name));
-        out.push_str(&format!("        level: \"{}\",\n", lint.level));
-        out.push_str(&format!("        description: \"{}\",\n", lint.description));
-        out.push_str("    },\n");
+        info_out.push_str("    LintInfo {\n");
+        info_out.push_str(&format!("        name: \"{}\",\n", lint.name));
+        info_out.push_str(&format!("        level: \"{}\",\n", lint.level));
+        info_out.push_str(&format!("        description: \"{}\",\n", lint.description));
+        info_out.push_str("    },\n");
     }
-    out.push_str("];\n");
+    info_out.push_str("];\n");
+    fs::write(&info_path, info_out).expect("Failed to write lint_info.rs");
 
     metadata_out.push_str("    ],\n");
     metadata_out.push_str("};\n");

--- a/cargo-cost-lint/src/config.rs
+++ b/cargo-cost-lint/src/config.rs
@@ -1,85 +1,18 @@
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::fs;
-use std::path::Path;
 
 #[derive(Deserialize, Debug, Default, Clone)]
-pub struct Config {
-    #[allow(dead_code)]
-    lints: Option<HashMap<String, String>>,
-}
-
-impl Config {
-    pub fn from_file_or_default(path: &Path) -> Self {
-        if !path.exists() {
-            return Config::default();
-        }
-        match fs::read_to_string(path) {
-            Ok(content) => toml::from_str::<Config>(&content).unwrap_or_default(),
-            Err(_) => Config::default(),
-        }
-    }
+pub struct BudgetConfig {
+    pub lints: Option<HashMap<String, String>>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
-    use tempfile::tempdir;
-
-    fn write_file(path: &Path, contents: &str) {
-        let mut f = File::create(path).unwrap();
-        f.write_all(contents.as_bytes()).unwrap();
-    }
-
-    #[test]
-    fn from_file_or_default_returns_default_for_missing_file() {
-        let dir = tempdir().unwrap();
-        let missing = dir.path().join("nonexistent.toml");
-        let config = Config::from_file_or_default(&missing);
-        assert!(config.lints.is_none());
-    }
-
-    #[test]
-    fn from_file_or_default_parses_valid_toml() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("budget.toml");
-        write_file(
-            &path,
-            r#"[lints]
-soroban_storage_in_loop = "deny"
-"#,
-        );
-        let config = Config::from_file_or_default(&path);
-        let lints = config.lints.expect("lints should be present");
-        assert_eq!(
-            lints.get("soroban_storage_in_loop").map(|s| s.as_str()),
-            Some("deny")
-        );
-    }
-
-    #[test]
-    fn from_file_or_default_handles_malformed_toml_gracefully() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("budget.toml");
-        write_file(&path, "this is not valid toml [[[");
-        let config = Config::from_file_or_default(&path);
-        assert!(config.lints.is_none());
-    }
-
-    #[test]
-    fn from_file_or_default_handles_empty_file() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("budget.toml");
-        write_file(&path, "");
-        let config = Config::from_file_or_default(&path);
-        assert!(config.lints.is_none());
-    }
 
     #[test]
     fn default_config_has_no_lints() {
-        let config = Config::default();
+        let config = BudgetConfig::default();
         assert!(config.lints.is_none());
     }
 }

--- a/cargo-cost-lint/src/config.rs
+++ b/cargo-cost-lint/src/config.rs
@@ -1,18 +1,132 @@
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
 
 #[derive(Deserialize, Debug, Default, Clone)]
 pub struct BudgetConfig {
     pub lints: Option<HashMap<String, String>>,
 }
 
+impl BudgetConfig {
+    /// Reads and parses `path` into a `BudgetConfig`, validating that every
+    /// configured lint name is one of `known_lints` and every level is one
+    /// of `allow`/`warn`/`deny`. This is the single canonical entry point
+    /// for loading a `budget.toml` — the file may be read from anywhere on
+    /// disk, but always goes through this same validation.
+    pub fn from_file_validated(path: &Path, known_lints: &[&str]) -> Result<Self, String> {
+        let path_display = path.display();
+        let content = fs::read_to_string(path)
+            .map_err(|e| format!("Error: Failed to read {}: {}", path_display, e))?;
+        let config: BudgetConfig = toml::from_str(&content)
+            .map_err(|e| format!("Error: Failed to parse {}: {}", path_display, e))?;
+
+        if let Some(lints) = &config.lints {
+            for (lint, level) in lints {
+                if !known_lints.contains(&lint.as_str()) {
+                    return Err(format!(
+                        "Error: Unknown lint name '{}' in {}. Valid lints: {}",
+                        lint,
+                        path_display,
+                        known_lints.join(", ")
+                    ));
+                }
+                if !matches!(level.as_str(), "allow" | "warn" | "deny") {
+                    return Err(format!(
+                        "Error: Unknown lint level '{}' for '{}' in {}. Valid levels are allow, warn, and deny.",
+                        level, lint, path_display
+                    ));
+                }
+            }
+        }
+
+        Ok(config)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    const KNOWN_LINTS: &[&str] = &["soroban_storage_in_loop", "redundant_env_clone"];
+
+    fn write_file(path: &Path, contents: &str) {
+        let mut f = File::create(path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+    }
 
     #[test]
     fn default_config_has_no_lints() {
         let config = BudgetConfig::default();
         assert!(config.lints.is_none());
+    }
+
+    #[test]
+    fn from_file_validated_returns_error_for_missing_file() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nonexistent.toml");
+        let result = BudgetConfig::from_file_validated(&missing, KNOWN_LINTS);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to read"));
+    }
+
+    #[test]
+    fn from_file_validated_returns_error_for_malformed_toml() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("budget.toml");
+        write_file(&path, "this is not valid toml [[[");
+        let result = BudgetConfig::from_file_validated(&path, KNOWN_LINTS);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to parse"));
+    }
+
+    #[test]
+    fn from_file_validated_parses_valid_toml() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("budget.toml");
+        write_file(
+            &path,
+            r#"[lints]
+soroban_storage_in_loop = "deny"
+"#,
+        );
+        let config = BudgetConfig::from_file_validated(&path, KNOWN_LINTS).unwrap();
+        let lints = config.lints.expect("lints should be present");
+        assert_eq!(
+            lints.get("soroban_storage_in_loop").map(|s| s.as_str()),
+            Some("deny")
+        );
+    }
+
+    #[test]
+    fn from_file_validated_handles_empty_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("budget.toml");
+        write_file(&path, "");
+        let config = BudgetConfig::from_file_validated(&path, KNOWN_LINTS).unwrap();
+        assert!(config.lints.is_none());
+    }
+
+    #[test]
+    fn from_file_validated_rejects_unknown_lint_name() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("budget.toml");
+        write_file(&path, "[lints]\nnot_a_real_lint = \"deny\"\n");
+        let result = BudgetConfig::from_file_validated(&path, KNOWN_LINTS);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown lint name"));
+    }
+
+    #[test]
+    fn from_file_validated_rejects_unknown_level() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("budget.toml");
+        write_file(&path, "[lints]\nsoroban_storage_in_loop = \"oops\"\n");
+        let result = BudgetConfig::from_file_validated(&path, KNOWN_LINTS);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown lint level"));
     }
 }

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -338,19 +338,19 @@ fn main() {
 
     let mut findings: Vec<LintFinding> = Vec::new();
 
-    for line_str in reader.lines().map_while(Result::ok) {
-        if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&line_str) {
-            if msg.get("reason").and_then(|r| r.as_str()) == Some("compiler-message") {
-                if let Some(message) = msg.get("message") {
-                    if let Some(code) = message.get("code") {
+    for line in reader.lines().map_while(Result::ok) {
+        if let Ok(cargo_record) = serde_json::from_str::<serde_json::Value>(&line) {
+            if cargo_record.get("reason").and_then(|r| r.as_str()) == Some("compiler-message") {
+                if let Some(diagnostic) = cargo_record.get("message") {
+                    if let Some(code) = diagnostic.get("code") {
                         if let Some(lint_name) = code.get("code").and_then(|c| c.as_str()) {
                             if LINT_NAMES.contains(&lint_name) {
-                                let level = message
+                                let level = diagnostic
                                     .get("level")
                                     .and_then(|l| l.as_str())
                                     .unwrap_or("unknown");
 
-                                let diagnostic_message = message
+                                let diagnostic_message = diagnostic
                                     .get("message")
                                     .and_then(|m| m.as_str())
                                     .unwrap_or("");
@@ -362,7 +362,8 @@ fn main() {
                                     column_end: 0,
                                 };
 
-                                if let Some(spans) = message.get("spans").and_then(|s| s.as_array())
+                                if let Some(spans) =
+                                    diagnostic.get("spans").and_then(|s| s.as_array())
                                 {
                                     for span in spans {
                                         if span
@@ -395,26 +396,16 @@ fn main() {
                                                 .and_then(|c| c.as_u64())
                                                 .unwrap_or(0)
                                                 as usize;
-                                        span_obj.column_start = s
-                                            .get("column_start")
-                                            .and_then(|c| c.as_u64())
-                                            .unwrap_or(0)
-                                            as usize;
-                                        span_obj.column_end = s
-                                            .get("column_end")
-                                            .and_then(|c| c.as_u64())
-                                            .unwrap_or(0)
-                                            as usize;
-                                        break;
+                                            break;
+                                        }
                                     }
                                 }
-                            }
 
-                            // Only apply .lintignore filtering to known soroban lints.
-                            // Regular compiler diagnostics always pass through.
-                            if is_soroban_lint && !is_reportable(&file, &allowed) {
-                                continue;
-                            }
+                                // Only apply .lintignore filtering to known soroban lints.
+                                // Regular compiler diagnostics always pass through.
+                                if !is_reportable(&file, &allowed) {
+                                    continue;
+                                }
 
                                 *lint_counts.entry(lint_name.to_string()).or_insert(0) += 1;
 
@@ -422,11 +413,10 @@ fn main() {
                                     highest_exit_code = 1;
                                 }
 
-                            if let Some(name) = lint_name {
                                 let mut help_text = None;
                                 let mut suggestion = None;
                                 if let Some(children) =
-                                    message.get("children").and_then(|c| c.as_array())
+                                    diagnostic.get("children").and_then(|c| c.as_array())
                                 {
                                     for child_item in children {
                                         if child_item.get("level").and_then(|l| l.as_str())
@@ -435,10 +425,11 @@ fn main() {
                                             let child_msg = child_item
                                                 .get("message")
                                                 .and_then(|m| m.as_str())
-                                                .map(|s| s.to_string());
+                                                .map(|text| text.to_string());
                                             help_text = child_msg.clone();
                                             if cli.fix {
-                                                suggestion = extract_suggestion(&child_msg, name);
+                                                suggestion =
+                                                    extract_suggestion(&child_msg, lint_name);
                                             }
                                             break;
                                         }
@@ -446,7 +437,7 @@ fn main() {
                                 }
 
                                 let finding = LintFinding {
-                                    name: name.to_string(),
+                                    name: lint_name.to_string(),
                                     level: level.to_string(),
                                     file: file.clone(),
                                     span: primary_span,
@@ -463,18 +454,12 @@ fn main() {
                                         println!("{}", json_str);
                                     }
                                 } else if cli.format != OutputFormat::Sarif {
-                                    let rendered = message
+                                    let rendered = diagnostic
                                         .get("rendered")
                                         .and_then(|r| r.as_str())
                                         .unwrap_or(diagnostic_message);
                                     print!("{}", rendered);
                                 }
-                            } else if cli.format != OutputFormat::Json {
-                                let rendered = message
-                                    .get("rendered")
-                                    .and_then(|r| r.as_str())
-                                    .unwrap_or(msg_text);
-                                print!("{}", rendered);
                             }
                         }
                     }

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -192,39 +192,23 @@ fn is_reportable(file: &str, allowed: &HashSet<PathBuf>) -> bool {
     }
 }
 
+/// Loads `path` as a validated `BudgetConfig` and formats its `[lints]`
+/// entries into `-A`/`-W`/`-D` flags for `DYLINT_RUSTFLAGS`. Validation
+/// (unknown lint names, invalid levels) is handled by
+/// `BudgetConfig::from_file_validated`, the single canonical config parser.
 fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
-    let config_str =
-        fs::read_to_string(path).map_err(|e| format!("Error: Failed to read {}: {}", path, e))?;
-    let config: BudgetConfig = toml::from_str(&config_str)
-        .map_err(|e| format!("Error: Failed to parse {}: {}", path, e))?;
-    let mut lint_flags = Vec::new();
+    let config = BudgetConfig::from_file_validated(Path::new(path), LINT_NAMES)?;
 
+    let mut lint_flags = Vec::new();
     if let Some(lints) = config.lints {
         for (lint, level) in lints {
-            if !LINT_NAMES.contains(&lint.as_str()) {
-                return Err(format!(
-                    "Error: Unknown lint name '{}' in {}. Valid lints: {}",
-                    lint,
-                    path,
-                    LINT_NAMES.join(", ")
-                ));
-            }
-
-            let level_flag = match level.as_str() {
-                "allow" => Some("-A"),
-                "warn" => Some("-W"),
-                "deny" => Some("-D"),
-                _ => None,
+            let flag = match level.as_str() {
+                "allow" => "-A",
+                "warn" => "-W",
+                "deny" => "-D",
+                _ => unreachable!("level already validated by BudgetConfig::from_file_validated"),
             };
-
-            if let Some(flag) = level_flag {
-                lint_flags.push(format!("{} {}", flag, lint));
-            } else {
-                return Err(format!(
-                    "Error: Unknown lint level '{}' for '{}' in {}. Valid levels are allow, warn, and deny.",
-                    level, lint, path
-                ));
-            }
+            lint_flags.push(format!("{} {}", flag, lint));
         }
     }
 

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -1,14 +1,14 @@
 use clap::{Parser, ValueEnum};
 use ignore::WalkBuilder;
 use serde::Serialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio, exit};
 
 mod config;
-use config::Config;
+use config::BudgetConfig;
 
 /// Output format for lint results.
 #[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
@@ -57,7 +57,7 @@ struct SarifReport {
 #[derive(Serialize)]
 struct SarifRun {
     tool: SarifTool,
-    results: Vec<serde_json::Value>,
+    results: Vec<SarifResult>,
 }
 
 /// Tool metadata for SARIF output.
@@ -146,7 +146,10 @@ struct Cli {
     #[arg(long, help = "Path to budget.toml")]
     config: Option<String>,
 
-    #[arg(long, help = "Emit the lint inventory and exit")]
+    #[arg(
+        long,
+        help = "List all registered lints with their default levels and descriptions"
+    )]
     list_lints: bool,
 
     #[arg(long, value_enum, default_value_t = OutputFormat::Text, help = "Output format")]
@@ -154,16 +157,11 @@ struct Cli {
 
     #[arg(long, help = "Automatically apply fixable lint suggestions")]
     fix: bool,
-
-    #[arg(
-        long,
-        help = "List all registered lints with their default levels and descriptions"
-    )]
-    list_lints: bool,
 }
 
 include!(concat!(env!("OUT_DIR"), "/lint_names.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_metadata.rs"));
+include!(concat!(env!("OUT_DIR"), "/lint_info.rs"));
 
 /// Walks `root`, respecting `.gitignore` and `.lintignore`, and returns the
 /// canonicalized set of files that are allowed to be linted (i.e. not
@@ -192,15 +190,6 @@ fn is_reportable(file: &str, allowed: &HashSet<PathBuf>) -> bool {
         Ok(canon) => allowed.contains(&canon),
         Err(_) => true,
     }
-}
-
-fn load_budget_config(config_path: &Path) -> Option<BudgetConfig> {
-    if !config_path.exists() {
-        return None;
-    }
-
-    let config_str = fs::read_to_string(config_path).ok()?;
-    toml::from_str::<BudgetConfig>(&config_str).ok()
 }
 
 fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
@@ -242,6 +231,7 @@ fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
     Ok(lint_flags)
 }
 
+#[allow(clippy::collapsible_if)]
 fn main() {
     let mut args = std::env::args().collect::<Vec<_>>();
     if args.len() > 1 && args[1] == "cost-lint" {
@@ -273,13 +263,15 @@ fn main() {
 
     let allowed = allowed_files(Path::new("."));
 
-    let lint_flags: Vec<String> = Vec::new();
+    let mut lint_flags: Vec<String> = Vec::new();
     if let Some(config_path) = &cli.config {
-        if let Some(config) = load_budget_config(Path::new(config_path)) {
-            // ... validate (existing code)
-            let _ = config;
+        match parse_budget_config(config_path) {
+            Ok(flags) => lint_flags = flags,
+            Err(e) => {
+                eprintln!("{}", e);
+                exit(1);
+            }
         }
-        let _config = Config::from_file_or_default(Path::new(config_path));
     }
 
     let preflight = Command::new("cargo")
@@ -295,11 +287,6 @@ fn main() {
             eprintln!("    cargo install cargo-dylint dylint-link");
             exit(1);
         }
-        Some(config_path) => {
-            eprintln!("Warning: config file '{}' not found", config_path);
-            Vec::new()
-        }
-        None => Vec::new(),
     };
 
     let mut cmd = Command::new("cargo");
@@ -603,11 +590,11 @@ fn apply_fixes(findings: &[LintFinding]) {
             for (line_idx, _message, suggestion) in edits {
                 if *line_idx > 0 && *line_idx <= lines.len() {
                     let line = &mut lines[*line_idx - 1];
-                    if let Some(start) = line.find("Symbol::new") {
-                        if let Some(end) = line[start..].find(')') {
-                            let replace_end = start + end + 1;
-                            line.replace_range(start..replace_end, suggestion);
-                        }
+                    if let Some(start) = line.find("Symbol::new")
+                        && let Some(end) = line[start..].find(')')
+                    {
+                        let replace_end = start + end + 1;
+                        line.replace_range(start..replace_end, suggestion);
                     }
                 }
             }
@@ -725,7 +712,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("budget.toml");
         let mut file = fs::File::create(&path).unwrap();
-        writeln!(file, "this is not valid toml = {{{").unwrap();
+        writeln!(file, "this is not valid toml = {{{{{{").unwrap();
         drop(file);
 
         let result = parse_budget_config(&path.to_string_lossy());

--- a/cargo-cost-lint/tests/integration.rs
+++ b/cargo-cost-lint/tests/integration.rs
@@ -26,14 +26,20 @@ fn test_list_lints() {
     // update this array as well.
     let expected_lints = &[
         "soroban_storage_in_loop",
+        "loop_invariant_storage_access",
+        "unbounded_input_loop",
         "redundant_env_clone",
         "unnecessary_host_function_call",
         "host_in_loop",
         "symbol_new_for_short_literal",
+        "unnecessary_string_to_bytes",
         "storage_write_without_read",
         "inefficient_bytes_concat",
         "map_insert_in_loop",
         "bytes_append_in_loop",
+        "signature_verification_in_loop",
+        "storage_key_construction_in_loop",
+        "vec_where_slice_could_be_used",
     ];
 
     for expected in expected_lints {

--- a/cargo-cost-lint/tests/real_world_corpus.rs
+++ b/cargo-cost-lint/tests/real_world_corpus.rs
@@ -70,7 +70,14 @@ fn run_lints_on_contract(contract_dir: &Path) -> Vec<Finding> {
         .output()
         .expect("Failed to execute cargo-cost-lint");
 
-    if !output.status.success() {
+    let stdout_str = String::from_utf8(output.stdout).expect("Stdout is not valid UTF-8");
+
+    // A non-zero exit can mean cargo-cost-lint genuinely failed to run, or
+    // that a `deny`-level lint fired and correctly failed the underlying
+    // `cargo check` — findings were already streamed to stdout before the
+    // process exited in that case. Only treat this as a hard failure when
+    // there's nothing to show for it.
+    if !output.status.success() && stdout_str.trim().is_empty() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         panic!(
             "cargo-cost-lint failed on {:?}:\n{}",
@@ -79,7 +86,6 @@ fn run_lints_on_contract(contract_dir: &Path) -> Vec<Finding> {
         );
     }
 
-    let stdout_str = String::from_utf8(output.stdout).expect("Stdout is not valid UTF-8");
     let findings: Vec<Finding> = stdout_str
         .lines()
         .filter(|l| !l.is_empty())

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -437,6 +437,9 @@ pub const LINT_METADATA: &[LintMetadata] = &[
     },
     LintMetadata {
         lint: LOOP_INVARIANT_STORAGE_ACCESS,
+        category: LintCategory::StorageOperations,
+    },
+    LintMetadata {
         lint: UNBOUNDED_INPUT_LOOP,
         category: LintCategory::StorageOperations,
     },

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -934,8 +934,8 @@ impl<'tcx> LateLintPass<'tcx> for SymbolNewForShortLiteral {
             if let hir::ExprKind::Lit(lit) = args[1].kind
                 && let LitKind::Str(symbol, _) = lit.node
             {
-                let s = symbol.as_str();
-                if is_valid_short_symbol(s) {
+                let symbol_str = symbol.as_str();
+                if is_valid_short_symbol(symbol_str) {
                     // Check if there's a valid suggestion
                     if let Some(snippet) = snippet_opt(cx, args[1].span) {
                         let suggestion = format!("symbol_short!({})", snippet);
@@ -1255,11 +1255,13 @@ impl<'tcx> LateLintPass<'tcx> for BytesAppendInLoop {
 }
 
 /// Check if a string is a valid short symbol (<= 9 chars, only a-zA-Z0-9_)
-fn is_valid_short_symbol(s: &str) -> bool {
-    if s.len() > 9 || s.is_empty() {
+fn is_valid_short_symbol(symbol_str: &str) -> bool {
+    if symbol_str.len() > 9 || symbol_str.is_empty() {
         return false;
     }
-    s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    symbol_str
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 // =======================================================================


### PR DESCRIPTION
Closes #202

## Summary
`cargo-cost-lint` had three near-duplicate "read + parse `budget.toml`" implementations — only one of them (`parse_budget_config`) actually validated lint names/levels, and that validation wasn't reusable. Consolidated into a single canonical entry point.

## Changes
### `cargo-cost-lint/src/config.rs`
- Added `BudgetConfig::from_file_validated(path, known_lints) -> Result<Self, String>` — reads, parses, and validates (unknown lint names against `known_lints`, unknown levels against `allow`/`warn`/`deny`), returning the same formatted error strings the old inline logic produced.
- Added test coverage for missing file, malformed TOML, valid config, empty file, unknown lint name, and unknown level.

### `cargo-cost-lint/src/main.rs`
- `parse_budget_config` now delegates all reading/parsing/validation to `BudgetConfig::from_file_validated`, keeping only the `-A`/`-W`/`-D` flag formatting for `DYLINT_RUSTFLAGS` (CLI/dylint-specific plumbing, not validation).

## Note on branch base
This branch is stacked on `refactor/task-16` (#301) since `main` currently has pre-existing compile errors that block the crate from building at all (see #301 for details/fix) — `#301`'s commits are included here so this PR is independently buildable and testable. Once #301 merges, rebasing this branch will drop the now-redundant commits from the diff automatically.

## Verification
- `cargo fmt --all -- --check` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo test -p cargo-cost-lint --bins` — all 17 tests pass (including 6 new tests for `from_file_validated`, and the 4 existing `parse_budget_config` tests unchanged)