### PR TITLE
Fix issue 436

### DIFF
--- a/.github/ISSUE_TEMPLATE/lint-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/lint-proposal.yml
@@ -49,6 +49,59 @@ body:
         // Refactored code or valid usage
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### Scope and Clippy Overlap
+        Please review [docs/scope_boundary.md](https://github.com/Tollcraft/soroban-cost-linter/blob/main/docs/scope_boundary.md) before answering these questions.
+  - type: input
+    id: clippy_lint
+    attributes:
+      label: "Which Clippy lint already catches this? (Or state that there is none)"
+      placeholder: "e.g., clippy::redundant_clone, or 'none'"
+    validations:
+      required: true
+  - type: dropdown
+    id: soroban_harm
+    attributes:
+      label: "Does the Soroban cost model make the pattern more harmful than in general Rust?"
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
+    validations:
+      required: true
+  - type: dropdown
+    id: clippy_orthogonal
+    attributes:
+      label: "Is the Clippy lint's trigger condition orthogonal to cost?"
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
+    validations:
+      required: true
+  - type: dropdown
+    id: actionable_guidance
+    attributes:
+      label: "Does the Soroban lint give actionable, Soroban-specific guidance that Clippy cannot?"
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
+    validations:
+      required: true
+  - type: dropdown
+    id: resource_dimension
+    attributes:
+      label: "Which resource dimension does the pattern affect?"
+      options:
+        - "CPU"
+        - "Ledger accesses"
+        - "I/O bytes"
+        - "Memory"
+    validations:
+      required: true
   - type: dropdown
     id: default_severity
     attributes:


### PR DESCRIPTION
Closes #436

## Summary of Changes

This PR updates the `.github/ISSUE_TEMPLATE/lint-proposal.yml` to automatically ask the four checklist questions from `docs/scope_boundary.md` at the time of proposal creation. This ensures proposals have scope evaluated immediately, saving maintainers a round-trip.

Specifically:
- Added a `clippy_lint` input field requiring users to state which Clippy lint catches the pattern (or state that there is none).
- Added `soroban_harm`, `clippy_orthogonal`, and `actionable_guidance` as dropdown fields to ask the remaining three scope questions.
- Added a `resource_dimension` dropdown to collect the impacted resource dimension (CPU, Ledger accesses, I/O bytes, Memory), assisting in later assignment of `LintCategory`.
- Included a Markdown block linking to `docs/scope_boundary.md` to provide proposers with the necessary context before they answer.

No existing fields were removed or altered. The UI changes were kept compact by utilizing dropdown menus and single-line inputs to ensure the form remains accessible within a single screen view.
