### PR TITLE
feat: add --explain subcommand backed by embedded lint doc pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ cargo +<channel-from-rust-toolchain> install --git https://github.com/Tollcraft/
 | `--config <PATH>` | Path to `budget.toml` for lint-level overrides |
 | `--format <text\|json>` | Output format (default: `text`) |
 | `--list-lints` | Print every registered lint with its default level and one-line description, then exit |
+| `--explain <LINT>` | Print the full documentation for a specific lint (what it does, why it's expensive, suggested fix) and exit |
 | `--version` | Print the crate version and exit |
 
 ### Running the linter

--- a/cargo-cost-lint/build.rs
+++ b/cargo-cost-lint/build.rs
@@ -101,6 +101,22 @@ fn parse_declare_lints(content: &str) -> Vec<LintMeta> {
     results
 }
 
+fn raw_string_literal(s: &str) -> String {
+    // Find the smallest n such that " followed by n # signs does not appear
+    // in the string, so r###"..."### is a valid raw string literal.
+    let mut hashes: usize = 0;
+    loop {
+        let needle: String = format!("\"{}", "#".repeat(hashes));
+        if s.contains(&needle) {
+            hashes += 1;
+        } else {
+            break;
+        }
+    }
+    let hash_str = "#".repeat(hashes);
+    format!("r{hash_str}\"{}\"{hash_str}", s, hash_str = hash_str)
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=../soroban_cost_lints/src/lib.rs");
 
@@ -140,6 +156,32 @@ fn main() {
                 meta.name
             );
         }
+    }
+
+    // --- Verify every registered lint has a corresponding doc file ---
+    let docs_dir = "../docs/lints";
+    for name in &names {
+        let doc_path = format!("{}/{}.md", docs_dir, name);
+        assert!(
+            Path::new(&doc_path).exists(),
+            "lint '{}' is registered but has no doc file at '{}'. \
+             Create a documentation page at docs/lints/{}.md to explain \
+             what the lint does, why it is expensive, and how to fix it.",
+            name,
+            doc_path,
+            name
+        );
+    }
+
+    // --- Read each doc file and embed as raw string literals ---
+    let mut explanations: Vec<(String, String)> = Vec::new();
+    for name in &names {
+        let doc_path = format!("{}/{}.md", docs_dir, name);
+        let doc_content = fs::read_to_string(&doc_path)
+            .unwrap_or_else(|e| panic!("Failed to read doc file '{}': {}", doc_path, e));
+        // Notify cargo to re-run build.rs when any doc file changes
+        println!("cargo:rerun-if-changed={}", doc_path);
+        explanations.push((name.clone(), doc_content));
     }
 
     let mut declarations = Vec::new();
@@ -192,6 +234,7 @@ fn main() {
     let names_path = Path::new(&out_dir).join("lint_names.rs");
     let metadata_path = Path::new(&out_dir).join("lint_metadata.rs");
     let info_path = Path::new(&out_dir).join("lint_info.rs");
+    let explanations_path = Path::new(&out_dir).join("lint_explanations.rs");
 
     let mut names_out = String::new();
     names_out.push_str("pub const LINT_NAMES: &[&str] = &[\n");
@@ -241,4 +284,21 @@ fn main() {
     metadata_out.push_str("    ],\n");
     metadata_out.push_str("};\n");
     fs::write(&metadata_path, metadata_out).expect("Failed to write lint_metadata.rs");
+
+    // --- Write lint_explanations.rs with embedded doc content as raw string literals ---
+    let mut explanations_out = String::new();
+    explanations_out.push_str("pub struct LintExplanation {\n");
+    explanations_out.push_str("    pub name: &'static str,\n");
+    explanations_out.push_str("    pub markdown: &'static str,\n");
+    explanations_out.push_str("}\n\n");
+    explanations_out.push_str("pub const LINT_EXPLANATIONS: &[LintExplanation] = &[\n");
+    for (name, content) in &explanations {
+        let escaped = raw_string_literal(content);
+        explanations_out.push_str("    LintExplanation {\n");
+        explanations_out.push_str(&format!("        name: \"{}\",\n", name));
+        explanations_out.push_str(&format!("        markdown: {},\n", escaped));
+        explanations_out.push_str("    },\n");
+    }
+    explanations_out.push_str("];\n");
+    fs::write(&explanations_path, explanations_out).expect("Failed to write lint_explanations.rs");
 }

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -152,6 +152,12 @@ struct Cli {
     )]
     list_lints: bool,
 
+    #[arg(
+        long,
+        help = "Explain a specific lint by name, printing its documentation"
+    )]
+    explain: Option<String>,
+
     #[arg(long, value_enum, default_value_t = OutputFormat::Text, help = "Output format")]
     format: OutputFormat,
 
@@ -162,6 +168,7 @@ struct Cli {
 include!(concat!(env!("OUT_DIR"), "/lint_names.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_metadata.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_info.rs"));
+include!(concat!(env!("OUT_DIR"), "/lint_explanations.rs"));
 
 /// Walks `root`, respecting `.gitignore` and `.lintignore`, and returns the
 /// canonicalized set of files that are allowed to be linted (i.e. not
@@ -242,6 +249,11 @@ fn main() {
         for info in LINT_INFO {
             println!("{}\t{}\t{}", info.name, info.level, info.description);
         }
+        return;
+    }
+
+    if let Some(lint_name) = &cli.explain {
+        print_explanation(lint_name);
         return;
     }
 
@@ -590,6 +602,76 @@ fn apply_fixes(findings: &[LintFinding]) {
     }
 }
 
+/// Prints the explanation for a lint, or errors with valid lint names if not found.
+fn print_explanation(lint_name: &str) {
+    let normalized = lint_name.to_lowercase();
+
+    let explanation = LINT_EXPLANATIONS
+        .iter()
+        .find(|e| e.name == normalized);
+
+    match explanation {
+        Some(entry) => {
+            // Clean up the markdown for terminal display
+            let cleaned = clean_markdown_for_terminal(entry.markdown);
+            println!("{}", cleaned);
+        }
+        None => {
+            eprintln!(
+                "Error: unknown lint '{}'.\n\nValid lints:\n",
+                lint_name
+            );
+            for info in LINT_INFO {
+                eprintln!("  {} — {}", info.name, info.description);
+            }
+            exit(1);
+        }
+    }
+}
+
+/// Strips GitBook-specific hint syntax and lightens the markdown for plain
+/// terminal output. The result is still markdown-ish but without block-level
+/// tags that only render on a documentation site.
+fn clean_markdown_for_terminal(markdown: &str) -> String {
+    let mut result = String::new();
+    let mut in_code_block = false;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+
+        // Track code-fence boundaries so we don't strip inside them
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        if in_code_block {
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        // Strip GitBook hint tags and their content delimiters
+        if trimmed.starts_with("{% hint")
+            || trimmed.starts_with("{% endhint")
+            || trimmed.ends_with("%}") && !line.starts_with("    ")
+        {
+            // Skip hint markers entirely
+            continue;
+        }
+
+        // Replace bold markers with plain text for terminal
+        let cleaned = line.replace("**", "");
+
+        result.push_str(&cleaned);
+        result.push('\n');
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -674,6 +756,99 @@ mod tests {
     fn is_reportable_keeps_empty_file_field() {
         let allowed: HashSet<PathBuf> = HashSet::new();
         assert!(is_reportable("", &allowed));
+    }
+
+    #[test]
+    fn every_registered_lint_has_explanation_text() {
+        for info in LINT_INFO {
+            let explanation = LINT_EXPLANATIONS
+                .iter()
+                .find(|e| e.name == info.name);
+            assert!(
+                explanation.is_some(),
+                "lint '{}' is registered but has no explanation text. \
+                 Add a documentation page at docs/lints/{}.md",
+                info.name,
+                info.name
+            );
+            if let Some(entry) = explanation {
+                assert!(
+                    !entry.markdown.is_empty(),
+                    "lint '{}' has an empty explanation text",
+                    info.name
+                );
+            }
+        }
+    }
+
+    /// Verifies that document has at least the structure of valid markdown
+    /// by checking it contains the key sections.
+    #[test]
+    fn every_explanation_has_key_sections() {
+        for entry in LINT_EXPLANATIONS {
+            assert!(
+                entry.markdown.contains("## What it does"),
+                "lint '{}' explanation is missing 'What it does' section",
+                entry.name
+            );
+            assert!(
+                entry.markdown.contains("## Why is this bad")
+                    || entry.markdown.contains("## Why is this bad?"),
+                "lint '{}' explanation is missing 'Why is this bad' section",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn print_explanation_known_lint_succeeds() {
+        // Test that the first registered lint's explanation resolves
+        // correctly and produces terminal-clean output.
+        let first = LINT_INFO.first().expect("at least one lint registered");
+        let explanation = LINT_EXPLANATIONS
+            .iter()
+            .find(|e| e.name == first.name);
+        assert!(
+            explanation.is_some(),
+            "lint '{}' should have explanation",
+            first.name
+        );
+        let entry = explanation.unwrap();
+        assert!(!entry.markdown.is_empty(), "explanation should not be empty");
+        // The cleaned output should not contain GitBook hint tags
+        let cleaned = clean_markdown_for_terminal(entry.markdown);
+        assert!(
+            !cleaned.contains("{% hint"),
+            "cleaned output should not contain GitBook hint tags"
+        );
+    }
+
+    #[test]
+    fn clean_markdown_removes_hint_tags() {
+        let input = "{% hint style=\"danger\" %}\nSome content\n{% endhint %}";
+        let cleaned = clean_markdown_for_terminal(input);
+        assert!(
+            !cleaned.contains("{% hint"),
+            "hint open tag should be removed"
+        );
+        assert!(
+            !cleaned.contains("{% endhint"),
+            "endhint tag should be removed"
+        );
+        // Content between hint tags should remain
+        assert!(
+            cleaned.contains("Some content"),
+            "content between hint tags should remain"
+        );
+    }
+
+    #[test]
+    fn clean_markdown_preserves_code_blocks() {
+        let input = "```rust\nlet x = 1;\n```";
+        let cleaned = clean_markdown_for_terminal(input);
+        assert!(cleaned.contains("```rust"), "code fence start should remain");
+        assert!(cleaned.contains("let x = 1;"), "code content should remain");
+        assert!(cleaned.contains("```"), "code fence end should remain");
     }
 
     #[test]

--- a/cargo-cost-lint/tests/integration.rs
+++ b/cargo-cost-lint/tests/integration.rs
@@ -252,6 +252,115 @@ fn test_cli_workspace_lints_all_contracts() {
 }
 
 #[test]
+fn test_explain_known_lint() {
+    let bin_path = env!("CARGO_BIN_EXE_cargo-cost-lint");
+
+    let output = Command::new(bin_path)
+        .arg("--explain")
+        .arg("soroban_storage_in_loop")
+        .output()
+        .expect("Failed to execute cargo-cost-lint --explain");
+
+    assert!(
+        output.status.success(),
+        "--explain should exit 0 for known lint, got: {}",
+        output.status
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is not valid UTF-8");
+
+    // Should contain key sections from the doc
+    assert!(
+        stdout.contains("What it does"),
+        "output should contain 'What it does' section. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Why is this bad"),
+        "output should contain 'Why is this bad' section. Output: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Suggested Fix"),
+        "output should contain 'Suggested Fix' section. Output: {}",
+        stdout
+    );
+
+    // Should NOT contain GitBook hint syntax
+    assert!(
+        !stdout.contains("{% hint"),
+        "output should not contain raw GitBook hint tags. Output: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_explain_unknown_lint_exits_with_error() {
+    let bin_path = env!("CARGO_BIN_EXE_cargo-cost-lint");
+
+    let output = Command::new(bin_path)
+        .arg("--explain")
+        .arg("nonexistent_lint")
+        .output()
+        .expect("Failed to execute cargo-cost-lint --explain");
+
+    assert!(
+        !output.status.success(),
+        "--explain should exit with error for unknown lint"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr is not valid UTF-8");
+
+    // Should mention the unknown lint name
+    assert!(
+        stderr.contains("nonexistent_lint"),
+        "error should mention the unknown lint name. Stderr: {}",
+        stderr
+    );
+    // Should mention valid lint names
+    assert!(
+        stderr.contains("Valid lints"),
+        "error should list valid lints. Stderr: {}",
+        stderr
+    );
+    // Should mention at least one known lint
+    assert!(
+        stderr.contains("soroban_storage_in_loop"),
+        "error should include known lints. Stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_explain_flag_does_not_run_lint_pass() {
+    // --explain should exit immediately without invoking cargo dylint,
+    // even if run in a directory without a Cargo project.
+    let bin_path = env!("CARGO_BIN_EXE_cargo-cost-lint");
+
+    // Use tmpdir so there's no Cargo.toml
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = Command::new(bin_path)
+        .arg("--explain")
+        .arg("redundant_env_clone")
+        .current_dir(dir.path())
+        .output()
+        .expect("Failed to execute cargo-cost-lint --explain");
+
+    assert!(
+        output.status.success(),
+        "--explain should succeed even outside a Cargo project, got: {}",
+        output.status
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is not valid UTF-8");
+    assert!(
+        stdout.contains("redundant_env_clone"),
+        "explain should print content for redundant_env_clone"
+    );
+}
+
+#[test]
 fn test_sarif_output() {
     let bin_path = env!("CARGO_BIN_EXE_cargo-cost-lint");
 

--- a/docs/lints/unbounded_input_loop.md
+++ b/docs/lints/unbounded_input_loop.md
@@ -1,0 +1,47 @@
+# `unbounded_input_loop`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [Storage — ledger entry accesses and CPU](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Flags loops whose iteration count is derived from an untrusted function parameter and whose body performs a storage write. Such loops can be abused to exhaust the contract's CPU and memory budget.
+
+## Why is this bad?
+
+{% hint style="danger" %}
+Loops that iterate an unbounded number of times based on untrusted input present a denial-of-service vector. An attacker can craft input that forces the loop to run thousands or millions of iterations, each performing a metered storage write, quickly exhausting the contract's resource budget. See the [Cost Rationale — Storage](../cost_rationale.md#3-storage-ledger-entry-accesses-and-ledger-io) for details.
+{% endhint %}
+
+## Example
+
+```rust
+// ❌ Bad: loop bound comes from untrusted input
+pub fn process(env: Env, items: Vec<u32>) {
+    for item in items.iter() {
+        env.storage().instance().set(&item, &1u32);
+    }
+}
+```
+
+```rust
+// ✅ Good: bound is clamped to a safe constant
+pub fn process(env: Env, items: Vec<u32>) {
+    let max_items = 100;
+    let count = items.len().min(max_items);
+    for i in 0..count {
+        env.storage().instance().set(&i, &1u32);
+    }
+}
+```
+
+## Cost impact
+
+An unbound loop whose iteration count is attacker-controlled can execute as many storage writes as the caller's budget allows, potentially draining the contract's available CPU and memory resources.
+
+## Suggested Fix
+
+{% hint style="success" %}
+Clamp the loop bound with `.min(CONST)` or validate the input size before using it as a loop bound. Alternatively, process items in batches with a bounded number per invocation.
+{% endhint %}


### PR DESCRIPTION
Closes #103 

## Summary

Adds a `--explain <LINT_NAME>` flag to `cargo cost-lint` that prints a lint's full documentation (what it does, why it's expensive, suggested fix) by embedding the markdown doc pages at build time. Exits 0 without running a lint pass.

## What changed

### Design decision: embed docs at build time

The markdown files under `docs/lints/` are the single source of truth. `build.rs` reads each registered lint's doc file at build time and embeds the content as Rust raw string literals (`r#"..."#`). This ensures:
- CLI output and doc pages can never drift apart
- Build.rs panics if a registered lint has no corresponding doc file (CI fails immediately)
- No additional runtime dependencies or filesystem access needed

### Files changed

- **`cargo-cost-lint/build.rs`**: Added `raw_string_literal()` helper; verify every registered lint has a doc file; generate `lint_explanations.rs` with embedded markdown
- **`cargo-cost-lint/src/main.rs`**: Added `--explain <LINT>` CLI arg; `print_explanation()` lookup + terminal-friendly output; `clean_markdown_for_terminal()` strips GitBook hint syntax; unit tests for explanation integrity and markdown cleaning
- **`cargo-cost-lint/tests/integration.rs`**: Integration tests for known-lint success, unknown-lint error, and no-lint-pass outside Cargo project
- **`docs/lints/unbounded_input_loop.md`**: Created missing doc page for the `unbounded_input_loop` lint that was registered without documentation
- **`README.md`**: Documented the `--explain` flag in the CLI flags table

## Acceptance Criteria Checklist

- [x] `cargo cost-lint --explain soroban_storage_in_loop` prints what-it-does, why-it-is-expensive, and suggested fix, exits 0
- [x] Unknown lint name errors with a list of valid lint names
- [x] Single source of truth: docs embedded at build time from `docs/lints/*.md`
- [x] Test asserts every registered lint has retrievable explanation text (two layers: build.rs panics + unit test)
- [x] `README.md` documents the flag

## Test output

Could not run tests in this environment (no Rust toolchain installed). The following commands should pass on a machine with the pinned nightly:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --package cargo-cost-lint
```

## Follow-ups

None required. The `--explain` subcommand is self-contained and does not affect the linting pipeline.

## Security note

No new dependencies or unsafe code. The doc embedding operates at build time on trusted files within the repository.


