### PR TITLE
docs: make CHANGELOG match shipped lints and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,19 @@ and this project adheres to Semantic Versioning.
 - New lint `map_insert_in_loop` detecting `Map::insert()` calls inside loop bodies.
 - New lint `signature_verification_in_loop` detecting `env.crypto().ed25519_verify()`/`secp256k1_recover()`/`secp256r1_verify()` calls inside loop bodies, suggesting batch/aggregate signature verification or a bulk callee entrypoint instead.
 - New lint `instance_storage_for_unbounded_data` detecting `env.storage().instance().set(...)` calls where the written value is an unbounded `Vec`/`Map`/`Bytes`, since instance storage is re-read and rewritten as a single blob on every contract invocation regardless of which call touches it.
-- `--fix` flag for `cargo-cost-lint` to automatically apply machine-applicable lint suggestions in-place.
 - New lint `formatted_panic_payload` detecting `format!(...)`, `panic!(...)` with formatting arguments, and `.expect(&format!(...))`, all of which pull `core::fmt` string-formatting machinery into a `#![no_std]` contract; the diagnostic points at `panic_with_error!` with a `#[contracterror]` enum as the cheap alternative. Skips `#[cfg(test)]` code.
+- New lint `loop_invariant_storage_access` detecting storage operations inside loops whose operands are provably loop-invariant, so the access can be hoisted out of the loop.
+- New lint `soroban_redundant_storage_read` detecting multiple sequential reads of the same storage key without an intervening modification.
+- New lint `soroban_inefficient_bytes_concat` detecting inefficient `Bytes` concatenation inside loop bodies.
+- New lint `host_in_loop` detecting use of a `Host` object inside a loop.
+- New lint `contract_call_in_loop` detecting cross-contract invocation inside loop bodies, where each call pays VM instantiation and dispatch overhead.
+- New lint `unbounded_input_loop` detecting loop bounds derived from untrusted input with a storage write in the body, flagging caller-controlled storage write amplification.
+- New lint `storage_key_construction_in_loop` detecting storage keys constructed inside a loop body where they could be hoisted.
+- New lint `vec_where_slice_could_be_used` detecting `soroban_sdk::Vec` passed by value where a native Rust slice would suffice.
+- New lint `extend_ttl_in_loop` detecting `extend_ttl` calls inside loop bodies, which pay a metered host call and rent per iteration.
+- New lint `linear_scan_in_loop` detecting linear scans over collections inside loops, which turn O(n) work into O(n²).
+- New lint `persistent_read_without_ttl_extension` detecting reads of persistent storage without a TTL extension, avoiding the archival cost cliff.
+- New lint `unnecessary_string_to_bytes` detecting unnecessary `String` to `Bytes` conversions.
 
 ### Changed
 
@@ -38,9 +49,10 @@ and this project adheres to Semantic Versioning.
   keyed on the terminal `.get` / `.has` / `.set`. Intermediate accessor calls
   no longer contribute separate diagnostics.
 - Documented the `--config <PATH>` flag of `cargo cost-lint` in `README.md` and
-  `docs/integration.md`. The flag is the only supported way today to apply a
-  `budget.toml`; with it omitted, no config is loaded and every lint runs at
-  its declared default level (`warn`).
+  `docs/integration.md`. A `budget.toml` in the directory the tool is run from
+  is picked up automatically; `--config <PATH>` points it at a config
+  elsewhere. The tool does not walk up to a workspace-root `budget.toml`; when
+  no config is found, every lint runs at its declared default level.
 - Split the `soroban_storage_in_loop` lint page into a `Writes (set)` and
   `Reads (get, has)` section, each with its own suggested-fix hint that lines
   up with the diagnostic help text.


### PR DESCRIPTION
## Summary

Closes #426

The `[Unreleased]` section of `CHANGELOG.md` claimed a `--fix` flag for `cargo-cost-lint` that does not exist, which made the whole file unreliable as a reference. This PR fixes that entry and audits the rest of the `[Unreleased]` section the same way: every lint claim was checked against the `declare_lint!` blocks in `soroban_cost_lints/src/lib.rs`, and every CLI claim was checked against the `Cli` struct in `cargo-cost-lint/src/main.rs`.

## Audit results — every entry, with evidence

### Removed (1 entry)

- **`--fix` flag for `cargo-cost-lint` to automatically apply machine-applicable lint suggestions in-place** — *removed from `[Unreleased]` / Added.* Evidence: the `Cli` struct in `cargo-cost-lint/src/main.rs` defines exactly four flags — `--config`, `--list-lints`, `--explain`, `--format` — and there is no `--fix` anywhere in the CLI or the crate. The issue text confirms implementing `--fix` is an open, unstarted issue. I removed the entry rather than moving it to a "planned" section because a changelog records shipped work and planned work is already tracked as an issue; nothing was reworded to hide the removal.

### Added (12 entries)

Twelve lints are genuinely shipped — declared with `declare_lint!`, registered in `register_lints`, present in `LINT_METADATA` (so the CLI ships them), and documented under `docs/lints/` — yet never appeared anywhere in the changelog. Each was added to `[Unreleased]` / Added with a description grounded in its `declare_lint!` text:

| Lint added | Evidence |
| --- | --- |
| `loop_invariant_storage_access` | declared + in `LINT_METADATA` (StorageOperations) |
| `soroban_redundant_storage_read` | declared + in `LINT_METADATA` (StorageOperations) |
| `soroban_inefficient_bytes_concat` | declared + in `LINT_METADATA` (Memory) |
| `host_in_loop` | declared + in `LINT_METADATA` (Compute) |
| `contract_call_in_loop` | declared + in `LINT_METADATA` (Compute) |
| `unbounded_input_loop` | declared + in `LINT_METADATA` (Compute) |
| `storage_key_construction_in_loop` | declared + in `LINT_METADATA` (Memory) |
| `vec_where_slice_could_be_used` | declared + in `LINT_METADATA` (Memory) |
| `extend_ttl_in_loop` | declared + in `LINT_METADATA` (EntryLifecycle) |
| `linear_scan_in_loop` | declared + in `LINT_METADATA` (Compute) |
| `persistent_read_without_ttl_extension` | declared + in `LINT_METADATA` (EntryLifecycle) |
| `unnecessary_string_to_bytes` | declared + in `LINT_METADATA` (Memory) |

### Corrected (1 entry)

- **The `--config <PATH>` entry under `[Unreleased]` / Changed** said *"The flag is the only supported way today to apply a `budget.toml`; with it omitted, no config is loaded and every lint runs at its declared default level (`warn`)."* Two claims there are inaccurate, verified against the source:
  1. `resolve_config` in `cargo-cost-lint/src/main.rs` auto-loads a `budget.toml` in the invocation directory even when `--config` is omitted (it only fails to walk up to a workspace root).
  2. Not every lint defaults to `warn` — `soroban_storage_in_loop` is declared with default level `Deny` in `lib.rs` (line ~664).
  
  The entry was reworded to state the actual behavior: a cwd `budget.toml` is picked up automatically, `--config` points elsewhere, the tool does not walk up to a workspace root, and lints run at their declared default level when no config is found.

### Verified accurate (no change)

- All 10 other new-lint entries in `[Unreleased]` / Added — each lint confirmed present in `declare_lint!` (`symbol_new_for_short_literal`, `bytes_append_in_loop`, `require_auth_in_loop`, `storage_write_without_read`, `inefficient_bytes_concat`, `map_insert_in_loop`, `signature_verification_in_loop`, `instance_storage_for_unbounded_data`, `formatted_panic_payload`; method names like `ed25519_verify`/`secp256k1_recover`/`secp256r1_verify` confirmed in the source).
- The `unnecessary_host_function_call` entries (host accessors `crypto()`/`prng()`/`events()`/`deployer()`/`current_contract_address()` confirmed in `SOROBAN_HOST_TYPES`/`SOROBAN_ENV_HOST_METHODS`; loop-dependence via `depends_on_loop_state`; iterator-closure coverage via `enclosing_loop_or_closure`).
- The `soroban_storage_in_loop` entries (read/write help-text split and single-warning collapse via `is_terminal_storage_op` confirmed in `lib.rs`).
- The "Split the `soroban_storage_in_loop` lint page" entry (`docs/lints/soroban_storage_in_loop.md` has `Writes (set)` and `Reads (get, has)` sections).

### Not changed

- `redundant_env_clone` is one of the "Three built-in Soroban cost lints" recorded under `[0.1.0]` — it shipped in that release, so it was **not** added to `[Unreleased]`; versioned sections were left as historical records.
- The `--config` documentation in `README.md`/`docs/integration.md` itself was not edited — this PR is scoped to the changelog.
- Out of scope per the issue: implementing `--fix`, and changing the release process.

## Validation

- Every shipped lint (24 declared, all present in `LINT_METADATA`) now appears in the changelog.
- `--fix` no longer appears anywhere in `CHANGELOG.md`.
- This PR is **docs-only** (one Markdown file); the project's CI checks (`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`) are unaffected and will run on the PR.

## Files changed

- `CHANGELOG.md`