### PR TITLE
perf: use HashSet for storage read tracking in storage_write_without_read

### DIFF
--- a/cargo-cost-lint/build.rs
+++ b/cargo-cost-lint/build.rs
@@ -191,6 +191,7 @@ fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let names_path = Path::new(&out_dir).join("lint_names.rs");
     let metadata_path = Path::new(&out_dir).join("lint_metadata.rs");
+    let info_path = Path::new(&out_dir).join("lint_info.rs");
 
     let mut names_out = String::new();
     names_out.push_str("pub const LINT_NAMES: &[&str] = &[\n");
@@ -218,31 +219,24 @@ fn main() {
     metadata_out.push_str("    schema: \"https://github.com/Tollcraft/soroban-cost-linter/blob/main/docs/lints/README.md#lint-inventory-schema\",\n");
     metadata_out.push_str("    lints: &[\n");
 
-    let mut out = String::new();
+    // Emit LintInfo/LINT_INFO for --list-lints (included by main.rs).
+    let mut info_out = String::new();
+    info_out.push_str("pub struct LintInfo {\n");
+    info_out.push_str("    pub name: &'static str,\n");
+    info_out.push_str("    pub level: &'static str,\n");
+    info_out.push_str("    pub description: &'static str,\n");
+    info_out.push_str("}\n\n");
 
-    // Emit LINT_NAMES (used by the filter logic in main.rs).
-    out.push_str("pub const LINT_NAMES: &[&str] = &[\n");
-    for name in &names {
-        out.push_str(&format!("    \"{}\",\n", name));
-    }
-    out.push_str("];\n\n");
-
-    // Emit LINT_INFO for --list-lints.
-    out.push_str("pub struct LintInfo {\n");
-    out.push_str("    pub name: &'static str,\n");
-    out.push_str("    pub level: &'static str,\n");
-    out.push_str("    pub description: &'static str,\n");
-    out.push_str("}\n\n");
-
-    out.push_str("pub const LINT_INFO: &[LintInfo] = &[\n");
+    info_out.push_str("pub const LINT_INFO: &[LintInfo] = &[\n");
     for lint in &ordered {
-        out.push_str("    LintInfo {\n");
-        out.push_str(&format!("        name: \"{}\",\n", lint.name));
-        out.push_str(&format!("        level: \"{}\",\n", lint.level));
-        out.push_str(&format!("        description: \"{}\",\n", lint.description));
-        out.push_str("    },\n");
+        info_out.push_str("    LintInfo {\n");
+        info_out.push_str(&format!("        name: \"{}\",\n", lint.name));
+        info_out.push_str(&format!("        level: \"{}\",\n", lint.level));
+        info_out.push_str(&format!("        description: \"{}\",\n", lint.description));
+        info_out.push_str("    },\n");
     }
-    out.push_str("];\n");
+    info_out.push_str("];\n");
+    fs::write(&info_path, info_out).expect("Failed to write lint_info.rs");
 
     metadata_out.push_str("    ],\n");
     metadata_out.push_str("};\n");

--- a/cargo-cost-lint/src/config.rs
+++ b/cargo-cost-lint/src/config.rs
@@ -1,85 +1,18 @@
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::fs;
-use std::path::Path;
 
 #[derive(Deserialize, Debug, Default, Clone)]
-pub struct Config {
-    #[allow(dead_code)]
-    lints: Option<HashMap<String, String>>,
-}
-
-impl Config {
-    pub fn from_file_or_default(path: &Path) -> Self {
-        if !path.exists() {
-            return Config::default();
-        }
-        match fs::read_to_string(path) {
-            Ok(content) => toml::from_str::<Config>(&content).unwrap_or_default(),
-            Err(_) => Config::default(),
-        }
-    }
+pub struct BudgetConfig {
+    pub lints: Option<HashMap<String, String>>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
-    use tempfile::tempdir;
-
-    fn write_file(path: &Path, contents: &str) {
-        let mut f = File::create(path).unwrap();
-        f.write_all(contents.as_bytes()).unwrap();
-    }
-
-    #[test]
-    fn from_file_or_default_returns_default_for_missing_file() {
-        let dir = tempdir().unwrap();
-        let missing = dir.path().join("nonexistent.toml");
-        let config = Config::from_file_or_default(&missing);
-        assert!(config.lints.is_none());
-    }
-
-    #[test]
-    fn from_file_or_default_parses_valid_toml() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("budget.toml");
-        write_file(
-            &path,
-            r#"[lints]
-soroban_storage_in_loop = "deny"
-"#,
-        );
-        let config = Config::from_file_or_default(&path);
-        let lints = config.lints.expect("lints should be present");
-        assert_eq!(
-            lints.get("soroban_storage_in_loop").map(|s| s.as_str()),
-            Some("deny")
-        );
-    }
-
-    #[test]
-    fn from_file_or_default_handles_malformed_toml_gracefully() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("budget.toml");
-        write_file(&path, "this is not valid toml [[[");
-        let config = Config::from_file_or_default(&path);
-        assert!(config.lints.is_none());
-    }
-
-    #[test]
-    fn from_file_or_default_handles_empty_file() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("budget.toml");
-        write_file(&path, "");
-        let config = Config::from_file_or_default(&path);
-        assert!(config.lints.is_none());
-    }
 
     #[test]
     fn default_config_has_no_lints() {
-        let config = Config::default();
+        let config = BudgetConfig::default();
         assert!(config.lints.is_none());
     }
 }

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -338,19 +338,19 @@ fn main() {
 
     let mut findings: Vec<LintFinding> = Vec::new();
 
-    for line_str in reader.lines().map_while(Result::ok) {
-        if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&line_str) {
-            if msg.get("reason").and_then(|r| r.as_str()) == Some("compiler-message") {
-                if let Some(message) = msg.get("message") {
-                    if let Some(code) = message.get("code") {
+    for line in reader.lines().map_while(Result::ok) {
+        if let Ok(cargo_record) = serde_json::from_str::<serde_json::Value>(&line) {
+            if cargo_record.get("reason").and_then(|r| r.as_str()) == Some("compiler-message") {
+                if let Some(diagnostic) = cargo_record.get("message") {
+                    if let Some(code) = diagnostic.get("code") {
                         if let Some(lint_name) = code.get("code").and_then(|c| c.as_str()) {
                             if LINT_NAMES.contains(&lint_name) {
-                                let level = message
+                                let level = diagnostic
                                     .get("level")
                                     .and_then(|l| l.as_str())
                                     .unwrap_or("unknown");
 
-                                let diagnostic_message = message
+                                let diagnostic_message = diagnostic
                                     .get("message")
                                     .and_then(|m| m.as_str())
                                     .unwrap_or("");
@@ -362,7 +362,8 @@ fn main() {
                                     column_end: 0,
                                 };
 
-                                if let Some(spans) = message.get("spans").and_then(|s| s.as_array())
+                                if let Some(spans) =
+                                    diagnostic.get("spans").and_then(|s| s.as_array())
                                 {
                                     for span in spans {
                                         if span
@@ -395,26 +396,16 @@ fn main() {
                                                 .and_then(|c| c.as_u64())
                                                 .unwrap_or(0)
                                                 as usize;
-                                        span_obj.column_start = s
-                                            .get("column_start")
-                                            .and_then(|c| c.as_u64())
-                                            .unwrap_or(0)
-                                            as usize;
-                                        span_obj.column_end = s
-                                            .get("column_end")
-                                            .and_then(|c| c.as_u64())
-                                            .unwrap_or(0)
-                                            as usize;
-                                        break;
+                                            break;
+                                        }
                                     }
                                 }
-                            }
 
-                            // Only apply .lintignore filtering to known soroban lints.
-                            // Regular compiler diagnostics always pass through.
-                            if is_soroban_lint && !is_reportable(&file, &allowed) {
-                                continue;
-                            }
+                                // Only apply .lintignore filtering to known soroban lints.
+                                // Regular compiler diagnostics always pass through.
+                                if !is_reportable(&file, &allowed) {
+                                    continue;
+                                }
 
                                 *lint_counts.entry(lint_name.to_string()).or_insert(0) += 1;
 
@@ -422,11 +413,10 @@ fn main() {
                                     highest_exit_code = 1;
                                 }
 
-                            if let Some(name) = lint_name {
                                 let mut help_text = None;
                                 let mut suggestion = None;
                                 if let Some(children) =
-                                    message.get("children").and_then(|c| c.as_array())
+                                    diagnostic.get("children").and_then(|c| c.as_array())
                                 {
                                     for child_item in children {
                                         if child_item.get("level").and_then(|l| l.as_str())
@@ -435,10 +425,11 @@ fn main() {
                                             let child_msg = child_item
                                                 .get("message")
                                                 .and_then(|m| m.as_str())
-                                                .map(|s| s.to_string());
+                                                .map(|text| text.to_string());
                                             help_text = child_msg.clone();
                                             if cli.fix {
-                                                suggestion = extract_suggestion(&child_msg, name);
+                                                suggestion =
+                                                    extract_suggestion(&child_msg, lint_name);
                                             }
                                             break;
                                         }
@@ -446,7 +437,7 @@ fn main() {
                                 }
 
                                 let finding = LintFinding {
-                                    name: name.to_string(),
+                                    name: lint_name.to_string(),
                                     level: level.to_string(),
                                     file: file.clone(),
                                     span: primary_span,
@@ -463,18 +454,12 @@ fn main() {
                                         println!("{}", json_str);
                                     }
                                 } else if cli.format != OutputFormat::Sarif {
-                                    let rendered = message
+                                    let rendered = diagnostic
                                         .get("rendered")
                                         .and_then(|r| r.as_str())
                                         .unwrap_or(diagnostic_message);
                                     print!("{}", rendered);
                                 }
-                            } else if cli.format != OutputFormat::Json {
-                                let rendered = message
-                                    .get("rendered")
-                                    .and_then(|r| r.as_str())
-                                    .unwrap_or(msg_text);
-                                print!("{}", rendered);
                             }
                         }
                     }

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -1,14 +1,14 @@
 use clap::{Parser, ValueEnum};
 use ignore::WalkBuilder;
 use serde::Serialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio, exit};
 
 mod config;
-use config::Config;
+use config::BudgetConfig;
 
 /// Output format for lint results.
 #[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
@@ -57,7 +57,7 @@ struct SarifReport {
 #[derive(Serialize)]
 struct SarifRun {
     tool: SarifTool,
-    results: Vec<serde_json::Value>,
+    results: Vec<SarifResult>,
 }
 
 /// Tool metadata for SARIF output.
@@ -146,7 +146,10 @@ struct Cli {
     #[arg(long, help = "Path to budget.toml")]
     config: Option<String>,
 
-    #[arg(long, help = "Emit the lint inventory and exit")]
+    #[arg(
+        long,
+        help = "List all registered lints with their default levels and descriptions"
+    )]
     list_lints: bool,
 
     #[arg(long, value_enum, default_value_t = OutputFormat::Text, help = "Output format")]
@@ -154,16 +157,11 @@ struct Cli {
 
     #[arg(long, help = "Automatically apply fixable lint suggestions")]
     fix: bool,
-
-    #[arg(
-        long,
-        help = "List all registered lints with their default levels and descriptions"
-    )]
-    list_lints: bool,
 }
 
 include!(concat!(env!("OUT_DIR"), "/lint_names.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_metadata.rs"));
+include!(concat!(env!("OUT_DIR"), "/lint_info.rs"));
 
 /// Walks `root`, respecting `.gitignore` and `.lintignore`, and returns the
 /// canonicalized set of files that are allowed to be linted (i.e. not
@@ -192,15 +190,6 @@ fn is_reportable(file: &str, allowed: &HashSet<PathBuf>) -> bool {
         Ok(canon) => allowed.contains(&canon),
         Err(_) => true,
     }
-}
-
-fn load_budget_config(config_path: &Path) -> Option<BudgetConfig> {
-    if !config_path.exists() {
-        return None;
-    }
-
-    let config_str = fs::read_to_string(config_path).ok()?;
-    toml::from_str::<BudgetConfig>(&config_str).ok()
 }
 
 fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
@@ -242,6 +231,7 @@ fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
     Ok(lint_flags)
 }
 
+#[allow(clippy::collapsible_if)]
 fn main() {
     let mut args = std::env::args().collect::<Vec<_>>();
     if args.len() > 1 && args[1] == "cost-lint" {
@@ -273,13 +263,15 @@ fn main() {
 
     let allowed = allowed_files(Path::new("."));
 
-    let lint_flags: Vec<String> = Vec::new();
+    let mut lint_flags: Vec<String> = Vec::new();
     if let Some(config_path) = &cli.config {
-        if let Some(config) = load_budget_config(Path::new(config_path)) {
-            // ... validate (existing code)
-            let _ = config;
+        match parse_budget_config(config_path) {
+            Ok(flags) => lint_flags = flags,
+            Err(e) => {
+                eprintln!("{}", e);
+                exit(1);
+            }
         }
-        let _config = Config::from_file_or_default(Path::new(config_path));
     }
 
     let preflight = Command::new("cargo")
@@ -295,11 +287,6 @@ fn main() {
             eprintln!("    cargo install cargo-dylint dylint-link");
             exit(1);
         }
-        Some(config_path) => {
-            eprintln!("Warning: config file '{}' not found", config_path);
-            Vec::new()
-        }
-        None => Vec::new(),
     };
 
     let mut cmd = Command::new("cargo");
@@ -603,11 +590,11 @@ fn apply_fixes(findings: &[LintFinding]) {
             for (line_idx, _message, suggestion) in edits {
                 if *line_idx > 0 && *line_idx <= lines.len() {
                     let line = &mut lines[*line_idx - 1];
-                    if let Some(start) = line.find("Symbol::new") {
-                        if let Some(end) = line[start..].find(')') {
-                            let replace_end = start + end + 1;
-                            line.replace_range(start..replace_end, suggestion);
-                        }
+                    if let Some(start) = line.find("Symbol::new")
+                        && let Some(end) = line[start..].find(')')
+                    {
+                        let replace_end = start + end + 1;
+                        line.replace_range(start..replace_end, suggestion);
                     }
                 }
             }
@@ -725,7 +712,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("budget.toml");
         let mut file = fs::File::create(&path).unwrap();
-        writeln!(file, "this is not valid toml = {{{").unwrap();
+        writeln!(file, "this is not valid toml = {{{{{{").unwrap();
         drop(file);
 
         let result = parse_budget_config(&path.to_string_lossy());

--- a/cargo-cost-lint/tests/integration.rs
+++ b/cargo-cost-lint/tests/integration.rs
@@ -26,14 +26,20 @@ fn test_list_lints() {
     // update this array as well.
     let expected_lints = &[
         "soroban_storage_in_loop",
+        "loop_invariant_storage_access",
+        "unbounded_input_loop",
         "redundant_env_clone",
         "unnecessary_host_function_call",
         "host_in_loop",
         "symbol_new_for_short_literal",
+        "unnecessary_string_to_bytes",
         "storage_write_without_read",
         "inefficient_bytes_concat",
         "map_insert_in_loop",
         "bytes_append_in_loop",
+        "signature_verification_in_loop",
+        "storage_key_construction_in_loop",
+        "vec_where_slice_could_be_used",
     ];
 
     for expected in expected_lints {

--- a/cargo-cost-lint/tests/real_world_corpus.rs
+++ b/cargo-cost-lint/tests/real_world_corpus.rs
@@ -70,7 +70,14 @@ fn run_lints_on_contract(contract_dir: &Path) -> Vec<Finding> {
         .output()
         .expect("Failed to execute cargo-cost-lint");
 
-    if !output.status.success() {
+    let stdout_str = String::from_utf8(output.stdout).expect("Stdout is not valid UTF-8");
+
+    // A non-zero exit can mean cargo-cost-lint genuinely failed to run, or
+    // that a `deny`-level lint fired and correctly failed the underlying
+    // `cargo check` — findings were already streamed to stdout before the
+    // process exited in that case. Only treat this as a hard failure when
+    // there's nothing to show for it.
+    if !output.status.success() && stdout_str.trim().is_empty() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         panic!(
             "cargo-cost-lint failed on {:?}:\n{}",
@@ -79,7 +86,6 @@ fn run_lints_on_contract(contract_dir: &Path) -> Vec<Finding> {
         );
     }
 
-    let stdout_str = String::from_utf8(output.stdout).expect("Stdout is not valid UTF-8");
     let findings: Vec<Finding> = stdout_str
         .lines()
         .filter(|l| !l.is_empty())

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -437,6 +437,9 @@ pub const LINT_METADATA: &[LintMetadata] = &[
     },
     LintMetadata {
         lint: LOOP_INVARIANT_STORAGE_ACCESS,
+        category: LintCategory::StorageOperations,
+    },
+    LintMetadata {
         lint: UNBOUNDED_INPUT_LOOP,
         category: LintCategory::StorageOperations,
     },

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -73,6 +73,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::DefId;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 dylint_linting::dylint_library!();
 
@@ -1302,7 +1303,7 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
         /// receiver-snippet and key-snippet for later cross-referencing.
         struct ReadVisitor<'a, 'tcx> {
             cx: &'a LateContext<'tcx>,
-            reads: Vec<(String, String)>,
+            reads: HashSet<(String, String)>,
         }
 
         impl<'a, 'tcx> Visitor<'tcx> for ReadVisitor<'a, 'tcx> {
@@ -1327,7 +1328,7 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
                         let receiver_snippet =
                             snippet_opt(self.cx, receiver.span).unwrap_or_default();
                         let key_snippet = snippet_opt(self.cx, args[0].span).unwrap_or_default();
-                        self.reads.push((receiver_snippet, key_snippet));
+                        self.reads.insert((receiver_snippet, key_snippet));
                     }
                 }
                 intravisit::walk_expr(self, expr);
@@ -1366,7 +1367,7 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
             }
         }
 
-        let reads = Vec::new();
+        let reads = HashSet::new();
         let writes = Vec::new();
         let mut read_visitor = ReadVisitor { cx, reads };
         read_visitor.visit_body(body);
@@ -1377,8 +1378,7 @@ impl<'tcx> LateLintPass<'tcx> for StorageWriteWithoutRead {
         for (w_receiver, w_key, w_span) in &write_visitor.writes {
             let has_read = read_visitor
                 .reads
-                .iter()
-                .any(|(r_receiver, r_key)| r_receiver == w_receiver && r_key == w_key);
+                .contains(&(w_receiver.clone(), w_key.clone()));
             if !has_read {
                 span_lint_and_help(
                     cx,
@@ -1698,4 +1698,52 @@ impl<'tcx> LateLintPass<'tcx> for VecWhereSliceCouldBeUsed {
 #[test]
 fn ui() {
     dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+}
+
+/// Benchmarks the read/write matching lookup backing
+/// [`STORAGE_WRITE_WITHOUT_READ`] — a `HashSet::contains` lookup (current)
+/// against the `Vec::iter().any()` scan it replaced — on synthetic data
+/// sized to approximate a function body with many storage operations.
+/// Not a correctness test beyond the parity assertion: mirrors
+/// `cargo-cost-lint/benches/linter_performance.rs`'s `Instant`-based,
+/// no-hard-assertion-on-timing reporting style, since this workspace has
+/// no Criterion dependency.
+#[test]
+fn storage_write_without_read_lookup_benchmark() {
+    const N: usize = 500;
+
+    let reads: HashSet<(String, String)> = (0..N)
+        .map(|i| (format!("storage_{}", i % 7), format!("key_{i}")))
+        .collect();
+    let writes: Vec<(String, String)> = (0..N)
+        .map(|i| (format!("storage_{}", i % 7), format!("other_key_{i}")))
+        .collect();
+    let reads_vec: Vec<(String, String)> = reads.iter().cloned().collect();
+
+    let started = std::time::Instant::now();
+    let hashset_misses = writes
+        .iter()
+        .filter(|(receiver, key)| !reads.contains(&(receiver.clone(), key.clone())))
+        .count();
+    let hashset_elapsed = started.elapsed();
+
+    let started = std::time::Instant::now();
+    let vec_misses = writes
+        .iter()
+        .filter(|(w_receiver, w_key)| {
+            !reads_vec
+                .iter()
+                .any(|(r_receiver, r_key)| r_receiver == w_receiver && r_key == w_key)
+        })
+        .count();
+    let vec_elapsed = started.elapsed();
+
+    assert_eq!(
+        hashset_misses, vec_misses,
+        "HashSet and Vec lookups must agree on which writes are missing a read"
+    );
+
+    eprintln!(
+        "storage_write_without_read_lookup/{N}x{N}: hashset={hashset_elapsed:?} vec_scan={vec_elapsed:?}"
+    );
 }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -934,8 +934,8 @@ impl<'tcx> LateLintPass<'tcx> for SymbolNewForShortLiteral {
             if let hir::ExprKind::Lit(lit) = args[1].kind
                 && let LitKind::Str(symbol, _) = lit.node
             {
-                let s = symbol.as_str();
-                if is_valid_short_symbol(s) {
+                let symbol_str = symbol.as_str();
+                if is_valid_short_symbol(symbol_str) {
                     // Check if there's a valid suggestion
                     if let Some(snippet) = snippet_opt(cx, args[1].span) {
                         let suggestion = format!("symbol_short!({})", snippet);
@@ -1255,11 +1255,13 @@ impl<'tcx> LateLintPass<'tcx> for BytesAppendInLoop {
 }
 
 /// Check if a string is a valid short symbol (<= 9 chars, only a-zA-Z0-9_)
-fn is_valid_short_symbol(s: &str) -> bool {
-    if s.len() > 9 || s.is_empty() {
+fn is_valid_short_symbol(symbol_str: &str) -> bool {
+    if symbol_str.len() > 9 || symbol_str.is_empty() {
         return false;
     }
-    s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    symbol_str
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 // =======================================================================


### PR DESCRIPTION
Closes #199

## Summary
`StorageWriteWithoutRead`'s `check_fn` (the lint pass backing `storage_write_without_read`) tracked storage reads in a `Vec<(String, String)>`, then for every write did a `Vec::iter().any()` linear scan over all reads to check for a match — O(reads × writes) per function body. A function body with many storage operations (realistic for batch-init/migration-style contract code) scales quadratically.

Searched the rest of the codebase for similar linear-scan state tracking before settling on this target — everything else was either already using a hash-based structure (`HirIdSet`/`FxHashSet` in a few other lint passes), or a `.contains()` on a small fixed-size constant array where a HashSet wouldn't help.

## Changes
### `soroban_cost_lints/src/lib.rs`
- `ReadVisitor::reads` changed from `Vec<(String, String)>` to `HashSet<(String, String)>`.
- The write-matching check changed from `reads.iter().any(|(r,k)| ...)` to `reads.contains(&(...))` — same unordered membership-test semantics, no behavior change.
- Added a synthetic before/after benchmark (`storage_write_without_read_lookup_benchmark`) sized at 500 reads / 500 writes, following this repo's existing `Instant`-based, no-Criterion convention (see `cargo-cost-lint/benches/linter_performance.rs`). It also asserts both approaches agree on which writes are flagged, as a correctness-parity check.

## Benchmark results
On this workspace's hardware, 500×500 synthetic reads/writes:
```
storage_write_without_read_lookup/500x500: hashset=386.1µs vec_scan=6.884523ms
```
~18x faster, consistent with the expected O(n) vs O(n²) difference.

## Note on branch base
Stacked on `refactor/task-16` (#301) since `main` currently has pre-existing compile errors that block the crate from building (see #301) — its commits are included here so this PR is independently buildable/testable. Rebasing after #301 merges will drop the redundant commits from the diff.

## Verification
- `cargo fmt --all -- --check` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo test -p soroban_cost_lints --lib storage_write_without_read_lookup_benchmark` passes