### PR TITLE
feat: add --quiet and --verbose flags to cargo-cost-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,11 @@ cargo +<channel-from-rust-toolchain> install --git https://github.com/Tollcraft/
 | `--format <text\|json>` | Output format (default: `text`) |
 | `--list-lints` | Print every registered lint with its default level and one-line description, then exit |
 | `--explain <LINT>` | Print the full documentation for a specific lint (what it does, why it's expensive, suggested fix) and exit |
+| `--quiet` | Suppress informational and warning output (lint findings and errors are never suppressed) |
+| `--verbose` | Show diagnostic detail: resolved config path, lint flags, and the spawned command |
 | `--version` | Print the crate version and exit |
+
+`--quiet` and `--verbose` are mutually exclusive. In JSON mode (`--format json`), both flags keep stdout as clean NDJSON; all diagnostic output goes to stderr.
 
 ### Running the linter
 

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -7,7 +7,7 @@ mod module_13;
 #[allow(dead_code)]
 mod module_15;
 
-use clap::{Parser, ValueEnum};
+use clap::{ArgGroup, Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -43,6 +43,11 @@ struct LintFinding {
 #[command(name = "cargo-cost-lint")]
 #[command(version)]
 #[command(about = "CLI wrapper for soroban-cost-linter")]
+#[command(group(
+    ArgGroup::new("verbosity")
+        .args(["quiet", "verbose"])
+        .multiple(false)
+))]
 struct Cli {
     #[arg(long, help = "Path to budget.toml")]
     config: Option<String>,
@@ -59,6 +64,15 @@ struct Cli {
 
     #[arg(long, value_enum, default_value_t = OutputFormat::Text, help = "Output format")]
     format: OutputFormat,
+
+    #[arg(long, help = "Suppress informational and warning output")]
+    quiet: bool,
+
+    #[arg(
+        long,
+        help = "Show diagnostic detail: config path, lint flags, spawned command"
+    )]
+    verbose: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -207,10 +221,16 @@ fn main() {
         return;
     }
 
+    let quiet = cli.quiet;
+    let verbose = cli.verbose;
     let mut lint_flags = Vec::new();
+    let mut resolved_config_path: Option<PathBuf> = None;
 
     if let Some(ref path) = resolve_config(cli.config.as_deref()) {
-        eprintln!("Using config: {}", path.display());
+        resolved_config_path = Some(path.clone());
+        if !quiet {
+            eprintln!("Using config: {}", path.display());
+        }
         if let Ok(config_str) = fs::read_to_string(path) {
             if let Ok(config) = toml::from_str::<BudgetConfig>(&config_str) {
                 match validate_and_build_flags(&config) {
@@ -221,11 +241,15 @@ fn main() {
                     }
                 }
             } else {
-                eprintln!("Warning: Failed to parse {}", path.display());
+                if !quiet {
+                    eprintln!("Warning: Failed to parse {}", path.display());
+                }
             }
         }
     } else {
-        eprintln!("Warning: budget.toml not found, using default lint levels.");
+        if !quiet {
+            eprintln!("Warning: budget.toml not found, using default lint levels.");
+        }
     }
 
     let mut cmd = Command::new("cargo");
@@ -233,15 +257,30 @@ fn main() {
     cmd.arg("--lib");
     cmd.arg("soroban_cost_lints");
 
+    let mut rustflags_value = String::new();
     if !lint_flags.is_empty() {
-        let mut rustflags = std::env::var("DYLINT_RUSTFLAGS").unwrap_or_default();
+        rustflags_value = std::env::var("DYLINT_RUSTFLAGS").unwrap_or_default();
         for flag in lint_flags {
-            if !rustflags.is_empty() {
-                rustflags.push(' ');
+            if !rustflags_value.is_empty() {
+                rustflags_value.push(' ');
             }
-            rustflags.push_str(&flag);
+            rustflags_value.push_str(&flag);
         }
-        cmd.env("DYLINT_RUSTFLAGS", rustflags);
+        cmd.env("DYLINT_RUSTFLAGS", &rustflags_value);
+    }
+
+    if verbose {
+        if let Some(ref p) = resolved_config_path {
+            eprintln!("[verbose] config: {}", p.display());
+        } else {
+            eprintln!("[verbose] config: (none — using default lint levels)");
+        }
+        if !rustflags_value.is_empty() {
+            eprintln!("[verbose] DYLINT_RUSTFLAGS: {}", rustflags_value);
+        } else {
+            eprintln!("[verbose] DYLINT_RUSTFLAGS: (empty)");
+        }
+        eprintln!("[verbose] command: {:?}", cmd);
     }
 
     if cli.format == OutputFormat::Json {
@@ -803,5 +842,37 @@ mod tests {
     fn cli_unknown_flag_returns_error() {
         let result = Cli::try_parse_from(["cargo-cost-lint", "--unknown-flag"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn cli_parses_quiet_flag() {
+        let cli =
+            Cli::try_parse_from(["cargo-cost-lint", "--quiet"]).expect("parsing should succeed");
+        assert!(cli.quiet);
+        assert!(!cli.verbose);
+    }
+
+    #[test]
+    fn cli_parses_verbose_flag() {
+        let cli =
+            Cli::try_parse_from(["cargo-cost-lint", "--verbose"]).expect("parsing should succeed");
+        assert!(cli.verbose);
+        assert!(!cli.quiet);
+    }
+
+    #[test]
+    fn cli_quiet_and_verbose_are_mutually_exclusive() {
+        let result = Cli::try_parse_from(["cargo-cost-lint", "--quiet", "--verbose"]);
+        assert!(
+            result.is_err(),
+            "--quiet and --verbose should not be allowed together"
+        );
+    }
+
+    #[test]
+    fn cli_quiet_default_is_false() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint"]).expect("parsing should succeed");
+        assert!(!cli.quiet);
+        assert!(!cli.verbose);
     }
 }

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -117,6 +117,32 @@ Rustc resolves the effective lint level in this order (highest priority first):
 
 A `deny` in `budget.toml` raises the level from `warn` (the default) to `deny`. An `#[allow]` attribute on a function body suppresses a `warn`-level lint for that function just as it normally would — but a `deny` in `budget.toml` will cause that same function to fail, because `#[allow]` cannot override `-D`. Conversely, `allow` in budget.toml suppresses the lint everywhere, even overriding `#[deny]` in source code.
 
+## Verbosity Control
+
+The wrapper has two flags for controlling how much non-finding output it prints.
+
+| Flag | Behaviour |
+|------|----------|
+| `--quiet` | Suppresses informational messages and warnings (config loaded, budget.toml missing, parse failures). Lint findings and hard errors are never suppressed. |
+| `--verbose` | Prints diagnostic detail to stderr: the resolved `budget.toml` path, the `DYLINT_RUSTFLAGS` values, and the full `cargo dylint` command line. |
+
+The two flags are mutually exclusive — clap rejects `--quiet --verbose` on the same command line. Neither flag changes the exit code or the lint findings.
+
+In JSON mode (`--format json`), both flags keep stdout as clean NDJSON. All diagnostic output goes to stderr.
+
+**Examples:**
+
+```bash
+# Silent run — only lint findings appear
+cargo cost-lint --quiet
+
+# Diagnostic run — see exactly what the tool is doing
+cargo cost-lint --verbose
+
+# JSON + verbose — clean JSON on stdout, diagnostics on stderr
+cargo cost-lint --format json --verbose > results.json
+```
+
 ## Editor / IDE Integration
 
 `soroban-cost-linter` can surface lint warnings directly in your editor through **rust-analyzer**'s check override mechanism. This works in any editor that supports rust-analyzer (VS Code, Zed, Helix, Neovim, etc.).


### PR DESCRIPTION
## Description

Adds `--quiet` and `--verbose` flags to the `cargo-cost-lint` CLI wrapper, giving users control over how much non-finding output the tool prints. These are the two most common requests for a wrapper that currently has exactly one volume setting.

### Problem

The wrapper prints `Warning: budget.toml not found, using default lint levels.` every time it runs without a config — whether you are running it interactively for the first time or for the four-hundredth time in a CI loop where you have deliberately chosen the defaults. There is no way to turn that down, and no way to turn anything up when diagnosing a setup issue.

### Changes

**`cargo-cost-lint/src/main.rs`** — the core implementation:

- Added `--quiet` flag: suppresses informational messages and warnings (`Using config: ...`, `Warning: budget.toml not found`, `Warning: Failed to parse ...`). Lint findings and hard errors are **never** suppressed.
- Added `--verbose` flag: prints diagnostic detail to stderr before spawning `cargo dylint`:
  - `[verbose] config: <path>` — the resolved `budget.toml` path (or `(none)` if absent)
  - `[verbose] DYLINT_RUSTFLAGS: <flags>` — the exact flags being passed through
  - `[verbose] command: <cmd>` — the full `cargo dylint` command line being spawned
- Mutual exclusivity enforced via clap's `ArgGroup` — `--quiet --verbose` is rejected at parse time with no hand-rolling needed.
- Neither flag changes the exit code or the lint findings.
- In JSON mode (`--format json`), both flags keep stdout as clean NDJSON. All diagnostic output goes to stderr.

**`README.md`** — added `--quiet` and `--verbose` to the CLI Flags table with descriptions, plus a note about mutual exclusivity and JSON mode behaviour.

**`docs/integration.md`** — added a "Verbosity Control" section with a table, explanation, and usage examples.

### Design decisions

- **Clap `ArgGroup` for mutual exclusivity** — the issue explicitly says "it has built-in support for this, so do not hand-roll it." `ArgGroup::new("verbosity").multiple(false)` does exactly that.
- **`--verbose` output goes to stderr** — in JSON mode, stdout must remain clean NDJSON for machine parsing. All diagnostic output uses `eprintln!`.
- **Single level of each** — the issue says "multiple -v levels" are out of scope. One `--quiet` and one `--verbose` is enough for a wrapper this size.
- **`--verbose` prints the spawned command** — the issue calls this "the single most useful thing this issue can add." `{:?}` on the `Command` gives the full argument list.

### --verbose output examples

**Without a budget.toml:**
```
[verbose] config: (none — using default lint levels)
[verbose] DYLINT_RUSTFLAGS: (empty)
[verbose] command: "cargo" "dylint" "--lib" "soroban_cost_lints"
```

**With a budget.toml:**
```
[verbose] config: budget.toml
[verbose] DYLINT_RUSTFLAGS: -D soroban_storage_in_loop -W redundant_env_clone
[verbose] command: "cargo" "dylint" "--lib" "soroban_cost_lints"
```

## Testing

- [x] `cargo fmt --all -- —check` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes
- [x] `cargo test --workspace` — all 54 unit tests pass (including 4 new tests for the flags)
- [x] CLI tests verify: `--quiet` parses, `--verbose` parses, both are mutually exclusive, defaults are false
- [x] Integration test `test_json_output` fails due to missing `dylint-link` in this environment (pre-existing, unrelated)

Closes #421

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>