### PR TITLE
docs: document cargo-deny policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,24 @@ All PRs are checked by CI (Linux and Windows), and these checks must pass before
 
 Follow the patterns already used in the codebase: `soroban_cost_lints` uses edition 2024, so prefer let-chains (`if let ... && let ...`) over nested `if let` blocks, and match the structure of the existing lint passes when adding a new lint.
 
+### 4.1 Security and Policy Checks (`cargo-deny`)
+
+This project uses `cargo-deny` in CI (via `.github/workflows/security.yml`) to enforce policies on dependencies. The policy is defined in `deny.toml`. Note that the CI job runs only when manifests (`Cargo.toml`), the lockfile (`Cargo.lock`), or the workflow file change.
+
+**What the policy enforces:**
+- **Licenses:** Only `MIT`, `Apache-2.0`, `Unicode-3.0`, and `Apache-2.0 WITH LLVM-exception` are allowed. Copyleft licenses (like GPL/AGPL) are rejected.
+- **Advisories:** Vulnerabilities, unsoundness, and notice advisories from the RustSec database will cause the check to fail. Unmaintained crates in the workspace are also flagged.
+- **Bans:** Multiple versions of the same crate will trigger a warning.
+
+**Exceptions:**
+If you need an exception (e.g., to ignore a specific advisory or allow a license for a specific crate), you can propose adding it to `deny.toml`. Any such exception must include a comment explaining why it is safe for this project and under what condition it can be removed.
+
+**Running locally:**
+Run the check locally before pushing to catch policy violations early:
+```bash
+cargo deny check
+```
+
 ### 5. Upgrading the Nightly Toolchain
 
 The pinned nightly is declared once in `rust-toolchain` (the single source of truth) and must stay in sync across four files, the `clippy_utils` git rev in `soroban_cost_lints/Cargo.toml`, and the container image.

--- a/deny.toml
+++ b/deny.toml
@@ -51,11 +51,13 @@ allow = [
     "MIT",
     "Apache-2.0",
     # Unicode-3.0 — required by unicode-ident (transitive dep of syn/proc-macro2)
+    # This can be removed if the dependency on unicode-ident is dropped.
     "Unicode-3.0",
     # Apache-2.0 WITH LLVM-exception — the license the Rust project itself uses,
     # reached here through rustc_apfloat (transitive dep of the rustc/clippy
     # internals). The LLVM exception only removes a restriction, so this is
     # strictly more permissive than the plain Apache-2.0 already allowed above.
+    # This can be removed if the dependency on rustc_apfloat is dropped.
     "Apache-2.0 WITH LLVM-exception",
 ]
 # The precedence for determining which license applies when multiple are detected.
@@ -64,6 +66,8 @@ exceptions = [
     # clippy_utils — from a pinned git rev of rust-clippy; it follows the same
     # dual MIT/Apache-2.0 license as the Rust project, but the license file may
     # not be detectable by cargo-deny from a git source.
+    # This can be removed if clippy_utils is published to crates.io and consumed
+    # from there instead of a git repo, or if we stop depending on it.
     { name = "clippy_utils", allow = ["MIT", "Apache-2.0"] },
 ]
 
@@ -77,6 +81,8 @@ unknown-git = "deny"
 # LFS sources are not used.
 allow-git = [
     # clippy_utils pinned from rust-clippy repository
+    # This can be removed if clippy_utils is published to crates.io and consumed
+    # from there instead of a git repo, or if we stop depending on it.
     "https://github.com/rust-lang/rust-clippy",
 ]
 


### PR DESCRIPTION
This PR adds documentation for the `cargo-deny` policy that the `security.yml` CI job enforces. It adds a new section in `CONTRIBUTING.md` explaining the policies for licenses, advisories, exceptions, and how to run it locally.

Also added comments to `deny.toml` for all the explicit allowances, explaining why they are there and the conditions under which they can be removed.

Local `cargo deny check` output:
```
error[unexpected-value]: expected '["allow", "warn", "deny"]'
   ┌─ /home/wagmi/teamwork_projects/github_issue_solver/workspaces/hayzed/soroban-cost-linter_438/deny.toml:29:17
   │
29 │ unmaintained = "workspace"
   │                 ━━━━━━━━━ unexpected value
```

Note: the `unmaintained = "workspace"` value appears to be invalid for current cargo-deny versions. A separate issue should be opened to fix this in the policy configuration.

Closes #438