### PR TITLE
feat: add lint for 128-bit arithmetic where 64 bits would do

### DIFF
--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -144,3 +144,6 @@ When you suppress a lint, verify that the suppression works correctly:
 | Per-site | `#[allow(lint_name)]` | Intentional patterns at specific call sites |
 | Per-file | `.lintignore` | Generated code, vendored deps, entire files |
 | Per-workspace | `budget.toml` `"allow"` | Project-wide decisions (use sparingly) |
+
+## u128_where_u64_suffices
+None known.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -612,6 +612,11 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: FORMATTED_PANIC_PAYLOAD,
         category: LintCategory::Compute,
     },
+    LintMetadata {
+        name: "u128_where_u64_suffices",
+        category: LintCategory::Compute,
+        rationale: "wasm32 is a 32-bit target. A `u64` operation already compiles to several instructions; a `u128` operation compiles to several times more, since the runtime synthesises 128-bit arithmetic from 32-bit primitives.",
+    },
 ];
 
 /// `dylint` entry point. Registers every lint declared by this crate with
@@ -674,6 +679,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(SymbolNewForShortLiteral));
     lint_store.register_late_pass(|_| Box::new(PersistentReadWithoutTtlExtension));
     lint_store.register_late_pass(|_| Box::new(InstanceStorageForUnboundedData));
+    lint_store.register_late_pass(|_| Box::new(U128WhereU64Suffices));
 
     // `formatted_panic_payload` needs the AST-level `format_args!` nodes to
     // tell a zero-argument `panic!("literal")` apart from a formatted
@@ -2593,6 +2599,18 @@ rustc_session::declare_lint! {
     "unbounded recursion driven by caller-supplied input"
 }
 
+declare_lint! {
+    /// **What it does:** Checks for 128-bit arithmetic operations where 64-bit would suffice.
+    ///
+    /// **Why is this bad?** wasm32 is a 32-bit target. A `u64` operation already compiles to several instructions; a `u128` operation compiles to several times more, since the runtime synthesises 128-bit arithmetic from 32-bit primitives.
+    ///
+    /// **Known problems:** None.
+    pub U128_WHERE_U64_SUFFICES,
+    Warn,
+    "128-bit arithmetic where 64 bits would do"
+}
+
+
 #[derive(Default)]
 pub struct UnboundedRecursion {
     /// Call graph edges collected while walking every function body:
@@ -2949,4 +2967,47 @@ fn storage_write_without_read_lookup_benchmark() {
     eprintln!(
         "storage_write_without_read_lookup/{N}x{N}: hashset={hashset_elapsed:?} vec_scan={vec_elapsed:?}"
     );
+}
+
+pub struct U128WhereU64Suffices;
+
+impl<'tcx> LateLintPass<'tcx> for U128WhereU64Suffices {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        if let hir::ExprKind::Binary(op, left, right) = expr.kind {
+            let ty = cx.typeck_results().expr_ty(expr);
+            if matches!(ty.kind(), ty::Uint(ty::UintTy::U128) | ty::Int(ty::IntTy::I128)) {
+                if is_provably_64_bit(cx, left) && is_provably_64_bit(cx, right) {
+                    span_lint_and_help(
+                        cx,
+                        U128_WHERE_U64_SUFFICES,
+                        expr.span,
+                        "128-bit arithmetic where 64 bits would do",
+                        None,
+                        "wasm32 is a 32-bit target; 128-bit operations are significantly more expensive. Since both operands fit in 64 bits, consider performing this operation in `u64`/`i64` and casting the result to 128-bit only if necessary.",
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn is_provably_64_bit<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) -> bool {
+    let expr = expr.peel_blocks();
+    match expr.kind {
+        hir::ExprKind::Lit(lit) => {
+            if let LitKind::Int(val, _) = lit.node {
+                return val <= u64::MAX as u128;
+            }
+            false
+        },
+        hir::ExprKind::Cast(inner, _) => {
+            let inner_ty = cx.typeck_results().expr_ty(inner);
+            matches!(
+                inner_ty.kind(),
+                ty::Uint(ty::UintTy::U8 | ty::UintTy::U16 | ty::UintTy::U32 | ty::UintTy::U64) |
+                ty::Int(ty::IntTy::I8 | ty::IntTy::I16 | ty::IntTy::I32 | ty::IntTy::I64)
+            )
+        },
+        _ => false
+    }
 }

--- a/soroban_cost_lints/ui/u128_where_u64_suffices.rs
+++ b/soroban_cost_lints/ui/u128_where_u64_suffices.rs
@@ -1,0 +1,16 @@
+#![no_std]
+#![allow(unused)]
+
+pub fn test_u128_suffices() {
+    let x: u32 = 10;
+    // Should fire: both operands are provably <= 64 bits (one is a cast from u32, one is a small literal)
+    let y = (x as u128) + 5u128;
+
+    // Should NOT fire: one operand is an unproven u128 parameter
+    let z = y + 10u128;
+}
+
+pub fn token_balance_arithmetic(balance: i128) {
+    // Should NOT fire: 'balance' is a caller-supplied i128, could exceed 64 bits
+    let new_balance = balance - 100i128;
+}

--- a/soroban_cost_lints/ui/u128_where_u64_suffices.stderr
+++ b/soroban_cost_lints/ui/u128_where_u64_suffices.stderr
@@ -1,0 +1,10 @@
+warning: 128-bit arithmetic where 64 bits would do
+  --> $DIR/u128_where_u64_suffices.rs:7:13
+   |
+LL |     let y = (x as u128) + 5u128;
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: wasm32 is a 32-bit target; 128-bit operations are significantly more expensive. Since both operands fit in 64 bits, consider performing this operation in `u64`/`i64` and casting the result to 128-bit only if necessary.
+   = note: `-W u128-where-u64-suffices` implied by `-W warnings`
+
+warning: 1 warning emitted


### PR DESCRIPTION
## Summary

Adds the `U128_WHERE_U64_SUFFICES` lint to catch 128-bit arithmetic operations where 64-bit would suffice.

### What the lint proves before firing
The lint fires only when **both** operands are provably bounded within 64 bits at the point of the operation. Concretely, it considers an operand provably 64-bit if it is:
- An integer literal whose value fits in `u64`
- A cast (`as u128` / `as i128`) from a type that is at most 64 bits wide (`u8`, `u16`, `u32`, `u64`, `i8`, `i16`, `i32`, `i64`)

All other expressions — function parameters, variables, token balances, anything derived from a caller-supplied `i128` — are treated as potentially exceeding 64 bits, and the lint does **not** fire.

### Changes
- `soroban_cost_lints/src/lib.rs`: declare, implement, and register `U128_WHERE_U64_SUFFICES`; add row to `LINT_METADATA`
- `soroban_cost_lints/ui/u128_where_u64_suffices.rs`: UI fixture covering a firing case (cast + literal) and a non-firing case (caller-supplied `i128`)
- `soroban_cost_lints/ui/u128_where_u64_suffices.stderr`: expected compiler output
- `docs/false_positives.md`: append section (none currently known)

Closes #402