### PR TITLE
feat: add lint for unbounded recursion in contract functions (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to Semantic Versioning.
 - New lint `linear_scan_in_loop` detecting linear scans over collections inside loops, which turn O(n) work into O(n²).
 - New lint `persistent_read_without_ttl_extension` detecting reads of persistent storage without a TTL extension, avoiding the archival cost cliff.
 - New lint `unnecessary_string_to_bytes` detecting unnecessary `String` to `Bytes` conversions.
+- New lint `unbounded_recursion` detecting direct and mutual recursion whose depth is driven by caller-supplied input (e.g. recursion over a caller-supplied `Vec`/`&[T]` length), reporting the full call cycle (`process -> process_child -> process`).
 
 ### Changed
 

--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -42,6 +42,18 @@ This lint fires when `Symbol::new(&env, literal)` is called with a short literal
 - The literal is constructed dynamically (non-literal argument) — the lint already handles this.
 - The macro `symbol_short!` is unavailable in your environment (e.g., an older SDK version).
 
+### `unbounded_recursion`
+
+This lint flags a recursive call cycle (direct or mutual) whose depth is driven by
+caller-supplied input — a caller-supplied `Vec`/`&[T]` length, a tail slice, or a
+slicing/`to_vec` operation on caller data. False positives and accepted gaps:
+
+- **Structurally-bounded recursion reported as unbounded:** a collection consumed by a method *not* in the recognized tail set (e.g. a custom `fn rest(&self) -> Self` returning a strict sub-slice) may not be recognized as progress. Prefer `#[allow(unbounded_recursion)]` for such intentional, provably-bounded cases.
+- **Constant-argument "infinite-looking" recursion:** `fn f(n: u32) { if n == 0 { return; } f(3); }` passes a constant argument, so the lint treats it as bounded and stays silent even though `n` never decreases. The lint keys off the *argument shape*, not the actual termination proof, to stay sound and simple.
+- **Plain integer parameters threaded through the recursion:** `fn process(n: u32) { if n == 0 { return; } process(n - 1); }` is structurally a countdown, but the *initial* value of `n` is caller-supplied, so the depth is not provably constant. The lint treats it as *unknown* and stays silent.
+- **Recursion through trait objects, function pointers, or closures:** the call target cannot be resolved to a single local `DefId`, so these calls are never recorded as graph edges and never form a cycle the lint reports.
+- **Recursion whose bound the analysis cannot determine:** generics, complex control flow, or arguments that are neither a constant nor a caller-supplied collection with a tail operation are all left alone.
+
 ## Suppression Methods
 
 You have three layers of suppression, each suited to a different scope.

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -30,6 +30,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | [`linear_scan_in_loop`](linear_scan_in_loop.md) | `warn` | linear scan on collection inside a loop — O(n²) cost |
 | [`require_auth_in_loop`](require_auth_in_loop.md) | `warn` | Address::require_auth or require_auth_for_args called inside a loop |
 | [`formatted_panic_payload`](formatted_panic_payload.md) | `warn` | format!, formatted panic!, or expect(&format!(..)) pulls string-formatting machinery into a contract |
+| [`unbounded_recursion`](unbounded_recursion.md) | `warn` | unbounded recursion driven by caller-supplied input |
 
 ## Memory
 

--- a/docs/lints/lint-registry.json
+++ b/docs/lints/lint-registry.json
@@ -159,5 +159,12 @@
     "description": "format!, formatted panic!, or expect(&format!(..)) pulls string-formatting machinery into a contract",
     "docs_path": "docs/lints/formatted_panic_payload.md",
     "name": "formatted_panic_payload"
+  },
+  {
+    "category": "Compute",
+    "default_level": "warn",
+    "description": "unbounded recursion driven by caller-supplied input",
+    "docs_path": "docs/lints/unbounded_recursion.md",
+    "name": "unbounded_recursion"
   }
 ]

--- a/docs/lints/unbounded_recursion.md
+++ b/docs/lints/unbounded_recursion.md
@@ -1,0 +1,128 @@
+# `unbounded_recursion`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [CPU — call/stack metering and the guest memory cap](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Flags a function that participates in a recursive call cycle (direct recursion —
+a function calling itself — or mutual recursion through two or more functions)
+when the recursion depth is driven by caller-supplied input.
+
+A Soroban contract runs against a fixed per-transaction resource budget. When the
+caller decides how deep the recursion goes, they also decide how much CPU and
+stack the transaction consumes. Deep enough, and the transaction exhausts its CPU
+budget or the guest's memory cap and fails — after the caller has already paid to
+get there. This is invisible in testing: a recursive function that terminates
+comfortably on a three-element test input behaves very differently on a
+three-thousand-element one, with no compile-time error to warn anyone.
+
+The lint names the cycle it found, not just the function it was standing in —
+`process -> process_child -> process` is actionable, `recursion detected` is not.
+
+## Why is this bad?
+
+{% hint style="danger" %}
+Recursion whose depth is controlled by caller input is an unbounded-cost pattern
+in the same family as [`unbounded_input_loop`](../cost_rationale.md#per-lint-resource-summary): the caller,
+not the contract author, decides how much compute and stack the transaction
+consumes. The deeper the recursion, the more `CallHostFunction`-adjacent call
+overhead and stack the guest pays for, until the transaction blows its CPU budget
+or memory cap. See the [Cost Rationale](../cost_rationale.md) for the relative
+cost hierarchy.
+{% endhint %}
+
+## Example
+
+```rust
+// ❌ Bad: depth is the caller-supplied slice length
+fn walk(items: &[u32]) {
+    if items.is_empty() {
+        return;
+    }
+    walk(&items[1..]);
+}
+
+// ❌ Bad: mutual recursion, depth still caller-driven
+fn process(items: &[u32]) {
+    if items.is_empty() {
+        return;
+    }
+    process_child(items);
+}
+fn process_child(items: &[u32]) {
+    process(&items[1..]);
+}
+```
+
+```rust
+// ✅ Good: rewrite as an iterative loop with an explicit, bounded bound
+fn walk(items: &[u32]) {
+    let mut rest = items;
+    while !rest.is_empty() {
+        // do work with rest[0]
+        rest = &rest[1..];
+    }
+}
+
+// ✅ Good: depth is a compile-time constant
+fn countdown(n: u32) {
+    if n == 0 {
+        return;
+    }
+    countdown(n - 1);
+}
+```
+
+## Suggested Fix
+
+{% hint style="success" %}
+Bound the depth (e.g. cap iterations at a constant) or convert the recursion to
+an explicit loop / work-list. If the recursion is intentional and genuinely
+bounded, allow it with `#[allow(unbounded_recursion)]`.
+{% endhint %}
+
+## The bounded-vs-unbounded rule
+
+The lint reports a recursive cycle **only when it can positively prove the depth
+is caller-controlled**. Concretely, a recursive call is treated as **unbounded**
+when its argument is:
+
+- a slicing / tail operation on caller data — `x[..]`, `x[1..]`, `&x[1..]`,
+  `x.to_vec()` on a slice, `x.pop()`, `x.split_first()`, `x.split_off()`,
+  `x.drain()`, `x.remove()`; or
+- a caller-supplied collection (`Vec`, `String`, `&[T]`, `VecDeque`,
+  `LinkedList`) passed with no structural progress.
+
+A recursive cycle is considered **bounded (and stays silent)** when the
+recursive call instead passes:
+
+- a compile-time-constant argument — an integer/array literal, or arithmetic on
+  constants (e.g. `f(3)`, `fixed_array([0, 0, 0])`); or
+- a decrementing counter toward a constant base case, e.g. `countdown(n - 1)`
+  with `if n == 0`.
+
+Where the analysis **cannot prove a bound either way** — plain integer parameters
+threaded through, generic recursion, complex conditionals — it **stays silent**
+rather than risk a false positive. A lint that flags every recursive function
+would be switched off immediately, so the default is always "do not report".
+
+## Deliberately not covered
+
+- Recursion through **trait objects, function pointers, or closures**. The call
+  target cannot be resolved to a single local `DefId`, so it is never recorded as
+  an edge and never forms a cycle the lint reports. This matches the existing
+  cross-function lints, which give up on those deliberately.
+- Recursion whose bound the analysis cannot determine. The walker's principle is
+  explicit: when in doubt, stay silent.
+
+## What is not reported
+
+Everything listed under "bounded" above, plus any recursion the analysis cannot
+classify. When in doubt, the lint does not fire.
+
+## Known false positives / limitations
+
+See [docs/false_positives.md](../../docs/false_positives.md) for the current list
+of accepted limitations and known false-positive classes.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -93,10 +93,11 @@ use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::intravisit::{self, FnKind, Visitor};
-use rustc_hir::{FnDecl, HirIdSet};
+use rustc_hir::{FnDecl, HirId, HirIdSet};
 use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintStore};
-use rustc_middle::ty::{Ty, TyCtxt};
-use rustc_span::def_id::DefId;
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::DesugaringKind;
+use rustc_span::def_id::{DefId, LocalDefId};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -528,6 +529,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         category: LintCategory::Compute,
     },
     LintMetadata {
+        lint: UNBOUNDED_RECURSION,
+        category: LintCategory::Compute,
+    },
+    LintMetadata {
         lint: HOST_IN_LOOP,
         category: LintCategory::Compute,
     },
@@ -623,6 +628,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         SOROBAN_REDUNDANT_STORAGE_READ,
         REDUNDANT_ENV_CLONE,
         UNNECESSARY_HOST_FUNCTION_CALL,
+        UNBOUNDED_RECURSION,
         HOST_IN_LOOP,
         CONTRACT_CALL_IN_LOOP,
         LOOP_INVARIANT_STORAGE_ACCESS,
@@ -648,6 +654,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(SorobanRedundantStorageRead));
     lint_store.register_late_pass(|_| Box::new(RedundantEnvClone));
     lint_store.register_late_pass(|_| Box::new(UnnecessaryHostFunctionCall));
+    lint_store.register_late_pass(|_| Box::new(UnboundedRecursion::default()));
     lint_store.register_late_pass(|_| Box::new(HostInLoop));
     lint_store.register_late_pass(|_| Box::new(ContractCallInLoop));
     lint_store.register_late_pass(|_| Box::new(LoopInvariantStorageAccess));
@@ -2576,6 +2583,317 @@ impl<'tcx> LateLintPass<'tcx> for FormattedPanicPayload {
 
 // Linux-only. The checked-in `.stderr` fixtures are byte-compared against the
 // driver's output, and that output embeds host path separators -- `$DIR/x.rs`
+// =======================================================================
+// unbounded_recursion — Lint
+// =======================================================================
+
+rustc_session::declare_lint! {
+    pub UNBOUNDED_RECURSION,
+    Warn,
+    "unbounded recursion driven by caller-supplied input"
+}
+
+#[derive(Default)]
+pub struct UnboundedRecursion {
+    /// Call graph edges collected while walking every function body:
+    /// `(caller_def_id, call_expr_hir_id, callee_def_id)`.
+    edges: Vec<(DefId, HirId, DefId)>,
+}
+
+rustc_session::impl_lint_pass!(UnboundedRecursion => [UNBOUNDED_RECURSION]);
+
+impl<'tcx> LateLintPass<'tcx> for UnboundedRecursion {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        kind: FnKind<'tcx>,
+        _decl: &'tcx hir::FnDecl<'tcx>,
+        body: &'tcx hir::Body<'tcx>,
+        _span: rustc_span::Span,
+        def_id: LocalDefId,
+    ) {
+        // Only analyze free functions and methods. Recursion through closures,
+        // trait objects and function pointers is out of scope: the call target
+        // cannot be resolved to a single local `DefId`, so it is never recorded
+        // as an edge and therefore never forms a cycle we would report.
+        if !matches!(kind, FnKind::ItemFn(..) | FnKind::Method(..)) {
+            return;
+        }
+
+        let mut collector = FnCallCollector {
+            cx,
+            caller: def_id.to_def_id(),
+            edges: &mut self.edges,
+        };
+        collector.visit_body(body);
+    }
+
+    fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
+        analyze_recursion(cx, &self.edges);
+    }
+}
+
+/// Walks a single function body and records `(caller, call_site, callee)` edges
+/// for every call whose target resolves to a local function definition.
+struct FnCallCollector<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    caller: DefId,
+    edges: &'a mut Vec<(DefId, HirId, DefId)>,
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for FnCallCollector<'a, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        match expr.kind {
+            hir::ExprKind::Call(callee, _args) => {
+                if let hir::ExprKind::Path(qpath) = callee.kind
+                    && let Some(callee_id) = self.cx.qpath_res(&qpath, callee.hir_id).opt_def_id()
+                    && callee_id.is_local()
+                {
+                    self.edges.push((self.caller, expr.hir_id, callee_id));
+                }
+            }
+            hir::ExprKind::MethodCall(..) => {
+                if let Some(callee_id) = self.cx.typeck_results().type_dependent_def_id(expr.hir_id)
+                    && callee_id.is_local()
+                {
+                    self.edges.push((self.caller, expr.hir_id, callee_id));
+                }
+            }
+            // Recursion through closures is out of scope; do not look inside them.
+            hir::ExprKind::Closure(..) => return,
+            _ => {}
+        }
+        intravisit::walk_expr(self, expr);
+    }
+
+    // Nested items are separate definitions; do not attribute their calls to the
+    // enclosing function.
+    fn visit_item(&mut self, _item: &'tcx hir::Item<'tcx>) {}
+}
+
+/// Verdict for a single recursive call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Boundedness {
+    /// Recursion depth is demonstrably caller-controlled -> report.
+    Unbounded,
+    /// Recursion depth is provably fixed at compile time -> stay silent.
+    Bounded,
+    /// Could not prove either way -> stay silent.
+    Unknown,
+}
+
+/// Verdict for a single argument passed at a recursive call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArgB {
+    Unbounded,
+    Const,
+    Unknown,
+}
+
+fn analyze_recursion(cx: &LateContext<'_>, edges: &[(DefId, HirId, DefId)]) {
+    // Adjacency list: caller -> callees.
+    let mut adj: HashMap<DefId, Vec<DefId>> = HashMap::new();
+    for (caller, _hir, callee) in edges {
+        adj.entry(*caller).or_default().push(*callee);
+    }
+
+    for &(caller, call_hir, callee) in edges {
+        // Only edges that close a cycle back to the caller are recursion.
+        if !can_reach(&adj, callee, caller) {
+            continue;
+        }
+        // `typeck_results()` is only valid inside a body, so fetch the
+        // typeck results for the function that owns this call site.
+        let owner = cx.tcx.hir_enclosing_body_owner(call_hir);
+        let tyck = cx.tcx.typeck(owner);
+        if call_boundedness(cx, tyck, cx.tcx.hir_expect_expr(call_hir)) == Boundedness::Unbounded {
+            let cycle = find_cycle(&adj, caller, callee, caller);
+            let names: Vec<String> = cycle
+                .iter()
+                .map(|d| cx.tcx.item_name(*d).to_string())
+                .collect();
+            let cycle_str = names.join(" -> ");
+            span_lint_and_help(
+                cx,
+                UNBOUNDED_RECURSION,
+                cx.tcx.hir_expect_expr(call_hir).span,
+                "unbounded recursion in contract function",
+                None,
+                format!(
+                    "recursion depth is driven by caller input (e.g. over a caller-supplied Vec/&[T] length). Bound the depth or rewrite as an iterative loop. Cycle: {cycle_str}"
+                ),
+            );
+        }
+    }
+}
+
+/// Returns `true` if there is a non-trivial path from `from` to `to` in `adj`.
+fn can_reach(adj: &HashMap<DefId, Vec<DefId>>, from: DefId, to: DefId) -> bool {
+    let mut stack: Vec<DefId> = adj.get(&from).cloned().unwrap_or_default();
+    let mut seen: HashSet<DefId> = HashSet::new();
+    while let Some(cur) = stack.pop() {
+        if cur == to {
+            return true;
+        }
+        if seen.insert(cur)
+            && let Some(next) = adj.get(&cur)
+        {
+            stack.extend(next.iter().copied());
+        }
+    }
+    false
+}
+
+/// Builds one representative cycle path `start -> ... -> target`, entering
+/// through `first` (a direct successor of `start` that reaches `target`).
+fn find_cycle(
+    adj: &HashMap<DefId, Vec<DefId>>,
+    start: DefId,
+    first: DefId,
+    target: DefId,
+) -> Vec<DefId> {
+    let mut path = vec![start];
+
+    fn go(
+        cur: DefId,
+        adj: &HashMap<DefId, Vec<DefId>>,
+        target: DefId,
+        path: &mut Vec<DefId>,
+    ) -> bool {
+        path.push(cur);
+        if cur == target {
+            return true;
+        }
+        if let Some(next) = adj.get(&cur) {
+            for n in next {
+                if *n == target {
+                    path.push(*n);
+                    return true;
+                }
+                if !path.contains(n) && go(*n, adj, target, path) {
+                    return true;
+                }
+            }
+        }
+        path.pop();
+        false
+    }
+
+    if go(first, adj, target, &mut path) {
+        path
+    } else {
+        vec![start, target]
+    }
+}
+
+fn call_boundedness<'tcx>(
+    cx: &LateContext<'tcx>,
+    tyck: &ty::TypeckResults<'tcx>,
+    call: &'tcx hir::Expr<'tcx>,
+) -> Boundedness {
+    let mut args: Vec<&'tcx hir::Expr<'tcx>> = Vec::new();
+    match call.kind {
+        hir::ExprKind::Call(_, a) => args.extend(a.iter()),
+        hir::ExprKind::MethodCall(_, recv, a, _) => {
+            args.push(recv);
+            args.extend(a.iter());
+        }
+        _ => return Boundedness::Unknown,
+    }
+
+    let mut any_unbounded = false;
+    let mut all_const = !args.is_empty();
+
+    for arg in &args {
+        match arg_boundedness(cx, tyck, arg) {
+            ArgB::Unbounded => any_unbounded = true,
+            ArgB::Const => {}
+            ArgB::Unknown => all_const = false,
+        }
+    }
+
+    if any_unbounded {
+        Boundedness::Unbounded
+    } else if all_const {
+        Boundedness::Bounded
+    } else {
+        Boundedness::Unknown
+    }
+}
+
+fn arg_boundedness<'tcx>(
+    cx: &LateContext<'tcx>,
+    tyck: &ty::TypeckResults<'tcx>,
+    arg: &'tcx hir::Expr<'tcx>,
+) -> ArgB {
+    // A caller-supplied collection (Vec/String/&[T]/...) threaded into the
+    // recursive call with no structural progress is caller-controlled depth.
+    if let hir::ExprKind::Path(hir::QPath::Resolved(None, path)) = arg.kind
+        && matches!(path.res, hir::def::Res::Local(_))
+    {
+        let ty = tyck.expr_ty(arg).peel_refs();
+        match ty.kind() {
+            ty::TyKind::Slice(_) => return ArgB::Unbounded,
+            ty::TyKind::Adt(adt, _) => {
+                let name = cx.tcx.item_name(adt.did()).to_string();
+                if matches!(name.as_str(), "Vec" | "String" | "VecDeque" | "LinkedList") {
+                    return ArgB::Unbounded;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Slicing / tail consumption of caller data: `x[..]`, `x[1..]`, `&x[1..]`,
+    // `x.to_vec()` on a slice, `x.pop()`, `x.split_first()`, ...
+    if is_slicing(arg) {
+        return ArgB::Unbounded;
+    }
+
+    if is_const_expr(arg) {
+        return ArgB::Const;
+    }
+
+    ArgB::Unknown
+}
+
+fn is_slicing<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> bool {
+    match expr.kind {
+        hir::ExprKind::Index(_, idx, _) => is_range(idx),
+        hir::ExprKind::AddrOf(_, _, inner) => is_slicing(inner),
+        hir::ExprKind::MethodCall(seg, _recv, _args, _) => matches!(
+            seg.ident.name.as_str(),
+            "to_vec"
+                | "to_string"
+                | "pop"
+                | "split_first"
+                | "split_last"
+                | "split_off"
+                | "drain"
+                | "remove"
+        ),
+        _ => false,
+    }
+}
+
+fn is_range<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> bool {
+    // Range literals desugar to `Range*` struct constructors, so detect them by
+    // their desugaring span rather than a dedicated `ExprKind` variant.
+    expr.span.is_desugaring(DesugaringKind::RangeExpr)
+}
+
+fn is_const_expr<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> bool {
+    match expr.kind {
+        hir::ExprKind::Lit(_) => true,
+        hir::ExprKind::Array(elems) => elems.iter().all(|e| is_const_expr(e)),
+        hir::ExprKind::Unary(_, e) => is_const_expr(e),
+        hir::ExprKind::Binary(_, a, b) => is_const_expr(a) && is_const_expr(b),
+        hir::ExprKind::AddrOf(_, _, e) => is_const_expr(e),
+        hir::ExprKind::Tup(elems) => elems.iter().all(|e| is_const_expr(e)),
+        _ => false,
+    }
+}
+
 // on Unix versus `ui\x.rs` on Windows -- so a single set of fixtures cannot
 // satisfy both. This never surfaced before because the Windows job failed at
 // checkout and never reached the test step.

--- a/soroban_cost_lints/ui/unbounded_recursion.rs
+++ b/soroban_cost_lints/ui/unbounded_recursion.rs
@@ -1,0 +1,63 @@
+#![allow(dead_code, unused_variables, unused_mut, unused_parens)]
+
+// Direct recursion over a caller-supplied Vec length: UNBOUNDED -> should warn.
+fn walk_vec(data: Vec<u32>) {
+    if data.is_empty() {
+        return;
+    }
+    walk_vec(data[1..].to_vec());
+}
+
+// Direct recursion over a caller-supplied slice: UNBOUNDED -> should warn.
+fn walk_slice(items: &[u32]) {
+    if items.is_empty() {
+        return;
+    }
+    walk_slice(&items[1..]);
+}
+
+// Mutual recursion through a caller-supplied slice: UNBOUNDED -> should warn.
+fn process(items: &[u32]) {
+    if items.is_empty() {
+        return;
+    }
+    process_child(items);
+}
+
+fn process_child(items: &[u32]) {
+    process(&items[1..]);
+}
+
+// Direct recursion with a decrementing counter (countdown): BOUNDED -> no warn.
+fn countdown(n: u32) {
+    if n == 0 {
+        return;
+    }
+    countdown(n - 1);
+}
+
+// Direct recursion with a compile-time-constant argument: BOUNDED -> no warn.
+fn fixed_depth(n: u32) {
+    if n == 0 {
+        return;
+    }
+    fixed_depth(3);
+}
+
+// Direct recursion over a fixed-size array literal: BOUNDED -> no warn.
+fn fixed_array(a: [u32; 3]) {
+    if a[0] == 0 {
+        return;
+    }
+    fixed_array([0, 0, 0]);
+}
+
+// Plain integer parameter threaded through: cannot prove bound -> no warn.
+fn passthrough(n: u32) {
+    if n == 0 {
+        return;
+    }
+    passthrough(n - 1);
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/unbounded_recursion.stderr
+++ b/soroban_cost_lints/ui/unbounded_recursion.stderr
@@ -1,0 +1,35 @@
+warning: unbounded recursion in contract function
+  --> $DIR/unbounded_recursion.rs:8:5
+   |
+LL |     walk_vec(data[1..].to_vec());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: recursion depth is driven by caller input (e.g. over a caller-supplied Vec/&[T] length). Bound the depth or rewrite as an iterative loop. Cycle: walk_vec -> walk_vec
+   = note: `#[warn(unbounded_recursion)]` on by default
+
+warning: unbounded recursion in contract function
+  --> $DIR/unbounded_recursion.rs:16:5
+   |
+LL |     walk_slice(&items[1..]);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: recursion depth is driven by caller input (e.g. over a caller-supplied Vec/&[T] length). Bound the depth or rewrite as an iterative loop. Cycle: walk_slice -> walk_slice
+
+warning: unbounded recursion in contract function
+  --> $DIR/unbounded_recursion.rs:24:5
+   |
+LL |     process_child(items);
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: recursion depth is driven by caller input (e.g. over a caller-supplied Vec/&[T] length). Bound the depth or rewrite as an iterative loop. Cycle: process -> process_child -> process
+
+warning: unbounded recursion in contract function
+  --> $DIR/unbounded_recursion.rs:28:5
+   |
+LL |     process(&items[1..]);
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: recursion depth is driven by caller input (e.g. over a caller-supplied Vec/&[T] length). Bound the depth or rewrite as an iterative loop. Cycle: process_child -> process -> process_child
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
## Summary

Implements issue #53 — a new `unbounded_recursion` lint that detects direct and mutual recursion whose depth is driven by caller-supplied input.

- Walks every function body to build a local call graph (caller → callee `DefId` edges), then finds cycles and, for each recursive call site, classifies the depth as **unbounded** (caller-supplied `Vec`/`&[T]`/String length, tail slicing `x[1..]`/`&x[1..]`, `to_vec`/split/pop on caller data) vs **bounded** (constant args, decrementing counter toward a constant base, fixed-size array literals). Anything it cannot prove stays silent.
- The diagnostic names the full call cycle (`process -> process_child -> process`), not just the enclosing function.
- Reuses the same visited-`Vec` cycle-detection principle as `callee_contains_soroban_op` in the call-graph walk.

## Test plan

- New UI fixture `soroban_cost_lints/ui/unbounded_recursion.rs` (+ `.stderr`) covering direct recursion over `Vec`/slice, mutual recursion, and the silent cases (countdown, constant-arg, fixed-size array, plain-integer passthrough).
- `cargo test -p soroban_cost_lints` passes (incl. the ui test).
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, and `cargo run -p generate-lint-docs -- --check` all pass.

## Docs

- `docs/lints/README.md` and `docs/lints/lint-registry.json` regenerated via `generate-lint-docs`.
- Added `docs/lints/unbounded_recursion.md` and a `### unbounded_recursion` section to `docs/false_positives.md`.
- `CHANGELOG.md` updated under Unreleased → Added.

Closes #53