### PR TITLE
chore: update PR template with lint-specific checklist items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,12 @@ Closes #
 
 ## How Has This Been Tested?
 <!-- Please describe in detail how you tested your changes. -->
-- [ ] Added/Updated tests
-- [ ] Passed `cargo test`
-- [ ] Passed `cargo clippy`
-- [ ] Formatted with `cargo fmt`
+- [ ] Passed `cargo fmt --all -- --check`
+- [ ] Passed `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] Passed `cargo test --workspace`
+- [ ] _If you added or changed a lint:_ Regenerated UI fixtures with `UPDATE_EXPECT=1 cargo test --workspace` and reviewed every changed `.stderr` file
+- [ ] _If you added or changed a lint:_ Regenerated baseline with `BLESS=1 cargo test --test real_world_corpus --workspace`
+- [ ] _If you added or changed a lint:_ Added a CHANGELOG.md entry under the `[Unreleased]` section
 
 ## Types of changes
 <!-- What types of changes does your code introduce? -->


### PR DESCRIPTION
## Description

Updates the PR testing checklist in `.github/pull_request_template.md` to include lint-specific items that commonly cause CI failures in this repository — the two that catch contributors out are stale `.stderr` fixtures and missing documentation/baseline updates.

### Changes

- **Replaced abbreviated generic items** with the exact commands CI runs:
  - `cargo fmt --all -- --check`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo test --workspace`

- **Added three conditional checklist items** (each prefixed with _"If you added or changed a lint:"_):
  1. Regenerated UI fixtures with `UPDATE_EXPECT=1 cargo test --workspace` and reviewed every changed `.stderr` file
  2. Regenerated baseline with `BLESS=1 cargo test --test real_world_corpus --workspace`
  3. Added a CHANGELOG.md entry under the `[Unreleased]` section

### Rationale

With roughly thirty open issues asking contributors to add new lints, every one of them will hit both stale fixtures and missing documentation updates. A checklist that names these commands turns a confusing CI failure into a box someone ticks before pushing. The additions are conditional in wording so a documentation-only PR is not asked to tick irrelevant boxes.

The template stays short — six items, still well under one screen.

## Testing

- [x] Verified each command against `.github/workflows/lint.yml`
- [x] Verified `.stderr` bless command against `DEVELOPING_LINTS.md` §3 and §5
- [x] Template remains concise (6 checklist items)

Closes #423

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>