### PR TITLE
fix(ci): repair the cargo-deny config so the security audit actually runs

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,18 +17,18 @@ no-default-features = false
 # Security and maintenance checks via the RustSec Advisory Database
 # https://rustsec.org
 [advisories]
-# Deny known vulnerabilities — the core purpose of this check.
-vulnerability = "deny"
-# Deny crates flagged as unmaintained in the RustSec database.
-unmaintained = "deny"
-# Warn on unsound crates (but let CI pass). These are crates with unsound
-# API patterns that are not exploitable in the normal sense.
-unsound = "deny"
-# Warn on yanked crates. A yanked crate is a supply-chain risk.
+# Vulnerability, unsound and notice advisories no longer have configurable lint
+# levels — cargo-deny always errors on them, and the only way to accept one is
+# to list its ID in `ignore` below with a justification. The former
+# `vulnerability`/`unsound`/`notice` keys were removed from the schema, which is
+# why they are absent here.
+#
+# Which unmaintained crates to flag. "workspace" covers direct dependencies;
+# "all" additionally covers transitive ones, which pulls in advisories this
+# project cannot act on directly.
+unmaintained = "workspace"
+# A yanked crate is a supply-chain risk.
 yanked = "deny"
-# Ignore timeouts when fetching the advisory database; fail instead of silently
-# skipping security checks.
-notice = "warn"
 # Advisory IDs to ignore (none currently needed).
 ignore = [
     # Add entries like "RUSTSEC-2024-XXXX" with a comment explaining why the
@@ -40,11 +40,11 @@ ignore = [
 # The Rust ecosystem standard is MIT OR Apache-2.0 — copyleft licenses like
 # GPL/AGPL are rejected to avoid encumbering downstream users.
 [licenses]
-# Fail the check if a crate has no detectable license.
-unlicensed = "deny"
-# Explicitly deny copyleft licenses (GPL, AGPL, LGPL, MPL-2.0, etc.) that are
-# incompatible with the permissive Apache-2.0 ecosystem policy.
-copyleft = "deny"
+# The `allow` list is now exhaustive: anything not listed here is denied, and a
+# crate with no detectable license is denied too. That subsumes the former
+# `unlicensed` and `copyleft` keys, which were removed from the schema — GPL,
+# AGPL, LGPL and MPL-2.0 are rejected by virtue of not appearing below.
+#
 # Allow MIT and Apache-2.0 as well as permissive licenses that are
 # broadly compatible with the ecosystem standard.
 allow = [
@@ -52,8 +52,11 @@ allow = [
     "Apache-2.0",
     # Unicode-3.0 — required by unicode-ident (transitive dep of syn/proc-macro2)
     "Unicode-3.0",
-    # ISC — used by some crates (similar to MIT)
-    "ISC",
+    # Apache-2.0 WITH LLVM-exception — the license the Rust project itself uses,
+    # reached here through rustc_apfloat (transitive dep of the rustc/clippy
+    # internals). The LLVM exception only removes a restriction, so this is
+    # strictly more permissive than the plain Apache-2.0 already allowed above.
+    "Apache-2.0 WITH LLVM-exception",
 ]
 # The precedence for determining which license applies when multiple are detected.
 confidence-threshold = 0.8

--- a/tools/generate-lint-docs/Cargo.toml
+++ b/tools/generate-lint-docs/Cargo.toml
@@ -2,6 +2,9 @@
 name = "generate-lint-docs"
 version = "0.1.0"
 edition = "2021"
+# Matches the sibling workspace crates and the repository LICENSE. Without it
+# cargo-deny reports this crate as unlicensed.
+license = "Apache-2.0"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## The security audit has never passed

`security.yml` has failed **11 of 11 runs** since #293 added it on 2026-07-27 —
on `main` as well as on PRs:

```
failure 08-04   failure 07-29   failure 07-28   failure 07-27
failure 08-03   failure 07-29   failure 07-28   failure 07-27
failure 07-28   failure 07-28   failure 07-28
```

Every one failed while deserializing `deny.toml`, *before examining a single
dependency*. The repository has had no vulnerability, license or supply-chain
auditing at all since the day the check was introduced — only the appearance of
one. It shows up on dependency PRs because `security.yml` has a `paths` filter
for `Cargo.toml`/`Cargo.lock`.

## Why it drifted

`deny.toml` was written against an older cargo-deny schema and never validated
against the action that runs it, and `cargo-deny-action@v2` is a floating tag.

| key | what changed |
|---|---|
| `[advisories]` `vulnerability`, `unsound`, `notice` | removed from the schema — now unconditional errors, acceptable only via an `ignore` entry with justification. **Stricter** than the levels they replace. |
| `[advisories] unmaintained` | became a scope enum (`all`/`workspace`/`transitive`/`none`). Set to `workspace`, the upstream default — `all` reaches transitive deps this project cannot act on. |
| `[licenses]` `unlicensed`, `copyleft` | removed — the `allow` list is now exhaustive, so unlicensed and copyleft are denied by omission. Same effective policy. |

## What the check found once it could run

`advisories`, `bans` and `sources` all came back **clean** — no outstanding
RUSTSEC advisories, which was the real open risk. Two license findings, both
fixed here:

- **`generate-lint-docs` declared no license**, unlike `cargo-cost-lint` and
  `soroban_cost_lints` which both declare `Apache-2.0`. Added to match them and
  the repository `LICENSE`. This is a metadata omission in our own crate.
- **`rustc_apfloat` is `Apache-2.0 WITH LLVM-exception`**, reached transitively
  through the rustc/clippy internals. Allowed — the LLVM exception only removes
  a restriction, so it is strictly more permissive than the plain `Apache-2.0`
  already on the list, and it is the license the Rust project itself uses.

Also dropped the `ISC` allowance, which cargo-deny flagged as matching no
dependency in the graph.

## Verification

Run locally with cargo-deny 0.20.2, same arguments as CI:

```
$ cargo deny --all-features check
advisories ok, bans ok, licenses ok, sources ok
```

## Suggested follow-up

Pin the cargo-deny version rather than tracking the floating `v2` tag. A config
and a tool that can drift apart silently are half the reason an 11-run failure
streak went unnoticed for eight days.