### PR TITLE
perf(ci): compile the corpus dependency tree once, not once per contract

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,17 +22,23 @@ jobs:
           components: rustc-dev, llvm-tools-preview, rustfmt, clippy
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Pin the cache identity. The default key embeds the job name, so
+          # renaming this job silently discards every existing cache entry.
+          shared-key: cost-linter
+          # rust-cache only covers the root `target/` by default; the corpus
+          # contracts build outside it into the shared directory below.
+          cache-directories: tests/corpus/.shared-target
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Install Dylint
-        run: cargo install cargo-dylint dylint-link --version "^6.0.1"
-      - name: Build corpus contracts
-        run: |
-          cargo build --manifest-path tests/corpus/contracts/token/Cargo.toml
-          cargo build --manifest-path tests/corpus/contracts/timelock/Cargo.toml
-          cargo build --manifest-path tests/corpus/contracts/swap/Cargo.toml
+        # Upstream ships prebuilt binaries for Linux only, so cargo-binstall
+        # would not help windows-latest, where this step is slowest. What makes
+        # it fast is rust-cache restoring ~/.cargo/bin, which the pinned
+        # shared-key above keeps stable.
+        run: cargo install cargo-dylint dylint-link --version "^6.0.1" --locked
       - name: Generate baseline (first run only)
         # Explicit bash: the default shell on windows-latest is PowerShell,
         # which cannot parse `if ...; then`.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ node_modules/
 package-lock.json
 tests/corpus/contracts/*/target
 tests/corpus/contracts/*/Cargo.lock
+# Single target directory shared by every corpus contract, so the Soroban SDK
+# is compiled once rather than once per contract. See real_world_corpus.rs.
+tests/corpus/.shared-target
 tests/cli_integration_workspace/target/
 # Build output from the dylint test fixtures. These were committed by mistake;
 # their nested `dylint/target/.../incremental/...` paths run to ~220 characters,

--- a/cargo-cost-lint/tests/real_world_corpus.rs
+++ b/cargo-cost-lint/tests/real_world_corpus.rs
@@ -56,6 +56,16 @@ fn baseline_path() -> PathBuf {
     corpus_dir().join("baseline.json")
 }
 
+/// Every corpus contract is an independent cargo workspace depending on the
+/// same `soroban-sdk`, so left alone each one compiles that dependency tree
+/// into its own `target/` — nine near-identical builds, none of them shared and
+/// none of them covered by the CI cache, which only holds the root `target/`.
+/// Pointing every contract build and its dylint pass at one directory compiles
+/// the SDK once and leaves a single directory to cache.
+fn shared_target_dir() -> PathBuf {
+    corpus_dir().join(".shared-target")
+}
+
 /// Run `cargo-cost-lint --format json` in the given contract directory.
 fn run_lints_on_contract(contract_dir: &Path) -> Vec<Finding> {
     let bin_path = env!("CARGO_BIN_EXE_cargo-cost-lint");
@@ -67,6 +77,7 @@ fn run_lints_on_contract(contract_dir: &Path) -> Vec<Finding> {
         .arg("json")
         .current_dir(contract_dir)
         .env("DYLINT_LIBRARY_PATH", &target_dir)
+        .env("CARGO_TARGET_DIR", shared_target_dir())
         .output()
         .expect("Failed to execute cargo-cost-lint");
 
@@ -148,6 +159,7 @@ fn collect_and_report(contract_dir: &Path) -> (String, Vec<Finding>) {
     let build_status = Command::new(cargo)
         .arg("build")
         .current_dir(contract_dir)
+        .env("CARGO_TARGET_DIR", shared_target_dir())
         .status()
         .expect("Failed to build contract");
 


### PR DESCRIPTION
## The problem

Each of the nine contracts under `tests/corpus/contracts/` is an independent
cargo workspace, and every one declares the same `soroban-sdk = "26"`. The
corpus test loops over all nine running `cargo build` in each directory, so the
SDK dependency tree was compiled nine times per run — and none of it was cached,
because `Swatinem/rust-cache` only covers the root `target/` by default.

This dominated `Run tests`, the slowest step on both runners:

| Step | ubuntu | windows |
|---|---|---|
| **Run tests** | **605s** | **1351s** |
| Build corpus contracts | 116s | 236s |
| everything else | ~50s | ~870s |

## The change

- Point every contract build **and its dylint pass** at one shared target
  directory. Redirecting only the build would leave dylint still writing nine
  separate `target/dylint/` trees, so half the duplication would survive.
- Add that directory to the rust-cache config, so it is actually cached.
- Drop the `Build corpus contracts` step: it pre-built three of the nine into
  per-contract directories the suite no longer uses.
- Pin the cache identity with an explicit `shared-key`. The default key embeds
  the job name, so renaming a job silently discards every cache entry — which is
  exactly what happened when #328 renamed this job.

`DYLINT_LIBRARY_PATH` is derived from the workspace binary path, not the
contract target dir, so it is unaffected.

## Measured locally

- Corpus suite passes against `baseline.json` — lint findings unchanged, this is
  purely a build-layout change.
- The nine per-contract target dirs came back **byte-identical** in size after
  the run: nothing was written to them, confirming the dylint pass honours the
  inherited `CARGO_TARGET_DIR` too.
- Disk: **13.4GB across nine dirs → 1.5GB in one**, which is also what makes it
  cacheable — nine dirs would not fit the 10GB repo cache budget.
- Suite completes in **114.5s from a cold shared directory**.

## Note on this PR's own CI timings

`shared-key` and `cache-directories` change the cache identity, so **this PR's
first run is cold on both legs** and will not show the improvement. Steady state
is the run after it.

## Not included

Windows currently spends ~1351s of its ~41min re-deriving lint findings that are
platform-independent and already fully verified on ubuntu, while every
Windows-specific failure this repo has actually hit has been in environment and
path handling (MAX_PATH, PowerShell, `.stderr` separators, CRLF). Gating the
corpus test to non-Windows — as the dylint ui tests already are — would cut most
of that. Left out here as a deliberate coverage decision for a maintainer.