### PR TITLE
Fix issue 433

### DIFF
--- a/cargo-cost-lint/src/config.rs
+++ b/cargo-cost-lint/src/config.rs
@@ -10,11 +10,13 @@ use super::error::{LinterError, LinterResult};
 // The newer config generation (fallback defaults, issue #211/#13). Not yet
 // wired into `main()`, which still uses the older validated path -- see the
 // note on `parse_budget_config` in main.rs.
+// Kept: scaffolding for newer config generation
 #[allow(dead_code)]
 pub struct Config {
     lints: Option<HashMap<String, String>>,
 }
 
+// Kept: part of the newer config generation
 #[allow(dead_code)]
 impl Config {
     /// Reads and parses the budget.toml at `path`.

--- a/cargo-cost-lint/src/error.rs
+++ b/cargo-cost-lint/src/error.rs
@@ -9,6 +9,7 @@ use std::io;
 #[derive(Debug)]
 // `Subprocess` and `MissingPrerequisite` are part of the consolidated error
 // surface (#299/#281) but nothing raises them yet.
+// Kept: part of a consolidated error surface but currently unraised
 #[allow(dead_code)]
 pub enum LinterError {
     /// An I/O error — file read/write, pipe capture, etc.

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -1,9 +1,11 @@
 mod config;
 mod error;
 // Declared but not yet wired into the CLI; see module_13.rs.
+// Kept: scaffolding awaiting maintainer decision
 #[allow(dead_code)]
 mod module_13;
 // Declared but not yet wired into the CLI; see module_15.rs.
+// Kept: scaffolding awaiting maintainer decision
 #[allow(dead_code)]
 mod module_15;
 
@@ -138,6 +140,7 @@ fn resolve_config(config: Option<&str>) -> Option<PathBuf> {
 // (fallback defaults, no name validation). Both are tested; picking which one
 // ships is a behavioural decision for a maintainer, so this change leaves
 // `main()` as it found it rather than choosing silently.
+// Kept: scaffolding for future feature implementations
 #[allow(dead_code)]
 fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
     let config = config::BudgetConfig::from_file_validated(Path::new(path), LINT_NAMES)?;
@@ -170,6 +173,7 @@ fn parse_budget_config(path: &str) -> Result<Vec<String>, String> {
 /// actually wrote something wrong — are returned unchanged so the
 /// strict behaviour already covered by [`parse_budget_config`] and
 /// its existing tests is preserved.
+// Kept: scaffolding for future feature implementations
 #[allow(dead_code)]
 fn try_parse_budget_config(path: &str) -> Result<Vec<String>, String> {
     match parse_budget_config(path) {

--- a/cargo-cost-lint/src/module_13.rs
+++ b/cargo-cost-lint/src/module_13.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct BudgetConfig {
     #[serde(default)]
-    #[allow(dead_code)]
     pub lints: HashMap<String, String>,
 }
 

--- a/cargo-cost-lint/src/module_15.rs
+++ b/cargo-cost-lint/src/module_15.rs
@@ -11,12 +11,10 @@ impl LintNameSet {
         self.inner.contains(name)
     }
 
-    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
-    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -1340,26 +1340,6 @@ impl<'tcx> Visitor<'tcx> for ParamHirIdCollector {
     }
 }
 
-/// Whether `expr` is a clamping method call (`.min(CONST)` or
-/// `.clamp(_, CONST)` where the constant is a literal).
-#[allow(dead_code)]
-fn is_clamped_by_constant(_cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> bool {
-    if let hir::ExprKind::MethodCall(path_segment, _receiver, args, _span) = expr.kind {
-        let name = path_segment.ident.name.as_str();
-        match name {
-            "min" => args
-                .first()
-                .is_some_and(|a| matches!(a.kind, hir::ExprKind::Lit(_))),
-            "clamp" => {
-                args.len() >= 2 && matches!(args[args.len() - 1].kind, hir::ExprKind::Lit(_))
-            }
-            _ => false,
-        }
-    } else {
-        false
-    }
-}
-
 impl<'tcx> LateLintPass<'tcx> for UnboundedInputLoop {
     /// Visits each named function, collecting parameter `HirId`s and walking
     /// the body for loops whose bound references a function parameter and


### PR DESCRIPTION
Closes #433

Audited all 11 `#[allow(dead_code)]` markers in the codebase.

| File | Item | Verdict |
| --- | --- | --- |
| `cargo-cost-lint/src/main.rs` | `mod module_13;` | **kept** - scaffolding awaiting maintainer decision |
| `cargo-cost-lint/src/main.rs` | `mod module_15;` | **kept** - scaffolding awaiting maintainer decision |
| `cargo-cost-lint/src/main.rs` | `parse_budget_config` | **kept** - scaffolding awaiting maintainer decision |
| `cargo-cost-lint/src/main.rs` | `try_parse_budget_config` | **kept** - scaffolding awaiting maintainer decision |
| `cargo-cost-lint/src/module_13.rs` | `pub lints: HashMap...` | **removed** - marker was stale (module suppression suffices) |
| `cargo-cost-lint/src/module_15.rs` | `pub fn len()` | **removed** - marker was stale |
| `cargo-cost-lint/src/module_15.rs` | `pub fn is_empty()` | **removed** - marker was stale |
| `cargo-cost-lint/src/config.rs` | `pub struct Config` | **kept** - newer config generation scaffolding |
| `cargo-cost-lint/src/config.rs` | `impl Config` | **kept** - newer config generation scaffolding |
| `cargo-cost-lint/src/error.rs` | `pub enum LinterError` | **kept** - part of consolidated error surface |
| `soroban_cost_lints/src/lib.rs` | `fn is_clamped_by_constant` | **removed** - item was deleted (genuinely dead) |

All tests pass and the linter `clippy` runs clean on `--workspace --all-targets -- -D warnings`.
