### PR TITLE
docs: document the five lint categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to Semantic Versioning.
 - Split the `soroban_storage_in_loop` lint page into a `Writes (set)` and
   `Reads (get, has)` section, each with its own suggested-fix hint that lines
   up with the diagnostic help text.
+- Added `docs/lint_categories.md` documenting the five `LintCategory` values
+  (`StorageOperations`, `Compute`, `Memory`, `EntryLifecycle`,
+  `SymbolOperations`), the metered Soroban resource each maps to, and how to
+  pick a category for a new lint. The contributing and lint-authoring guides
+  now link to it instead of carrying an incomplete inline list.
 
 ## [0.1.1]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ If you prefer to set up the toolchain on your machine directly:
 ### 3. Adding a New Lint
 - Read the [Scope: Clippy vs. soroban-cost-linter](../docs/scope_boundary.md) guide first. If a pattern is already covered by a Clippy lint and the Soroban cost story does not change the analysis, do not duplicate it here.
 - Find a structural anti-pattern in Soroban that is input-independent and costly, and that is **not** already covered by a Clippy lint with the same cost-relevant semantics.
-- Assign the lint to one of the defined cost categories (`StorageOperations`, `Compute`, `Memory`, or `EntryLifecycle`) and add it to the `LINT_METADATA` registry in `soroban_cost_lints/src/lib.rs`.
+- Assign the lint to one of the five [lint categories](docs/lint_categories.md) and add it to the `LINT_METADATA` registry in `soroban_cost_lints/src/lib.rs`.
 - Write a failing test case in the `ui` tests directory.
 - Implement the lint using the `dylint` framework, checking the AST or HIR for the specific pattern.
 - Update the `LINT_METADATA` entry with the correct category.

--- a/DEVELOPING_LINTS.md
+++ b/DEVELOPING_LINTS.md
@@ -7,7 +7,7 @@ This guide explains how to add a custom Dylint lint to `soroban-cost-linter`. It
 A lint in this repository should identify a structural Soroban cost problem: something that is expensive because of the shape of the code, rather than because of a particular runtime input. Before writing code:
 
 1. Read the [scope boundary](docs/scope_boundary.md) to make sure the proposed lint belongs in this project and does not duplicate a Clippy lint.
-2. Choose the relevant cost category: `StorageOperations`, `Compute`, `Memory`, or `EntryLifecycle`.
+2. Choose the relevant [lint category](docs/lint_categories.md) for the pattern — every lint is assigned one of the five `LintCategory` values defined in `soroban_cost_lints/src/lib.rs`.
 3. Search the existing lints for similar traversal and matching logic.
 4. Decide whether the pattern is easiest to recognize in the AST or HIR.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 ## Concepts
 
 * [Cost Rationale](cost_rationale.md)
+* [Lint Categories](lint_categories.md)
 
 ## Guides
 

--- a/docs/cost_rationale.md
+++ b/docs/cost_rationale.md
@@ -109,7 +109,7 @@ Raw Rust test estimates are **unreliable** for budget decisions — they can mis
 
 ## Per-Lint Resource Summary
 
-Each lint in this repository targets a specific resource dimension:
+Each lint in this repository targets a specific resource dimension. Every lint is assigned to one of the five [lint categories](lint_categories.md), and the table below shows the resource each one targets:
 
 | Lint | Primary resource targeted | Why it matters |
 |---|---|---|

--- a/docs/custom_lint_guide.md
+++ b/docs/custom_lint_guide.md
@@ -43,7 +43,7 @@ All lints are listed in `soroban_cost_lints/src/lib.rs` inside the `LINT_METADAT
 ```rust
 ("my_new_lint", LintMetadata {
     name: "my_new_lint",
-    category: Category::Compute, // choose StorageOperations, Compute, Memory, or EntryLifecycle
+    category: LintCategory::Compute, // pick one of the five LintCategory values — see docs/lint_categories.md
     default_level: LintLevel::Warn,
     description: "Detects ...",
 })

--- a/docs/lint_categories.md
+++ b/docs/lint_categories.md
@@ -1,0 +1,43 @@
+# Lint Categories
+
+> Every lint in `soroban-cost-linter` is assigned one of five `LintCategory` values. This page explains what each category means, which metered Soroban resource it maps to, and how to choose one when adding a new lint.
+
+The categories are defined by the `LintCategory` enum in `soroban_cost_lints/src/lib.rs`, and every shipped lint carries its category in the [`LINT_METADATA`](https://github.com/Tollcraft/soroban-cost-linter/blob/main/soroban_cost_lints/src/lib.rs) registry — the single source of truth. The `cargo-cost-lint` CLI reads that registry to enumerate lints (`--list`), to group warnings in the `--report` output, and to label `budget.toml` rows under their category. **If a documentation page and `LINT_METADATA` disagree, trust `LINT_METADATA`.**
+
+## The five categories
+
+| Category | What belongs in it | Soroban resource dimension | Shipped lints |
+| --- | --- | --- | --- |
+| `StorageOperations` | Direct ledger reads/writes via the `Storage`, `Instance`, `Persistent`, or `Temporary` accessors. | **Storage** — ledger entry accesses + ledger I/O bytes, the most expensive resource | [`soroban_storage_in_loop`](lints/soroban_storage_in_loop.md), [`loop_invariant_storage_access`](lints/loop_invariant_storage_access.md), [`soroban_redundant_storage_read`](lints/soroban_redundant_storage_read.md), [`storage_write_without_read`](lints/storage_write_without_read.md), [`instance_storage_for_unbounded_data`](lints/instance_storage_for_unbounded_data.md) |
+| `Compute` | Host functions that cross the Wasm guest/host boundary and burn CPU budget with each call (`ledger`, `crypto`, `events`, ...). | **CPU** — Wasm instruction execution + host function dispatch | [`unnecessary_host_function_call`](lints/unnecessary_host_function_call.md), [`host_in_loop`](lints/host_in_loop.md), [`contract_call_in_loop`](lints/contract_call_in_loop.md), [`unbounded_input_loop`](lints/unbounded_input_loop.md), [`signature_verification_in_loop`](lints/signature_verification_in_loop.md), [`linear_scan_in_loop`](lints/linear_scan_in_loop.md), [`require_auth_in_loop`](lints/require_auth_in_loop.md), [`formatted_panic_payload`](lints/formatted_panic_payload.md) |
+| `Memory` | Guest- or host-side allocations that grow with input size, including repeated `soroban_sdk::Bytes` / `Vec` / `Map` mutations. | **RAM** — guest linear memory, hard-capped but not charged in the resource fee | [`redundant_env_clone`](lints/redundant_env_clone.md), [`soroban_inefficient_bytes_concat`](lints/soroban_inefficient_bytes_concat.md), [`inefficient_bytes_concat`](lints/inefficient_bytes_concat.md), [`unnecessary_string_to_bytes`](lints/unnecessary_string_to_bytes.md), [`bytes_append_in_loop`](lints/bytes_append_in_loop.md), [`storage_key_construction_in_loop`](lints/storage_key_construction_in_loop.md), [`map_insert_in_loop`](lints/map_insert_in_loop.md), [`vec_where_slice_could_be_used`](lints/vec_where_slice_could_be_used.md) |
+| `EntryLifecycle` | Lifecycle of contract entries: authorisation, deployment, removal. | **Storage** — ledger space rent / TTL paid when entries are created, extended, or removed | [`extend_ttl_in_loop`](lints/extend_ttl_in_loop.md), [`persistent_read_without_ttl_extension`](lints/persistent_read_without_ttl_extension.md) |
+| `SymbolOperations` | Construction and reuse of `soroban_sdk::Symbol` values. | **CPU** — runtime symbol construction crosses the Wasm–host boundary | [`symbol_new_for_short_literal`](lints/symbol_new_for_short_literal.md) |
+
+The "what belongs in it" descriptions above are taken verbatim from the `LintCategory` rustdoc, and the shipped-lint examples are the current `LINT_METADATA` assignments. The resource dimensions come from the [Cost Rationale](cost_rationale.md) page, which explains Soroban's full metering model — budgets, fees, and what dominates a contract's resource usage.
+
+## How the categories map to the resource model
+
+Soroban meters execution along several dimensions, and each category tracks the dominant dimension the lints in it are trying to save:
+
+- **`StorageOperations`** → **Storage.** Every read or write on an instance, persistent, or temporary storage entry consumes a ledger entry access plus ledger I/O bytes. Storage is the single most expensive resource a typical contract can consume, so repeated, loop-invariant, or redundant storage access is the highest-priority class of lint.
+- **`Compute`** → **CPU instructions.** Host function calls pay a dispatch overhead plus the work the host performs; signature verification, cross-contract calls, and other cryptographic or host-boundary work are among the most expensive calls available. Repeated, invariant, or unbounded CPU work belongs here.
+- **`Memory`** → **RAM.** Needless clones, copies, and growth of SDK containers (`Bytes` / `Vec` / `Map`) allocate and copy guest linear memory. Memory is hard-capped per transaction but is *not* charged in the resource fee, so these lints are secondary to storage and CPU.
+- **`EntryLifecycle`** → **Storage (ledger space rent / TTL).** Authorising, deploying, extending the TTL of, or removing ledger entries has a lifecycle cost — the rent payments that keep entries alive are priced from ledger size. Lints about *when* entries are created, extended, or allowed to expire belong here.
+- **`SymbolOperations`** → **CPU.** `Symbol::new` constructs the symbol at runtime, which is metered; the `symbol_short!` macro produces a compile-time constant instead. Anything about how `Symbol` values are constructed or reused belongs here.
+
+## Choosing a category for a new lint
+
+Ask what the pattern wastes, in resource terms:
+
+1. **Does the pattern touch Soroban storage?** A read, write, or existence check on `Storage` / `Instance` / `Persistent` / `Temporary` — directly, repeatedly, or in a loop — is `StorageOperations`.
+2. **Is the waste CPU work?** A metered host call (`Ledger`, `Crypto`, `Prng`, `Events`, `Deployer`, ...), signature verification, a cross-contract call, or any computation repeated needlessly is `Compute`.
+3. **Is the waste allocation or copying?** A needless `.clone()`, repeated concatenation, or growing an SDK container inside a loop is `Memory`.
+4. **Does the pattern affect the lifecycle of ledger entries?** Authorisation, deployment, TTL extension, or removal — as opposed to the read/write itself — is `EntryLifecycle`.
+5. **Does the pattern build or reuse `Symbol` values?** Runtime symbol construction that could be a compile-time constant is `SymbolOperations`.
+
+When the answer is not obvious, look at the closest existing lint in `LINT_METADATA` and follow its category. The category is what the CLI uses to route diagnostics and `budget.toml` rows, so pick the *dominant* cost dimension of the pattern rather than a secondary one.
+
+{% hint style="info" %}
+Before writing a new lint, read [Scope: Clippy vs. soroban-cost-linter](scope_boundary.md) to confirm the pattern belongs here, and follow the [custom lint guide](custom_lint_guide.md) for the full workflow.
+{% endhint %}


### PR DESCRIPTION
## Summary

Closes #427

This PR makes the five lint categories — `StorageOperations`, `Compute`, `Memory`, `EntryLifecycle`, and `SymbolOperations` — first-class, user-facing documentation. Previously they existed only in the source (`LintCategory` in `soroban_cost_lints/src/lib.rs` and the `LINT_METADATA` registry), and the only places they appeared outside source code got them wrong: the lint-authoring guide called the type `Category` instead of `LintCategory` and listed only four of the five options, omitting `SymbolOperations` entirely. A contributor writing a new lint could not choose the right category because they did not know the fifth existed.

## What's in this PR

### New page: `docs/lint_categories.md`

A dedicated reference page that documents:

- **All five categories**, each with the "what belongs in it" description taken verbatim from the `LintCategory` rustdoc, plus the shipped lints in that category — confirmed one-by-one against `LINT_METADATA` (the single source of truth), not against any documentation page.
- **The connection to the Soroban resource model** — which metered dimension each category maps to, drawn from `docs/cost_rationale.md`:
  - `StorageOperations` → storage (ledger entry accesses + I/O bytes, the most expensive resource)
  - `Compute` → CPU (Wasm instruction execution + host function dispatch)
  - `Memory` → RAM (guest linear memory, hard-capped but not charged in the fee)
  - `EntryLifecycle` → storage (ledger space rent / TTL for created, extended, or removed entries)
  - `SymbolOperations` → CPU (runtime `Symbol::new` crosses the host boundary; `symbol_short!` avoids it)
- **A "Choosing a category for a new lint" section** — a five-question decision guide that asks what resource the pattern wastes, with a fallback to matching the closest existing lint in `LINT_METADATA`.

### Fixed the wrong inline lists — single source of truth

The same incorrect list (`StorageOperations`, `Compute`, `Memory`, or `EntryLifecycle` — missing `SymbolOperations`) appeared in three places. All three now point to the new page instead of repeating the list, so the categories can no longer drift:

- `docs/custom_lint_guide.md` — the `LintMetadata` example used the wrong type name `Category` and the four-item list; now `LintCategory::Compute` with a pointer to `docs/lint_categories.md` for the full set.
- `DEVELOPING_LINTS.md` — step 2 of "Before you start" now links to the categories page.
- `CONTRIBUTING.md` — the "Adding a New Lint" checklist now links to the categories page.

### Supporting edits

- `docs/SUMMARY.md` — appended a single bullet for the new page under **Concepts** (no reordering; `docs/lint_catalog.md` untouched).
- `docs/cost_rationale.md` — one-line cross-link from the "Per-Lint Resource Summary" section to the new page, so the resource model and the category reference point at each other.
- `CHANGELOG.md` — entry under **Unreleased → Changed**, per the project convention for user-facing doc changes.

## Category assignments (verified against `LINT_METADATA` in `soroban_cost_lints/src/lib.rs`)

| Category | Shipped lints |
| --- | --- |
| `StorageOperations` | `soroban_storage_in_loop`, `loop_invariant_storage_access`, `soroban_redundant_storage_read`, `storage_write_without_read`, `instance_storage_for_unbounded_data` |
| `Compute` | `unnecessary_host_function_call`, `host_in_loop`, `contract_call_in_loop`, `unbounded_input_loop`, `signature_verification_in_loop`, `linear_scan_in_loop`, `require_auth_in_loop`, `formatted_panic_payload` |
| `Memory` | `redundant_env_clone`, `soroban_inefficient_bytes_concat`, `inefficient_bytes_concat`, `unnecessary_string_to_bytes`, `bytes_append_in_loop`, `storage_key_construction_in_loop`, `map_insert_in_loop`, `vec_where_slice_could_be_used` |
| `EntryLifecycle` | `extend_ttl_in_loop`, `persistent_read_without_ttl_extension` |
| `SymbolOperations` | `symbol_new_for_short_literal` |

Note: these assignments are taken from `LINT_METADATA` at the tip of `main` (e.g. `unbounded_input_loop` → `Compute` and `map_insert_in_loop` → `Memory`), not from any documentation page, per the issue's implementation guidelines.

## Out of scope (per issue)

- No category was added, removed, or renamed.
- `docs/lint_catalog.md` and `docs/SUMMARY.md` entries other than the single appended bullet were not touched.
- The two lint-authoring guides (`docs/custom_lint_guide.md` and `DEVELOPING_LINTS.md`) are owned by a separate reconciliation issue; this PR only corrects the category list/type name in each and links to the new page.

## Validation

- Every link added in this PR resolves to an existing file in the tree (verified programmatically; the only two non-resolving links in touched files are pre-existing upstream issues: `CONTRIBUTING.md`'s `../docs/scope_boundary.md` and the guide's example `lints/my_new_lint.md` placeholder).
- This PR is **docs-only** — no Rust code was modified. The project's CI checks (`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`) are unaffected by these changes and will run on the PR.

## Files changed

- `docs/lint_categories.md` (new)
- `docs/custom_lint_guide.md`
- `DEVELOPING_LINTS.md`
- `CONTRIBUTING.md`
- `docs/SUMMARY.md`
- `docs/cost_rationale.md`
- `CHANGELOG.md`