### PR TITLE
docs(contributing): recommend a blobless clone, and guard against a repeat

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,13 +52,40 @@ jobs:
       - name: Check lint docs are up to date
         run: cargo run -p generate-lint-docs -- --check
 
+  # Build artefacts were committed to this repository early on and later
+  # removed. They are gone from the tree but remain in history, which is why a
+  # full clone costs 252MB against a 1.1MB working tree. Nothing prevented that
+  # from happening, so this guards against a repeat.
+  repo-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: No build artefacts committed
+        run: |
+          if tracked=$(git ls-files | grep -E '(^|/)target/'); then
+            echo "::error::Build output committed under a target/ directory:"
+            echo "$tracked"
+            exit 1
+          fi
+      - name: No large files committed
+        run: |
+          # The largest legitimate tracked file is ~108KB, so 5MB is generous.
+          large=$(git ls-files -z | xargs -0 du -k | awk '$1 > 5120 {print $1" KB\t"$2}')
+          if [ -n "$large" ]; then
+            echo "::error::Tracked files over 5MB. History is permanent, so these"
+            echo "::error::would inflate every clone forever even if deleted later:"
+            echo "$large"
+            exit 1
+          fi
+
   # Branch protection on `main` requires a status context named exactly
   # `build-and-test`. The job above is a matrix, so it can only ever report
   # `test (ubuntu-latest)` / `test (windows-latest)` — a bare name is never
   # reported and every PR waits on it forever. This job supplies that context
-  # and stays correct if the matrix legs change.
+  # and stays correct if the matrix legs change. Aggregating repo-hygiene here
+  # too keeps a single required context rather than adding a second one.
   build-and-test:
-    needs: test
+    needs: [test, repo-hygiene]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -66,5 +93,11 @@ jobs:
         run: |
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "Matrix job 'test' reported: ${{ needs.test.result }}"
+            exit 1
+          fi
+      - name: Check repo hygiene result
+        run: |
+          if [ "${{ needs.repo-hygiene.result }}" != "success" ]; then
+            echo "Job 'repo-hygiene' reported: ${{ needs.repo-hygiene.result }}"
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,18 @@ If you prefer to set up the toolchain on your machine directly:
 2. Clone the repository and build:
 
    ```bash
-   git clone https://github.com/Tollcraft/soroban-cost-linter.git
+   git clone --filter=blob:none https://github.com/Tollcraft/soroban-cost-linter.git
    cd soroban-cost-linter
    cargo build
    ```
+
+   `--filter=blob:none` performs a *blobless* clone: you still get the complete
+   history and every branch, but file contents are fetched on demand rather than
+   up front. Build artefacts were committed to this repository early in its life
+   and later removed; the files are gone from the current tree, but they remain
+   in history and a full clone still downloads them. That is the difference
+   between a **252 MB** clone and a **1.1 MB** one. Plain `git clone` still
+   works if you prefer it.
 
 3. Run tests:
 
@@ -84,7 +92,7 @@ If you prefer to set up the toolchain on your machine directly:
 3. **Clone the repository and build:**
 
    ```powershell
-   git clone https://github.com/Tollcraft/soroban-cost-linter.git
+   git clone --filter=blob:none https://github.com/Tollcraft/soroban-cost-linter.git
    cd soroban-cost-linter
    cargo build
    ```

--- a/docs/custom_lint_guide.md
+++ b/docs/custom_lint_guide.md
@@ -27,7 +27,7 @@ If the pattern fails any of the above checks, discuss with the maintainers first
 cargo install cargo-dylint dylint-link --version "^6.0.1"
 
 # Clone the repository and enter it
-git clone https://github.com/Tollcraft/soroban-cost-linter.git
+git clone --filter=blob:none https://github.com/Tollcraft/soroban-cost-linter.git
 cd soroban-cost-linter
 
 # Ensure you are on the develop branch (or the branch you will PR against)

--- a/docs/windows_setup.md
+++ b/docs/windows_setup.md
@@ -71,7 +71,7 @@ Open the Ubuntu shell **from inside WSL2**, not from `/mnt/c/`:
 ```bash
 # ✅ Linux filesystem — fast, recommended
 cd ~
-git clone https://github.com/Tollcraft/soroban-cost-linter.git
+git clone --filter=blob:none https://github.com/Tollcraft/soroban-cost-linter.git
 cd soroban-cost-linter
 cargo build
 ```
@@ -80,7 +80,7 @@ cargo build
 # ⚠️ Windows filesystem mounted at /mnt/c — works but is significantly slower
 #     and trips up scripts that translate CRLF↔LF.
 cd /mnt/c/Users/<you>/projects
-git clone https://github.com/Tollcraft/soroban-cost-linter.git
+git clone --filter=blob:none https://github.com/Tollcraft/soroban-cost-linter.git
 cd soroban-cost-linter
 cargo build
 ```
@@ -226,7 +226,7 @@ $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
 ### 4. Clone and build the linter
 
 ```powershell
-git clone https://github.com/Tollcraft/soroban-cost-linter.git
+git clone --filter=blob:none https://github.com/Tollcraft/soroban-cost-linter.git
 cd soroban-cost-linter
 cargo build
 ```


### PR DESCRIPTION
## The problem

Cloning this repository transfers **252 MB**. The working tree at `HEAD` is
**1.1 MB across 152 files**. Over 99% of what a contributor downloads is history.

Build artefacts were committed early in the repo's life and removed later —
`.gitignore` and `git rm` stop future commits but do not retract what is already
in history, and **a clone downloads history**:

| path | blobs ever committed |
|---|---|
| `soroban_cost_lints/test_fixtures/**/target/` | **932.6 MB** |
| `target/debug/` | **640.6 MB** |
| all actual source | ~10 MB |

Worst single blob: `libstellar_xdr-*.rlib` at **36.1 MB**, committed twice. Added
around #281, removed in #328 — absent from the tree, still paid for on every clone.

This is the same root cause as the Windows `MAX_PATH` checkout failures fixed
earlier: committed build output, different symptom.

## The fix: document a blobless clone

| clone | size | time | history |
|---|---|---|---|
| plain `git clone` | 252 MB | minutes | full |
| `--depth 1` | 432 KB | 2.1 s | 1 commit |
| **`--filter=blob:none`** | **1.1 MB** | **4.8 s** | **full — all 351 commits** |

A blobless clone keeps complete history and every branch; file contents are
fetched on demand, which for normal work means never. **99.6% smaller with no
loss of function.** Updated in all six places a clone is documented
(`CONTRIBUTING.md` ×2, `docs/windows_setup.md` ×3, `docs/custom_lint_guide.md`),
with a short note explaining why so it is not cargo-culted.

CI is already unaffected — `actions/checkout` defaults to depth 1.

## Guarding against a repeat

There is currently **no pre-commit config and no size check in CI**, which is why
1.5 GB of `.rlib` files could be committed unnoticed. Adds a `repo-hygiene` job
failing on:

- any tracked path under a `target/` directory
- any tracked file over 5 MB (largest legitimate file today is ~108 KB)

It is aggregated into `build-and-test` rather than exposed as its own check, so
branch protection keeps a single required context.

Verified both directions — passes on the current tree, and catches a planted
`sub/target/debug/lib.rlib` and a 6 MB file.

## Why not rewrite history

`git-filter-repo` would take the repo to ~10 MB permanently, but it rewrites
every commit SHA. That would break all **68 forks**, invalidate SHAs cited across
open issues and merged PRs, and require temporarily disabling force-push
protection on `main`. For a Wave repo whose purpose is inbound contribution from
those forks, that is a steep price when the change above already removes 99.6% of
the cost. Deliberately left as an org decision.

**Caveat:** this fixes the documented path, not every path — someone typing plain
`git clone` still transfers 252 MB.