### PR TITLE
feat: honour NO_COLOR and add --color flag to control coloured output

### DIFF
--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -6,7 +6,7 @@ mod error;
 mod lint_name_set;
 mod output_formatters;
 
-use clap::{ArgGroup, Parser};
+use clap::{ArgGroup, Parser, ValueEnum};
 use output_formatters::{LintFinding, OutputFormat, Span};
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -48,6 +48,16 @@ struct Cli {
         help = "Show diagnostic detail: config path, lint flags, spawned command"
     )]
     verbose: bool,
+
+    /// Control coloured output: auto, always, never.
+    ///
+    /// When set to *auto* (the default), colour is enabled only when
+    /// standard output is a terminal.  Honouring the widely-adopted
+    /// `NO_COLOR` convention, if this flag is omitted and the
+    /// `NO_COLOR` environment variable is set to any non-empty value,
+    /// output is uncoloured.
+    #[arg(long, value_enum, default_value_t = ColorChoice::Auto, value_name = "WHEN")]
+    color: ColorChoice,
 }
 
 #[derive(Deserialize, Debug)]
@@ -59,6 +69,47 @@ include!(concat!(env!("OUT_DIR"), "/lint_names.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_metadata.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_info.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_explanations.rs"));
+
+#[derive(ValueEnum, Clone, Debug)]
+enum ColorChoice {
+    Auto,
+    Always,
+    Never,
+}
+
+impl ColorChoice {
+    /// Return the `cargo dylint` / `cargo check` `--color` argument
+    /// value, or `None` when we should let cargo pick its default
+    /// (i.e. when colour is desired and there is nothing to override).
+    fn as_dylint_arg(&self) -> Option<&'static str> {
+        match self {
+            ColorChoice::Auto => None,
+            ColorChoice::Always => Some("always"),
+            ColorChoice::Never => Some("never"),
+        }
+    }
+}
+
+/// Determine the effective colour preference by merging:
+///
+/// 1. An explicit `--color` CLI flag (highest priority).
+/// 2. The `NO_COLOR` environment variable (set to any non-empty value
+///    means "no colour").
+/// 3. Cargo's built-in default (`Auto`) — colour when stdout is a
+///    terminal, no colour otherwise.
+fn resolve_color_choice(cli_color: &ColorChoice) -> ColorChoice {
+    match cli_color {
+        ColorChoice::Auto => {
+            // Honour the NO_COLOR convention (https://no-color.org/).
+            if std::env::var("NO_COLOR").is_ok_and(|v| !v.is_empty()) {
+                ColorChoice::Never
+            } else {
+                ColorChoice::Auto
+            }
+        }
+        other => other.clone(),
+    }
+}
 
 fn validate_and_build_flags(config: &BudgetConfig) -> Result<Vec<String>, String> {
     let mut lint_flags = Vec::new();
@@ -230,6 +281,19 @@ fn main() {
     }
 
     let mut cmd = Command::new("cargo");
+
+    // Forward the resolved colour preference to cargo.
+    // `--color` must appear before the `dylint` subcommand so that
+    // cargo itself consumes it; we also set `CARGO_TERM_COLOR` so that
+    // any inner `cargo check` invoked by dylint inherits the same
+    // preference.
+    let effective_color = resolve_color_choice(&cli.color);
+    if let Some(color_val) = effective_color.as_dylint_arg() {
+        cmd.arg("--color");
+        cmd.arg(color_val);
+        cmd.env("CARGO_TERM_COLOR", color_val);
+    }
+
     cmd.arg("dylint");
     cmd.arg("--lib");
     cmd.arg("soroban_cost_lints");

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -273,3 +273,49 @@ You can pipe the JSON output into a tool like `jq` to create GitHub annotations 
           # jq -r '. | "::\(.level) file=\(.file),line=\(.span.line_start),col=\(.span.column_start)::\(.message) (Lint: \(.name))"' lint-results.json
 ```
 *(Note: If the linter returns a non-zero exit code due to a `deny` lint, the step will still fail correctly in Actions).*
+
+## Colour output
+
+`cargo cost-lint` does not emit colours itself, but the underlying
+`rustc` diagnostics it surfaces are coloured by default when standard
+output is a terminal.
+
+### The `--color` flag
+
+Use `--color <WHEN>` to control coloured output explicitly:
+
+| Value    | Behaviour |
+|----------|-----------|
+| `auto`   | Colour when stdout is a terminal, none otherwise (default). |
+| `always` | Always emit colour. |
+| `never`  | Never emit colour. |
+
+```bash
+cargo cost-lint --color never
+```
+
+The flag is forwarded to `cargo dylint` (and propagated via
+`CARGO_TERM_COLOR`) so that the child process that actually emits
+the diagnostics honours the setting.
+
+### The `NO_COLOR` convention
+
+[no-color.org](https://no-color.org/) defines the convention that
+setting the `NO_COLOR` environment variable to **any non-empty value**
+disables colour.  `cargo cost-lint` honours this automatically —
+no flag is required:
+
+```bash
+NO_COLOR=1 cargo cost-lint   # uncoloured output
+```
+
+### Precedence
+
+1. `--color` flag (highest priority)
+2. `NO_COLOR` environment variable
+3. Cargo's built-in default (colour when stdout is a terminal)
+
+{% hint style="info" %}
+JSON mode (`--format json`) is unaffected — it already
+emits no colour.
+{% endhint %}


### PR DESCRIPTION
## feat: honour `NO_COLOR` and add `--color` flag to control coloured output

### Problem

`cargo cost-lint` surfaces `rustc` diagnostics which are coloured by default when stdout is a terminal. Previously there was no way to disable this — setting `NO_COLOR` had no effect because the variable was never read and no `--color` argument was forwarded to the child process.

This bites in the places where it is most annoying to debug: log files, CI systems without ANSI support, and anything that captures output for later reading.

### Solution

- **`--color <auto|always|never>`** CLI flag (default: `auto`) forwarded to `cargo dylint` and propagated via `CARGO_TERM_COLOR` env var so that the child process that actually emits the diagnostics honours the setting.
- **`NO_COLOR`** environment variable support per [no-color.org](https://no-color.org/) convention — any non-empty value disables colour output.
- Precedence: `--color` flag → `NO_COLOR` env var → cargo's built-in default (colour when stdout is a terminal).
- JSON mode (`--format json`) is unaffected — it already pipes stdout and emits no colour.

### Implementation details

**Argument forwarding:** The `--color` flag is placed *before* the `dylint` subcommand in the `Command::new("cargo")` invocation, so cargo itself consumes it. Additionally, `CARGO_TERM_COLOR` is set on the child process environment so that any inner `cargo check` spawned by dylint inherits the same preference.

**`resolve_color_choice()`** merges three sources:
1. Explicit `--color` flag (highest priority)
2. `NO_COLOR` env var (any non-empty value → `never`)
3. Cargo's built-in default (`auto` — colour when stdout is a terminal)

### Files changed

- `cargo-cost-lint/src/main.rs` — `ColorChoice` enum, `resolve_color_choice()`, `--color` arg, colour forwarding
- `docs/integration.md` — new "Colour output" section documenting the flag, `NO_COLOR` support, and precedence

### How to test

```bash
# With colour (terminal):
cargo cost-lint

# Without colour (explicit):
cargo cost-lint --color never

# Without colour (env var):
NO_COLOR=1 cargo cost-lint

# Piped output (auto detects non-terminal):
cargo cost-lint | cat
```

### CI checks (all passing)

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (61 tests passed)

Closes #420