### PR TITLE
fix: docs: explain the cargo-deny policy the security job enforces

### DIFF
--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,0 +1,9 @@
+fix: address #438
+
+docs: explain the cargo-deny policy the security job enforces
+
+- update README.md
+
+Fixes #438
+
+Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -246,3 +246,6 @@ Join the discussion on our [Discord](https://discord.gg/5aprtMSyR).
 
 
 <!-- [`soroban-budget-assert`](https://github.com/Tollcraft/soroban-budget-assert). -->
+## Security / cargo-deny
+
+CI runs `cargo deny` using `deny.toml` to enforce dependency license and advisory policy. See `deny.toml` for the active rules; update that file when adjusting allowed licenses.


### PR DESCRIPTION
## Summary

Addresses #438: docs: explain the cargo-deny policy the security job enforces

## Changes

- `README.md`

Fixes #438
