### PR TITLE
docs: fix broken relative links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ If you prefer to set up the toolchain on your machine directly:
     This runs `fmt`, `lint`, and `test` in sequence. See the [`Makefile`](./Makefile) for all available targets.
 
 ### 3. Adding a New Lint
-- Read the [Scope: Clippy vs. soroban-cost-linter](../docs/scope_boundary.md) guide first. If a pattern is already covered by a Clippy lint and the Soroban cost story does not change the analysis, do not duplicate it here.
+- Read the [Scope: Clippy vs. soroban-cost-linter](./docs/scope_boundary.md) guide first. If a pattern is already covered by a Clippy lint and the Soroban cost story does not change the analysis, do not duplicate it here.
 - Find a structural anti-pattern in Soroban that is input-independent and costly, and that is **not** already covered by a Clippy lint with the same cost-relevant semantics.
 - Assign the lint to one of the defined cost categories (`StorageOperations`, `Compute`, `Memory`, or `EntryLifecycle`) and add it to the `LINT_METADATA` registry in `soroban_cost_lints/src/lib.rs`.
 - Write a failing test case in the `ui` tests directory.

--- a/docs/custom_lint_guide.md
+++ b/docs/custom_lint_guide.md
@@ -127,7 +127,7 @@ cargo test --test ui_my_new_lint
 1. **Add an entry to the lint catalog** (`docs/lint_catalog.md`):
 
 ```markdown
-| `my_new_lint` | warn | Detects ... | [Link](lints/my_new_lint.md) |
+| `my_new_lint` | warn | Detects ... | `lints/my_new_lint.md` |
 ```
 
 2. **Create a lint reference page** (`docs/lints/my_new_lint.md`):


### PR DESCRIPTION
This PR fixes two broken relative links:
1. In `CONTRIBUTING.md`, `../docs/scope_boundary.md` was pointing outside the repo; changed to `./docs/scope_boundary.md`.
2. In `docs/custom_lint_guide.md`, the illustrative placeholder `lints/my_new_lint.md` was formatted as a link but the target did not exist, so it was converted to an inline code snippet.

I also ran a link checking script across all tracked `.md` files and verified no other broken relative links exist.

Closes #456