### PR TITLE
test: add ui fixtures and false-positive notes for the storage lints (#341)

### DIFF
--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -144,3 +144,41 @@ When you suppress a lint, verify that the suppression works correctly:
 | Per-site | `#[allow(lint_name)]` | Intentional patterns at specific call sites |
 | Per-file | `.lintignore` | Generated code, vendored deps, entire files |
 | Per-workspace | `budget.toml` `"allow"` | Project-wide decisions (use sparingly) |
+
+### `loop_invariant_storage_access`
+
+This lint flags storage method calls (`env.storage()`, `.instance()`/`.persistent()`/`.temporary()`, and the terminal `get`/`has`/`set`) that sit inside a loop and whose operands are provably loop-invariant. Notes from writing the fixture:
+
+- A single logical `env.storage().instance().get(&1)` inside a loop emits **three** warnings — one per call in the chain (`storage`, `instance`, then `get`) — because each call is matched independently and each is loop-invariant. This is expected, not a defect.
+- **Genuine near-miss (must not fire):** when the *receiver* is the loop variable — `for s in stores.iter() { s.get(&1); }` where `s: &Instance` — the access depends on loop state and is correctly skipped. This is the real "varies per iteration" case.
+- **Subtler near-miss:** a `get(item)` whose *argument* `item` is the loop variable. The `get` call is correctly skipped (its argument depends on loop state), but the `env.storage()` and `.instance()` receiver calls are *still* flagged, because their receiver `env` is constant and therefore loop-invariant. So "the key varies per iteration" does not fully silence the lint — only the terminal call is suppressed. This is documented so the surviving receiver warnings are not mistaken for a bug.
+- The lint keys off structural loop-invariance, not value ranges; a literal key (`&1`) is treated the same as `let k = &1; get(k)`.
+
+### `soroban_redundant_storage_read`
+
+Fires when two reads of the same key (by source-text snippet) appear with no intervening write, at the top level of a block.
+
+- **Near-miss 1 — write between reads:** `get(&1); set(&1, &2); get(&1)`. The write resets the tracked key, so the second read is **not** flagged. Correct.
+- **Near-miss 2 — different keys:** `get(&1); get(&2)`. Different source-text keys, so no redundancy is reported. Correct.
+- Key equality is **textual** (the `snippet_opt` of the key argument), not semantic. `get(&k)` and `get(&k)` match; `get(&1)` and `get(1)` (without the `&`) would not, because the snippets differ. The check is syntactic — keep this in mind when reading the fixture.
+- The lint only compares reads that are top-level statements/expressions within the **same** block. A read inside a nested `if`/`match`/closure is in a different block and is not compared against an outer-block read of the same key; that is why the fixture keeps both reads at the same block level.
+- **No known false positives:** in every case the warning corresponds to a real duplicate read.
+
+### `storage_write_without_read`
+
+Fires on any `set` whose `(receiver, key)` snippet has no matching `get`/`has` anywhere in the same function.
+
+- **Near-miss — initializer skip:** a function whose name contains `init` or `set_admin` is intentionally not analyzed, so a legitimate initializing `set` with no prior read stays silent. The fixture exercises this with `fn initialize(...)` and `fn set_admin(...)`.
+- **Near-miss 2 — read precedes write:** `get(&1); set(&1, &2)`. The prior read of the same key suppresses the warning. Correct.
+- Matching is by source-snippet text, so a read written with a syntactically different but semantically equal key (e.g. `has(&key)` paired with `set(key)` without the `&`) will not link and the write will still fire. The fixture uses identical snippets to exercise the matching path.
+- Analysis is **per-function**: reads in a different function do not count toward a write's read set.
+- **No known false positives** beyond the intentional initializer skip: any write with a truly absent read is reported, which is the lint's purpose.
+
+### `persistent_read_without_ttl_extension`
+
+Fires on every `get`/`has` on `persistent` storage when the function contains no `extend_ttl` call.
+
+- **Near-miss 1 — TTL extended:** a single `extend_ttl(...)` call anywhere in the function suppresses **all** persistent-read warnings for that function. The check is all-or-nothing per function, not per key — so a function that extends TTL on one key but reads others without extending still produces no warning. Documented because it is easy to misread the fixture as per-key.
+- **Near-miss 2 — non-persistent storage:** `instance.get(...)` / `temporary.get(...)` are out of scope and never flagged.
+- The lint collects reads via a visitor over the whole function body, so a read in a nested block still counts.
+- **No known false positives:** a persistent read with no `extend_ttl` in the function is always reported.

--- a/soroban_cost_lints/ui/loop_invariant_storage_access.rs
+++ b/soroban_cost_lints/ui/loop_invariant_storage_access.rs
@@ -1,0 +1,73 @@
+#![allow(
+    soroban_storage_in_loop,
+    soroban_redundant_storage_read,
+    storage_write_without_read,
+    persistent_read_without_ttl_extension,
+    instance_storage_for_unbounded_data,
+    unbounded_input_loop
+)]
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+            pub fn persistent(&self) -> Persistent { Persistent }
+            pub fn temporary(&self) -> Temporary { Temporary }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Persistent;
+        impl Persistent {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+            pub fn extend_ttl<K>(&self, _k: &K, _ttl: &()) {}
+        }
+
+        pub struct Temporary;
+        impl Temporary {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+    }
+}
+
+use soroban_sdk::Env;
+use soroban_sdk::storage::Instance;
+
+// Fires: a storage access inside a loop whose operands do not depend on the
+// loop. `env` is a constant receiver, so every call in the chain
+// (`storage` / `instance` / `get`) is loop-invariant.
+fn invariant_get(env: Env) {
+    for _ in 0..10 {
+        let _: Option<i32> = env.storage().instance().get(&1); // Should Warn
+    }
+}
+
+// Near-miss: the storage receiver `s` IS the loop variable, so the access
+// depends on loop state and must NOT be flagged even though it is inside a loop.
+fn varying_receiver(env: Env, stores: Vec<Instance>) {
+    for s in stores.iter() {
+        let _: Option<i32> = s.get(&1); // Should NOT warn
+    }
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/loop_invariant_storage_access.stderr
+++ b/soroban_cost_lints/ui/loop_invariant_storage_access.stderr
@@ -1,0 +1,27 @@
+warning: loop-invariant storage operation inside a loop
+  --> $DIR/loop_invariant_storage_access.rs:61:30
+   |
+LL |         let _: Option<i32> = env.storage().instance().get(&1); // Should Warn
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: hoist this storage operation out of the loop
+   = note: `#[warn(loop_invariant_storage_access)]` on by default
+
+warning: loop-invariant storage operation inside a loop
+  --> $DIR/loop_invariant_storage_access.rs:61:30
+   |
+LL |         let _: Option<i32> = env.storage().instance().get(&1); // Should Warn
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: hoist this storage operation out of the loop
+
+warning: loop-invariant storage operation inside a loop
+  --> $DIR/loop_invariant_storage_access.rs:61:30
+   |
+LL |         let _: Option<i32> = env.storage().instance().get(&1); // Should Warn
+   |                              ^^^^^^^^^^^^^
+   |
+   = help: hoist this storage operation out of the loop
+
+warning: 3 warnings emitted
+

--- a/soroban_cost_lints/ui/persistent_read_without_ttl_extension.rs
+++ b/soroban_cost_lints/ui/persistent_read_without_ttl_extension.rs
@@ -1,0 +1,71 @@
+#![allow(
+    soroban_redundant_storage_read,
+    storage_write_without_read,
+    instance_storage_for_unbounded_data,
+    loop_invariant_storage_access,
+    soroban_storage_in_loop,
+    unbounded_input_loop
+)]
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+            pub fn persistent(&self) -> Persistent { Persistent }
+            pub fn temporary(&self) -> Temporary { Temporary }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Persistent;
+        impl Persistent {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+            pub fn extend_ttl<K>(&self, _k: &K, _ttl: &()) {}
+        }
+
+        pub struct Temporary;
+        impl Temporary {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+    }
+}
+
+use soroban_sdk::Env;
+
+// Fires: a persistent read with no `extend_ttl` call in the function.
+fn read_without_extend(env: Env) {
+    let _: Option<i32> = env.storage().persistent().get(&1); // Should Warn
+}
+
+// Near-miss: the TTL is extended after the read, so the lint stays silent.
+fn read_with_extend(env: Env) {
+    let _: Option<i32> = env.storage().persistent().get(&1);
+    env.storage().persistent().extend_ttl(&1, &()); // Should NOT warn
+}
+
+// Near-miss: reads of non-persistent storage are out of scope.
+fn non_persistent_read(env: Env) {
+    let _: Option<i32> = env.storage().instance().get(&1); // Should NOT warn
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/persistent_read_without_ttl_extension.stderr
+++ b/soroban_cost_lints/ui/persistent_read_without_ttl_extension.stderr
@@ -1,0 +1,11 @@
+warning: persistent storage read without TTL extension — archival cost cliff
+  --> $DIR/persistent_read_without_ttl_extension.rs:57:26
+   |
+LL |     let _: Option<i32> = env.storage().persistent().get(&1); // Should Warn
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: after reading from persistent storage, call extend_ttl on the same key to avoid paying archival cost on subsequent access
+   = note: `#[warn(persistent_read_without_ttl_extension)]` on by default
+
+warning: 1 warning emitted
+

--- a/soroban_cost_lints/ui/soroban_redundant_storage_read.rs
+++ b/soroban_cost_lints/ui/soroban_redundant_storage_read.rs
@@ -1,0 +1,76 @@
+#![allow(
+    storage_write_without_read,
+    persistent_read_without_ttl_extension,
+    instance_storage_for_unbounded_data,
+    loop_invariant_storage_access,
+    soroban_storage_in_loop,
+    unbounded_input_loop
+)]
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+            pub fn persistent(&self) -> Persistent { Persistent }
+            pub fn temporary(&self) -> Temporary { Temporary }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Persistent;
+        impl Persistent {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+            pub fn extend_ttl<K>(&self, _k: &K, _ttl: &()) {}
+        }
+
+        pub struct Temporary;
+        impl Temporary {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+    }
+}
+
+use soroban_sdk::Env;
+
+// Fires: two reads of the same key with no intervening write. The second read is
+// flagged as redundant.
+fn redundant_read(env: Env) {
+    let _: Option<i32> = env.storage().instance().get(&1);
+    let _: Option<i32> = env.storage().instance().get(&1); // Should Warn
+}
+
+// Near-miss: a write between the reads clears the tracked key, so the second
+// read is not redundant and must NOT be flagged.
+fn read_write_read(env: Env) {
+    let _: Option<i32> = env.storage().instance().get(&1);
+    env.storage().instance().set(&1, &2);
+    let _: Option<i32> = env.storage().instance().get(&1); // Should NOT warn
+}
+
+// Near-miss: the two reads use different keys, so the second is not redundant.
+fn different_keys(env: Env) {
+    let _: Option<i32> = env.storage().instance().get(&1); // Should NOT warn
+    let _: Option<i32> = env.storage().instance().get(&2); // Should NOT warn
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/soroban_redundant_storage_read.stderr
+++ b/soroban_cost_lints/ui/soroban_redundant_storage_read.stderr
@@ -1,0 +1,11 @@
+warning: redundant storage read: this key was already read without modification
+  --> $DIR/soroban_redundant_storage_read.rs:59:26
+   |
+LL |     let _: Option<i32> = env.storage().instance().get(&1); // Should Warn
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: store the value from the first read and reuse it instead of reading again
+   = note: `#[warn(soroban_redundant_storage_read)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
## Summary

Adds dedicated ui fixtures (with **generated** `.stderr`, never hand-written) for the four storage / entry-lifecycle lints that lacked them, plus a `docs/false_positives.md` section for each recording every near-miss considered while writing the fixtures.

- `loop_invariant_storage_access`
- `soroban_redundant_storage_read`
- `storage_write_without_read`
- `persistent_read_without_ttl_extension`

Each fixture contains a case that **must fire** and a near-miss that **must not**:
- `loop_invariant`: fires on a loop-invariant `env.storage().instance().get(&1)`; near-miss is a read whose receiver `s` is the loop variable (access depends on loop state).
- `soroban_redundant_storage_read`: fires on two same-key reads with no intervening write; near-misses are a write between reads and different keys.
- `storage_write_without_read`: fires on an orphaned `set`; near-misses are an `init`/`set_admin` initializer and a read that precedes the write.
- `persistent_read_without_ttl_extension`: fires on a persistent read with no `extend_ttl`; near-misses are a read with `extend_ttl` present and a non-persistent read.

Note: `upstream/main` already ships a `storage_write_without_read` fixture, so this PR only adds the three remaining ones (and documents all four).

## UI test output

```
$ cargo test -p soroban_cost_lints --lib ui
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass.

## Files

- `soroban_cost_lints/ui/loop_invariant_storage_access.{rs,stderr}`
- `soroban_cost_lints/ui/soroban_redundant_storage_read.{rs,stderr}`
- `soroban_cost_lints/ui/persistent_read_without_ttl_extension.{rs,stderr}`
- `soroban_cost_lints/ui/storage_write_without_read.{rs,stderr}` (already present upstream; left unchanged)
- `docs/false_positives.md` (four new sections)

Closes #341