### PR TITLE
chore: add Makefile and CLI argument parser unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,13 +91,11 @@ If you prefer to set up the toolchain on your machine directly:
 
 4. **Run the full quality checks** (these must pass before opening a PR):
 
-   ```powershell
-   cargo fmt --all -- --check
-   cargo clippy --workspace --all-targets -- -D warnings
-   cargo test --workspace
-   ```
+    ```bash
+    make check
+    ```
 
-> **Note:** All `cargo` commands work identically in PowerShell, CMD, and Git Bash. If you use Git Bash, you can also use the `bash` code blocks above.
+    This runs `fmt`, `lint`, and `test` in sequence. See the [`Makefile`](./Makefile) for all available targets.
 
 ### 3. Adding a New Lint
 - Read the [Scope: Clippy vs. soroban-cost-linter](../docs/scope_boundary.md) guide first. If a pattern is already covered by a Clippy lint and the Soroban cost story does not change the analysis, do not duplicate it here.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: fmt lint test doc check
+
+fmt:
+	cargo fmt --all
+
+lint:
+	cargo clippy --workspace --all-targets -- -D warnings
+
+test:
+	cargo test --workspace
+
+doc:
+	cargo doc --no-deps --open
+
+check: fmt lint test

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -716,4 +716,52 @@ mod tests {
         assert!(result.is_err(), "expected Err for unknown level");
         assert!(result.unwrap_err().contains("Unknown lint level"));
     }
+
+    // --- CLI argument parser unit tests (issue #320) ---
+
+    #[test]
+    fn cli_default_values_when_no_flags() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint"]).expect("parsing should succeed");
+        assert_eq!(cli.config, None);
+        assert_eq!(cli.list_lints, false);
+        assert_eq!(cli.format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn cli_parses_config_flag() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--config", "my-budget.toml"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.config, Some("my-budget.toml".to_string()));
+    }
+
+    #[test]
+    fn cli_parses_list_lints_flag() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--list-lints"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.list_lints, true);
+        assert_eq!(cli.config, None);
+        assert_eq!(cli.format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn cli_parses_format_flag() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--format", "json"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn cli_parses_multiple_flags() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--config", "budget.toml", "--format", "json", "--list-lints"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.config, Some("budget.toml".to_string()));
+        assert_eq!(cli.format, OutputFormat::Json);
+        assert_eq!(cli.list_lints, true);
+    }
+
+    #[test]
+    fn cli_unknown_flag_returns_error() {
+        let result = Cli::try_parse_from(["cargo-cost-lint", "--unknown-flag"]);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
# Closes #323
# Closes #320

## Changes

### Issue #323: Add Makefile with common developer commands
- Added a `Makefile` at the repository root with the following targets:
  - `make fmt` — runs `cargo fmt --all`
  - `make lint` — runs `cargo clippy --workspace --all-targets -- -D warnings`
  - `make test` — runs `cargo test --workspace`
  - `make doc` — runs `cargo doc --no-deps --open`
  - `make check` — runs `fmt` + `lint` + `test` in sequence
- All targets are declared `.PHONY` so they always run.
- Updated `CONTRIBUTING.md` to reference `make check` as the preferred pre-PR validation step.

### Issue #320: Add unit tests for the CLI argument parser
- Added 6 unit tests for the CLI argument parsing logic in `cargo-cost-lint/src/main.rs`:
  - `cli_default_values_when_no_flags` — verifies all Cli struct fields have correct defaults
  - `cli_parses_config_flag` — verifies `--config <path>` is parsed correctly
  - `cli_parses_list_lints_flag` — verifies `--list-lints` sets the flag to true
  - `cli_parses_format_flag` — verifies `--format <format>` parses the output format enum
  - `cli_parses_multiple_flags` — verifies multiple flags can be combined in a single invocation
  - `cli_unknown_flag_returns_error` — verifies that passing an unknown flag results in a parse error
- Uses `clap`\u2019s built-in `try_parse_from` to unit-test argument parsing without spawning a subprocess.
- `cargo test -p cargo-cost-lint` passes.