### PR TITLE
feat: honour NO_COLOR by forwarding colour preference to cargo dylint

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,12 @@ If the binary was not tampered with the output will say `cargo-cost-lint: OK`.
 |------|-------------|
 | `--config <PATH>` | Path to `budget.toml` for lint-level overrides |
 | `--format <text\|json>` | Output format (default: `text`) |
+| `--color <auto\|always\|never>` | Colour preference forwarded to `cargo dylint` (default: `auto`). Honours `NO_COLOR` env var. |
 | `--list-lints` | Print every registered lint with its default level and one-line description, then exit |
 | `--explain <LINT>` | Print the full documentation for a specific lint (what it does, why it's expensive, suggested fix) and exit |
 | `--version` | Print the crate version and exit |
+
+The `--color` flag controls rustc's coloured diagnostics. The `NO_COLOR` environment variable (any non-empty value) disables colour when `--color` is not explicitly set. JSON mode is unaffected — it already pipes stdout and emits no colour.
 
 ### Running the linter
 

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -20,6 +20,13 @@ enum OutputFormat {
     Json,
 }
 
+#[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
+enum ColorChoice {
+    Auto,
+    Always,
+    Never,
+}
+
 #[derive(Serialize, Debug)]
 struct Span {
     line_start: usize,
@@ -59,6 +66,14 @@ struct Cli {
 
     #[arg(long, value_enum, default_value_t = OutputFormat::Text, help = "Output format")]
     format: OutputFormat,
+
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = ColorChoice::Auto,
+        help = "Colour preference forwarded to cargo dylint (default: auto)"
+    )]
+    color: ColorChoice,
 }
 
 #[derive(Deserialize, Debug)]
@@ -243,6 +258,25 @@ fn main() {
         }
         cmd.env("DYLINT_RUSTFLAGS", rustflags);
     }
+
+    // Determine colour preference: explicit --color flag wins, then
+    // NO_COLOR env var (any non-empty value = no colour), then auto.
+    let color_arg = match cli.color {
+        ColorChoice::Auto => {
+            if std::env::var("NO_COLOR")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false)
+            {
+                "never"
+            } else {
+                "auto"
+            }
+        }
+        ColorChoice::Always => "always",
+        ColorChoice::Never => "never",
+    };
+    cmd.arg("--color");
+    cmd.arg(color_arg);
 
     if cli.format == OutputFormat::Json {
         cmd.arg("--");
@@ -803,5 +837,25 @@ mod tests {
     fn cli_unknown_flag_returns_error() {
         let result = Cli::try_parse_from(["cargo-cost-lint", "--unknown-flag"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn cli_color_default_is_auto() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint"]).expect("parsing should succeed");
+        assert_eq!(cli.color, ColorChoice::Auto);
+    }
+
+    #[test]
+    fn cli_parses_color_always() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--color", "always"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.color, ColorChoice::Always);
+    }
+
+    #[test]
+    fn cli_parses_color_never() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--color", "never"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.color, ColorChoice::Never);
     }
 }

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -117,6 +117,33 @@ Rustc resolves the effective lint level in this order (highest priority first):
 
 A `deny` in `budget.toml` raises the level from `warn` (the default) to `deny`. An `#[allow]` attribute on a function body suppresses a `warn`-level lint for that function just as it normally would — but a `deny` in `budget.toml` will cause that same function to fail, because `#[allow]` cannot override `-D`. Conversely, `allow` in budget.toml suppresses the lint everywhere, even overriding `#[deny]` in source code.
 
+## Colour Control
+
+`soroban-cost-lint` does not colour anything itself, but in text mode it spawns `cargo dylint` with inherited stdio, so rustc's coloured diagnostics come straight through. The wrapper provides a `--color` flag and honours the `NO_COLOR` convention to control this.
+
+| Flag | Behaviour |
+|------|----------|
+| `--color auto` (default) | Colour when stdout is a terminal, none when redirected or piped |
+| `--color always` | Always emit colour, even when piped |
+| `--color never` | Never emit colour |
+
+The `NO_COLOR` environment variable (set to any non-empty value, per [no-color.org](https://no-color.org/)) disables colour when `--color` is not explicitly passed. The explicit `--color` flag always takes precedence.
+
+**Examples:**
+
+```bash
+# Default — colour in terminal, none when piped
+cargo cost-lint | less -R
+
+# Force colour off (useful for CI logs)
+NO_COLOR=1 cargo cost-lint
+
+# Force colour on (useful for debugging)
+cargo cost-lint --color always
+```
+
+In JSON mode (`--format json`), colour is never emitted — stdout is already piped and contains only NDJSON.
+
 ## Editor / IDE Integration
 
 `soroban-cost-linter` can surface lint warnings directly in your editor through **rust-analyzer**'s check override mechanism. This works in any editor that supports rust-analyzer (VS Code, Zed, Helix, Neovim, etc.).


### PR DESCRIPTION
## Description

Adds a `--color <auto|always|never>` flag to `cargo-cost-lint` and honours the `NO_COLOR` environment variable, giving users control over rustc's coloured diagnostics that come through the wrapper.

### Problem

`cargo cost-lint` does not colour anything itself, but in text mode it spawns `cargo dylint` with inherited stdio, so rustc's coloured diagnostics come straight through. Setting `NO_COLOR=1` — the convention the ecosystem has settled on — does nothing, because the variable is never read and no `--color` argument is forwarded to the child. This is most annoying in log files, CI systems without ANSI support, and anything that captures output for later reading.

### Changes

**`cargo-cost-lint/src/main.rs`** — the core implementation:

- Added `ColorChoice` enum (`Auto`, `Always`, `Never`) with clap `ValueEnum` derive.
- Added `--color` flag to the `Cli` struct, defaulting to `Auto`.
- Colour preference resolution: explicit `--color` flag > `NO_COLOR` env var > `auto`.
- The preference is forwarded to the spawned `cargo dylint` via `cmd.arg("--color").arg(color_arg)`. This goes before the `--` separator so cargo forwards it to the underlying rustc invocation.
- JSON mode is unaffected — it already pipes stdout and emits no colour.

**`README.md`** — added `--color` to the CLI Flags table with description, plus a note about `NO_COLOR` and JSON mode.

**`docs/integration.md`** — added a "Colour Control" section with a table of all three modes, explanation of `NO_COLOR` precedence, and usage examples.

### Design decisions

- **`cargo --color` is the lever** — cargo takes `--color` and forwards it to rustc. The argument goes before `--` (the separator for rustc args) so cargo processes it.
- **`auto` as default** — `cargo --color auto` already does the right thing: colour when stdout is a terminal, none when piped. No need to detect `IsTerminal` ourselves.
- **`NO_COLOR` takes precedence over `auto`** — per no-color.org, any non-empty value disables colour. The explicit `--color` flag always wins over the env var.
- **No new dependencies** — `NO_COLOR` detection is a simple `std::env::var` check.

### Output examples

**With NO_COLOR set:**
```bash
$ NO_COLOR=1 cargo cost-lint
# No ANSI escape codes in output
```

**Without NO_COLOR (terminal):**
```bash
$ cargo cost-lint
# Coloured diagnostics as usual
```

**Forced colour off:**
```bash
$ cargo cost-lint --color never
# No ANSI escape codes, regardless of terminal or NO_COLOR
```

**Forced colour on (useful for debugging):**
```bash
$ cargo cost-lint --color always | less -R
# Coloured output even when piped
```

## Testing

- [x] `cargo fmt --all -- —check` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes
- [x] `cargo test -p cargo-cost-lint` — all 53 unit tests pass (including 3 new color tests)
- [x] CLI tests verify: default is `Auto`, `--color always` parses, `--color never` parses
- [x] Lint docs regenerated and unchanged

Closes #420

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>