### PR TITLE
fix: detect storage operations inside iterator closures in storage_in_loop

### DIFF
--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -593,9 +593,9 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
     ///
     /// Storage access is metered on every iteration, so performing it in a loop
     /// multiplies the cost. The receiver type is matched against
-    /// [`SOROBAN_STORAGE_TYPES`]; the loop check uses [`enclosing_loop`]. No
-    /// suggestion is offered because the fix (hoisting or batching) is
-    /// context-specific, so only a help note is emitted.
+    /// [`SOROBAN_STORAGE_TYPES`]; the loop-or-closure check uses
+    /// [`enclosing_loop_or_closure`]. No suggestion is offered because the fix
+    /// (hoisting or batching) is context-specific, so only a help note is emitted.
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
         // --- Direct storage access in a loop ---
         if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
@@ -619,7 +619,7 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
                     false
                 };
 
-            if is_storage_access && enclosing_loop(cx, expr).is_some() {
+            if is_storage_access && enclosing_loop_or_closure(cx, expr).is_some() {
                 // Reads (`get`, `has`) and writes (`set`) deserve different
                 // advice: writes can be buffered and flushed once after the
                 // loop, but a loop-variant read cannot be accumulated — the
@@ -643,7 +643,7 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
 
         // --- Inter-procedural: call that transitively reaches storage ---
         if let hir::ExprKind::Call(_callee, _args) = expr.kind
-            && enclosing_loop(cx, expr).is_some()
+            && enclosing_loop_or_closure(cx, expr).is_some()
         {
             let mut visited: Vec<DefId> = Vec::new();
             if let Some(callee_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)

--- a/soroban_cost_lints/ui/soroban_storage_in_loop.rs
+++ b/soroban_cost_lints/ui/soroban_storage_in_loop.rs
@@ -86,12 +86,31 @@ fn good_storage_multiple_outside(env: Env) {
     env.storage().instance().set(&2, &2); // Good
 }
 
-// Note: The lint currently relies on `hir::ExprKind::Loop` and does not
-// trigger inside closure-based iterators like `for_each`. This is an acceptable
-// limitation for now unless explicitly requested. However, we document the behavior here.
-fn storage_in_closure(env: Env) {
+fn bad_storage_in_for_each_closure(env: Env) {
     (0..3).for_each(|i| {
-        env.storage().instance().set(&i, &1);
+        env.storage().instance().set(&i, &1); // Should Warn
+    });
+}
+
+fn bad_storage_in_map_closure(env: Env) {
+    let items = vec![1, 2, 3];
+    items.iter().map(|x| {
+        env.storage().instance().set(x, &1); // Should Warn
+    }).count();
+}
+
+fn bad_storage_in_fold_closure(env: Env) {
+    let items = vec![1, 2, 3];
+    items.iter().fold(0, |acc, x| {
+        env.storage().instance().set(x, &acc); // Should Warn
+        acc + 1
+    });
+}
+
+fn good_storage_in_option_map(env: Env) {
+    let opt = Some(42);
+    opt.map(|x| {
+        env.storage().instance().set(&x, &1); // Good — Option::map calls at most once
     });
 }
 

--- a/soroban_cost_lints/ui/soroban_storage_in_loop.stderr
+++ b/soroban_cost_lints/ui/soroban_storage_in_loop.stderr
@@ -1,98 +1,221 @@
-warning: storage operation inside a loop
+warning: storage write without a corresponding read
+  --> $DIR/soroban_storage_in_loop.rs:51:34
+   |
+LL |         env.storage().instance().set(&i, &1); // Should Warn
+   |                                  ^^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+   = note: `#[warn(storage_write_without_read)]` on by default
+
+error: storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:51:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move storage operations out of the loop or accumulate mutations in memory first
-   = note: `#[warn(soroban_storage_in_loop)]` on by default
+   = note: `#[deny(soroban_storage_in_loop)]` on by default
 
-warning: storage operation inside a loop
+warning: loop-invariant storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:51:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: hoist this storage operation out of the loop
+   = note: `#[warn(loop_invariant_storage_access)]` on by default
 
-warning: storage operation inside a loop
+warning: loop-invariant storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:51:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: hoist this storage operation out of the loop
 
-warning: storage operation inside a loop
+error: storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:58:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible
 
-warning: storage operation inside a loop
+warning: loop-invariant storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:58:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: hoist this storage operation out of the loop
 
-warning: storage operation inside a loop
+warning: loop-invariant storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:58:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: hoist this storage operation out of the loop
 
-warning: storage operation inside a loop
+error: storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:65:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible
 
-warning: storage operation inside a loop
+warning: loop-invariant storage operation inside a loop
+  --> $DIR/soroban_storage_in_loop.rs:65:12
+   |
+LL |         if env.storage().temporary().has(&1) { // Should Warn
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: hoist this storage operation out of the loop
+
+warning: loop-invariant storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:65:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: hoist this storage operation out of the loop
 
-warning: storage operation inside a loop
+warning: loop-invariant storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:65:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: hoist this storage operation out of the loop
 
-warning: storage operation inside a loop
+error: storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:74:13
    |
 LL |             env.storage().instance().has(&i); // Should Warn
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible
 
-warning: storage operation inside a loop
+warning: loop-invariant storage operation inside a loop
+  --> $DIR/soroban_storage_in_loop.rs:74:13
+   |
+LL |             env.storage().instance().has(&i); // Should Warn
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: hoist this storage operation out of the loop
+
+warning: loop-invariant storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:74:13
    |
 LL |             env.storage().instance().has(&i); // Should Warn
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move storage operations out of the loop or accumulate mutations in memory first
+   = help: hoist this storage operation out of the loop
 
-warning: storage operation inside a loop
+warning: loop-invariant storage operation inside a loop
   --> $DIR/soroban_storage_in_loop.rs:74:13
    |
 LL |             env.storage().instance().has(&i); // Should Warn
    |             ^^^^^^^^^^^^^
    |
+   = help: hoist this storage operation out of the loop
+
+warning: storage write without a corresponding read
+  --> $DIR/soroban_storage_in_loop.rs:80:30
+   |
+LL |     env.storage().instance().set(&1, &1); // Good
+   |                              ^^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+
+warning: storage write without a corresponding read
+  --> $DIR/soroban_storage_in_loop.rs:86:30
+   |
+LL |     env.storage().instance().set(&2, &2); // Good
+   |                              ^^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+
+warning: storage write without a corresponding read
+  --> $DIR/soroban_storage_in_loop.rs:91:34
+   |
+LL |         env.storage().instance().set(&i, &1); // Should Warn
+   |                                  ^^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+
+error: storage operation inside a loop
+  --> $DIR/soroban_storage_in_loop.rs:91:9
+   |
+LL |         env.storage().instance().set(&i, &1); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
-warning: 12 warnings emitted
+warning: storage write without a corresponding read
+  --> $DIR/soroban_storage_in_loop.rs:98:34
+   |
+LL |         env.storage().instance().set(x, &1); // Should Warn
+   |                                  ^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+
+error: storage operation inside a loop
+  --> $DIR/soroban_storage_in_loop.rs:98:9
+   |
+LL |         env.storage().instance().set(x, &1); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: move storage operations out of the loop or accumulate mutations in memory first
+
+warning: storage write without a corresponding read
+  --> $DIR/soroban_storage_in_loop.rs:105:34
+   |
+LL |         env.storage().instance().set(x, &acc); // Should Warn
+   |                                  ^^^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+
+error: storage operation inside a loop
+  --> $DIR/soroban_storage_in_loop.rs:105:9
+   |
+LL |         env.storage().instance().set(x, &acc); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: move storage operations out of the loop or accumulate mutations in memory first
+
+warning: storage write without a corresponding read
+  --> $DIR/soroban_storage_in_loop.rs:113:34
+   |
+LL |         env.storage().instance().set(&x, &1); // Good — Option::map calls at most once
+   |                                  ^^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+
+warning: storage write without a corresponding read
+  --> $DIR/soroban_storage_in_loop.rs:120:34
+   |
+LL |         env.storage().instance().set(&i, &1); // Good (allowed)
+   |                                  ^^^^^^^^^^^
+   |
+   = help: consider reading the value before writing or using `.has()` to check existence
+
+warning: loop-invariant storage operation inside a loop
+  --> $DIR/soroban_storage_in_loop.rs:120:9
+   |
+LL |         env.storage().instance().set(&i, &1); // Good (allowed)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: hoist this storage operation out of the loop
+
+warning: loop-invariant storage operation inside a loop
+  --> $DIR/soroban_storage_in_loop.rs:120:9
+   |
+LL |         env.storage().instance().set(&i, &1); // Good (allowed)
+   |         ^^^^^^^^^^^^^
+   |
+   = help: hoist this storage operation out of the loop
+
+error: aborting due to 7 previous errors; 20 warnings emitted
+


### PR DESCRIPTION
Closes #5

## Summary

Fixed soroban_storage_in_loop lint to detect storage operations inside iterator-adapter closures (for_each, map, fold) by switching from enclosing_loop to enclosing_loop_or_closure.

## Changes

- Core fix: In SorobanStorageInLoop::check_expr, replaced enclosing_loop(cx, expr) with enclosing_loop_or_closure(cx, expr) so the lint fires on both syntactic loops and multi-call closures (iterator adapters)
- UI test: Added test cases in soroban_storage_in_loop.rs for for_each, map, fold closures and Option::map negative case
- Updated soroban_storage_in_loop.stderr snapshot

## Acceptance Criteria

- Storage operations inside for_each closures are detected
- Storage operations inside map closures are detected
- Storage operations inside fold closures are detected
- Option::map closures remain clean (no false positive)
- Help message consistent with existing one
- UI tests pass