### PR TITLE
feat(cli): add github actions workflow annotation output format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,4 +67,4 @@ runs:
         if [ -n "${{ inputs.config }}" ]; then
           CONFIG_ARG="--config ${{ inputs.config }}"
         fi
-        "${{ github.action_path }}/target/release/cargo-cost-lint" $CONFIG_ARG ${{ inputs.args }}
+        "${{ github.action_path }}/target/release/cargo-cost-lint" --format github $CONFIG_ARG ${{ inputs.args }}

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -260,7 +260,7 @@ fn main() {
         eprintln!("[verbose] command: {:?}", cmd);
     }
 
-    if cli.format == OutputFormat::Json {
+    if cli.format != OutputFormat::Text {
         cmd.arg("--");
         cmd.arg("--message-format=json");
         cmd.stdout(Stdio::piped());
@@ -270,10 +270,11 @@ fn main() {
         .spawn()
         .expect("Failed to execute cargo dylint. Is cargo-dylint installed?");
 
-    if cli.format == OutputFormat::Json {
+    if cli.format != OutputFormat::Text {
         let stdout = child.stdout.take().expect("Failed to capture stdout");
         let reader = BufReader::new(stdout);
         let mut highest_exit_code = 0;
+        let mut sarif_findings = Vec::new();
 
         for line_str in reader.lines().map_while(Result::ok) {
             if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&line_str) {
@@ -367,8 +368,22 @@ fn main() {
                                         suggestion: None,
                                     };
 
-                                    if let Ok(json_str) = serde_json::to_string(&finding) {
-                                        println!("{}", json_str);
+                                    match cli.format {
+                                        OutputFormat::Json => {
+                                            if let Ok(json_str) = serde_json::to_string(&finding) {
+                                                println!("{}", json_str);
+                                            }
+                                        }
+                                        OutputFormat::Github => {
+                                            let _ = output_formatters::emit_github_annotation(
+                                                &finding,
+                                                &mut std::io::stdout(),
+                                            );
+                                        }
+                                        OutputFormat::Sarif => {
+                                            sarif_findings.push(finding);
+                                        }
+                                        OutputFormat::Text => {}
                                     }
                                 }
                             }
@@ -376,6 +391,10 @@ fn main() {
                     }
                 }
             }
+        }
+
+        if cli.format == OutputFormat::Sarif {
+            let _ = output_formatters::emit_sarif(&sarif_findings, &mut std::io::stdout());
         }
 
         let status = child.wait().expect("Failed to wait on cargo dylint");
@@ -798,6 +817,20 @@ mod tests {
         let cli = Cli::try_parse_from(["cargo-cost-lint", "--format", "json"])
             .expect("parsing should succeed");
         assert_eq!(cli.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn cli_parses_format_github() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--format", "github"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.format, OutputFormat::Github);
+    }
+
+    #[test]
+    fn cli_parses_format_sarif() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--format", "sarif"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.format, OutputFormat::Sarif);
     }
 
     #[test]

--- a/cargo-cost-lint/src/output_formatters.rs
+++ b/cargo-cost-lint/src/output_formatters.rs
@@ -14,6 +14,8 @@ pub enum OutputFormat {
     Json,
     /// SARIF 2.1.0 JSON report.
     Sarif,
+    /// GitHub Actions workflow command annotations.
+    Github,
 }
 
 /// Source-location span for a lint finding.
@@ -37,6 +39,90 @@ pub struct LintFinding {
     pub help: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggestion: Option<String>,
+}
+
+/// Escapes special characters for GitHub Actions workflow command message bodies.
+///
+/// According to GitHub Actions specification:
+/// - `%` is escaped as `%25`
+/// - `\r` is escaped as `%0D`
+/// - `\n` is escaped as `%0A`
+pub fn escape_github_message(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+}
+
+/// Escapes special characters for GitHub Actions workflow command property values.
+///
+/// According to GitHub Actions specification:
+/// - `%` is escaped as `%25`
+/// - `\r` is escaped as `%0D`
+/// - `\n` is escaped as `%0A`
+/// - `:` is escaped as `%3A`
+/// - `,` is escaped as `%2C`
+pub fn escape_github_property(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+        .replace(':', "%3A")
+        .replace(',', "%2C")
+}
+
+/// Format a single finding as a GitHub Actions workflow command annotation.
+pub fn format_github_annotation(finding: &LintFinding) -> String {
+    let severity = match finding.level.as_str() {
+        "error" | "deny" => "error",
+        _ => "warning",
+    };
+
+    let escaped_message = escape_github_message(&finding.message);
+
+    // Normalize file path: make relative to current directory if absolute, and use forward slashes.
+    let rel_file = if let Ok(current_dir) = std::env::current_dir() {
+        let p = std::path::Path::new(&finding.file);
+        if let Ok(stripped) = p.strip_prefix(&current_dir) {
+            stripped.to_string_lossy().replace('\\', "/")
+        } else {
+            finding.file.replace('\\', "/")
+        }
+    } else {
+        finding.file.replace('\\', "/")
+    };
+
+    let escaped_file = escape_github_property(&rel_file);
+
+    if finding.span.line_start > 0 {
+        if finding.span.column_start > 0 {
+            format!(
+                "::{} file={},line={},col={}::{}",
+                severity,
+                escaped_file,
+                finding.span.line_start,
+                finding.span.column_start,
+                escaped_message
+            )
+        } else {
+            format!(
+                "::{} file={},line={}::{}",
+                severity, escaped_file, finding.span.line_start, escaped_message
+            )
+        }
+    } else if !escaped_file.is_empty() {
+        format!("::{} file={}::{}", severity, escaped_file, escaped_message)
+    } else {
+        format!("::{}::{}", severity, escaped_message)
+    }
+}
+
+/// Emit a GitHub Actions workflow command annotation for a finding.
+pub fn emit_github_annotation<W: Write>(
+    finding: &LintFinding,
+    writer: &mut W,
+) -> crate::error::LinterResult<()> {
+    let annotation = format_github_annotation(finding);
+    writeln!(writer, "{}", annotation)?;
+    Ok(())
 }
 
 /// SARIF 2.1.0 report root.
@@ -152,6 +238,10 @@ pub fn handle_finding<W: Write>(
         writeln!(writer, "{}", json_str)?;
         return Ok(true);
     }
+    if cli.format == OutputFormat::Github {
+        emit_github_annotation(finding, writer)?;
+        return Ok(true);
+    }
     // For non‑SARIF formats we render the diagnostic message.
     if cli.format != OutputFormat::Sarif {
         // Use the rendered field if available; fallback to the raw message.
@@ -251,4 +341,148 @@ pub fn emit_sarif<W: Write>(
     Ok(())
 }
 
-// The suggestion extraction and fix‑application logic remain in the main crate.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_github_message() {
+        assert_eq!(
+            escape_github_message("Line 1\nLine 2\r\n100% complete: check here"),
+            "Line 1%0ALine 2%0D%0A100%25 complete: check here"
+        );
+    }
+
+    #[test]
+    fn test_escape_github_property() {
+        assert_eq!(
+            escape_github_property("file:name,with%special\r\nchars"),
+            "file%3Aname%2Cwith%25special%0D%0Achars"
+        );
+    }
+
+    #[test]
+    fn test_format_github_annotation_deny_error() {
+        let finding = LintFinding {
+            name: "soroban_storage_in_loop".to_string(),
+            level: "deny".to_string(),
+            file: "src/contract.rs".to_string(),
+            span: Span {
+                line_start: 42,
+                line_end: 42,
+                column_start: 13,
+                column_end: 20,
+            },
+            message: "storage operations in loops are expensive".to_string(),
+            help: None,
+            suggestion: None,
+        };
+
+        let annotation = format_github_annotation(&finding);
+        assert_eq!(
+            annotation,
+            "::error file=src/contract.rs,line=42,col=13::storage operations in loops are expensive"
+        );
+    }
+
+    #[test]
+    fn test_format_github_annotation_warn_warning() {
+        let finding = LintFinding {
+            name: "redundant_env_clone".to_string(),
+            level: "warn".to_string(),
+            file: "src/lib.rs".to_string(),
+            span: Span {
+                line_start: 15,
+                line_end: 15,
+                column_start: 5,
+                column_end: 10,
+            },
+            message: "redundant cloning of Env".to_string(),
+            help: None,
+            suggestion: None,
+        };
+
+        let annotation = format_github_annotation(&finding);
+        assert_eq!(
+            annotation,
+            "::warning file=src/lib.rs,line=15,col=5::redundant cloning of Env"
+        );
+    }
+
+    #[test]
+    fn test_format_github_annotation_multiline_and_colons() {
+        let finding = LintFinding {
+            name: "soroban_storage_in_loop".to_string(),
+            level: "deny".to_string(),
+            file: "contracts/vault/src/lib.rs".to_string(),
+            span: Span {
+                line_start: 100,
+                line_end: 105,
+                column_start: 9,
+                column_end: 14,
+            },
+            message: "storage operation inside loop detected:\n  env.storage().instance().set(&k, &v);\nhelp: consider batching writes outside the loop: see https://docs.rs/soroban-sdk".to_string(),
+            help: Some("consider batching writes".to_string()),
+            suggestion: None,
+        };
+
+        let annotation = format_github_annotation(&finding);
+        assert_eq!(
+            annotation,
+            "::error file=contracts/vault/src/lib.rs,line=100,col=9::storage operation inside loop detected:%0A  env.storage().instance().set(&k, &v);%0Ahelp: consider batching writes outside the loop: see https://docs.rs/soroban-sdk"
+        );
+        // Verify no raw newlines in the annotation string (single line command)
+        assert!(!annotation.contains('\n'));
+        assert!(!annotation.contains('\r'));
+    }
+
+    #[test]
+    fn test_format_github_annotation_without_span() {
+        let finding = LintFinding {
+            name: "budget_exceeded".to_string(),
+            level: "warn".to_string(),
+            file: "src/lib.rs".to_string(),
+            span: Span {
+                line_start: 0,
+                line_end: 0,
+                column_start: 0,
+                column_end: 0,
+            },
+            message: "general workspace warning".to_string(),
+            help: None,
+            suggestion: None,
+        };
+
+        let annotation = format_github_annotation(&finding);
+        assert_eq!(
+            annotation,
+            "::warning file=src/lib.rs::general workspace warning"
+        );
+    }
+
+    #[test]
+    fn test_emit_github_annotation() {
+        let finding = LintFinding {
+            name: "test_lint".to_string(),
+            level: "warn".to_string(),
+            file: "src/main.rs".to_string(),
+            span: Span {
+                line_start: 1,
+                line_end: 1,
+                column_start: 1,
+                column_end: 1,
+            },
+            message: "test message".to_string(),
+            help: None,
+            suggestion: None,
+        };
+
+        let mut buf = Vec::new();
+        emit_github_annotation(&finding, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            output,
+            "::warning file=src/main.rs,line=1,col=1::test message\n"
+        );
+    }
+}

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -236,7 +236,24 @@ The action defaults to the toolchain that matches the release. Override it only 
 | `args` | No | `''` | Extra arguments forwarded to `cargo cost-lint` |
 | `working-directory` | No | `'.'` | Directory containing the Soroban workspace |
 
-## JSON Output and CI Annotations
+## GitHub Actions Annotations (`--format github`)
+
+Pass `--format github` to output GitHub Actions workflow commands directly. Findings will appear as inline PR annotations on the Files Changed diff and Checks interface without requiring external tools like `jq`.
+
+```bash
+cargo cost-lint --format github
+```
+
+### Annotation format and severity mapping
+
+- `deny` lints emit `::error file=…,line=…,col=…::message`
+- `warn` lints emit `::warning file=…,line=…,col=…::message`
+
+File paths are output relative to the repository working directory, and special characters (`%`, `\r`, `\n`, `:`, `,`) are escaped per GitHub workflow command specifications so multi-line diagnostic messages and diagnostics containing colons render cleanly in GitHub's UI.
+
+The composite action (`action.yml`) uses `--format github` by default.
+
+## JSON Output (`--format json`)
 
 For machine-readable output, pass `--format json`. `cargo cost-lint` will emit JSON lines (NDJSON) detailing each lint finding. The exit code remains non-zero if a `deny` level lint fires.
 
@@ -258,18 +275,3 @@ Each line of stdout is a JSON object with the following schema:
 }
 ```
 
-### GitHub Actions Annotations Example
-You can pipe the JSON output into a tool like `jq` to create GitHub annotations (which show up directly on your PR's Files Changed tab).
-
-```yaml
-      - uses: Tollcraft/soroban-cost-linter@v1
-        with:
-          args: '--format json'
-      - name: Create GitHub annotations
-        if: always()
-        run: |
-          # If you captured the JSON output to a file, parse it:
-          # cargo cost-lint --format json > lint-results.json
-          # jq -r '. | "::\(.level) file=\(.file),line=\(.span.line_start),col=\(.span.column_start)::\(.message) (Lint: \(.name))"' lint-results.json
-```
-*(Note: If the linter returns a non-zero exit code due to a `deny` lint, the step will still fail correctly in Actions).*

--- a/templates/github-action.yml
+++ b/templates/github-action.yml
@@ -28,11 +28,4 @@ jobs:
       - name: Install soroban-cost-linter
         run: cargo install --git https://github.com/Tollcraft/soroban-cost-linter.git cargo-cost-lint
       - name: Run Cost Linter
-        run: cargo cost-lint
-        
-      # Example: Run in JSON mode and create inline PR annotations
-      # - name: Run Cost Linter (JSON)
-      #   run: |
-      #     cargo cost-lint --format json | jq -r '
-      #       . | "::\(.level) file=\(.file),line=\(.span.line_start),col=\(.span.column_start)::\(.message) (Lint: \(.name))"
-      #     '
+        run: cargo cost-lint --format github


### PR DESCRIPTION
## Summary

- Added `--format github` CLI output format to emit GitHub Actions workflow command annotations (`::error` and `::warning`).
- Mapped lint severities appropriately (`deny` / `error` -> `::error`, `warn` / `warning` -> `::warning`).
- Implemented RFC-compliant escaping for GitHub workflow message bodies (`%` -> `%25`, `\r` -> `%0D`, `\n` -> `%0A`) and properties (`:` -> `%3A`, `,` -> `%2C`), ensuring multi-line messages and messages containing colons do not break annotations.
- Normalized finding file paths to repository-relative paths with forward slashes for proper diff matching in GitHub Actions.
- Configured `action.yml` to run with `--format github` by default, updated `templates/github-action.yml`, and documented the format in `docs/integration.md`.

## Why

When the cost linter was run in GitHub Actions CI, findings were only visible in stdout job logs or required manual piping through `jq`. Providing native `--format github` enables workflow inline annotations directly on pull request diffs and check runs without external tooling.

## Implementation

- [`cargo-cost-lint/src/output_formatters.rs`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/soroban-cost-linter/cargo-cost-lint/src/output_formatters.rs):
  - Added `OutputFormat::Github` variant.
  - Implemented `escape_github_message` and `escape_github_property` to escape `%`, `\r`, `\n`, `:`, and `,`.
  - Implemented `format_github_annotation` and `emit_github_annotation` with `file=...,line=...,col=...` formatting.
  - Updated `handle_finding` to emit GitHub annotations when `OutputFormat::Github` is selected.
  - Added unit tests for escaping, deny vs warn severity mapping, multi-line message handling, and annotation emission.
- [`cargo-cost-lint/src/main.rs`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/soroban-cost-linter/cargo-cost-lint/src/main.rs):
  - Enabled `--message-format=json` compiler message parsing for all non-text output formats.
  - Handled `OutputFormat::Github` by streaming workflow command annotations to stdout.
  - Added CLI flag parsing unit tests for `--format github` and `--format sarif`.
- [`action.yml`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/soroban-cost-linter/action.yml): Updated CLI run step to use `--format github` by default.
- [`templates/github-action.yml`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/soroban-cost-linter/templates/github-action.yml): Updated template workflow step to `cargo cost-lint --format github`.
- [`docs/integration.md`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/soroban-cost-linter/docs/integration.md): Documented `--format github`, severity mapping, and workflow usage.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p cargo-cost-lint --bin cargo-cost-lint` (65/65 tests passed)

*Note on integration test*: `tests/integration.rs::test_json_output` was not run locally because `dylint-link` is not pre-installed in the local environment.

## Scope / Risk

- Low risk, non-breaking addition: default `Text` output format is unchanged, existing `Json` and `Sarif` formats remain intact.

## Issue

Closes #382
