### PR TITLE
feat(cli): add --package and --workspace crate selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ If the binary was not tampered with the output will say `cargo-cost-lint: OK`.
 | `--allow <LINT>`, `-A <LINT>` | Set a lint to `allow` for this run (repeatable, overrides `budget.toml`) |
 | `--warn <LINT>`, `-W <LINT>` | Set a lint to `warn` for this run (repeatable, overrides `budget.toml`) |
 | `--deny <LINT>`, `-D <LINT>` | Set a lint to `deny` for this run (repeatable, overrides `budget.toml`) |
+| `--package <SPEC>`, `-p <SPEC>` | Package(s) to lint (repeatable, restricts linting to specified packages) |
+| `--workspace` | Lint all packages in the workspace |
 | `--format <text\|json>` | Output format (default: `text`) |
 | `--list-lints` | Print every registered lint with its default level and one-line description, then exit |
 | `--explain <LINT>` | Print the full documentation for a specific lint (what it does, why it's expensive, suggested fix) and exit |
@@ -145,6 +147,26 @@ If the binary was not tampered with the output will say `cargo-cost-lint: OK`.
 | `--version` | Print the crate version and exit |
 
 `--quiet` and `--verbose` are mutually exclusive. In JSON mode (`--format json`), both flags keep stdout as clean NDJSON; all diagnostic output goes to stderr.
+
+### Package Selection
+
+In multi-crate workspaces, you can restrict linting to specific packages or explicitly lint the entire workspace:
+
+```bash
+# Lint a single package
+cargo cost-lint -p my-contract
+
+# Lint multiple packages
+cargo cost-lint -p contract-a --package contract-b
+
+# Explicitly lint all packages in the workspace
+cargo cost-lint --workspace
+```
+
+#### Default Behavior
+When neither `--package` nor `--workspace` is specified, `cargo cost-lint` follows standard Cargo semantics: it lints the package in the current working directory, or all default workspace members if invoked from the root of a virtual workspace.
+
+Passing an unknown package name with `--package` will be rejected with an error listing the available workspace members.
 
 ### Command-Line Level Overrides
 

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -75,6 +75,18 @@ struct Cli {
         help = "Deny a lint for this run (overrides budget.toml)"
     )]
     deny: Vec<String>,
+
+    #[arg(
+        long = "package",
+        short = 'p',
+        value_name = "SPEC",
+        action = clap::ArgAction::Append,
+        help = "Package(s) to lint (repeatable)"
+    )]
+    package: Vec<String>,
+
+    #[arg(long = "workspace", help = "Lint all packages in the workspace")]
+    workspace: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -86,6 +98,102 @@ include!(concat!(env!("OUT_DIR"), "/lint_names.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_metadata.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_info.rs"));
 include!(concat!(env!("OUT_DIR"), "/lint_explanations.rs"));
+
+/// Validates package selection options against available workspace members
+/// and constructs the command-line arguments to forward to cargo.
+pub fn validate_and_build_package_args(
+    packages: &[String],
+    workspace: bool,
+    available_packages: &[String],
+) -> Result<Vec<String>, String> {
+    if workspace && !packages.is_empty() {
+        return Err(
+            "Error: The argument '--workspace' cannot be used with '--package <SPEC>'".to_string(),
+        );
+    }
+
+    if workspace {
+        return Ok(vec!["--workspace".to_string()]);
+    }
+
+    if packages.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    for pkg in packages {
+        if !available_packages.iter().any(|p| p == pkg) {
+            let valid = available_packages.join(", ");
+            return Err(format!(
+                "Error: Package '{}' not found in workspace. Valid workspace members are: {}",
+                pkg, valid
+            ));
+        }
+    }
+
+    let mut args = Vec::new();
+    for pkg in packages {
+        args.push("--package".to_string());
+        args.push(pkg.clone());
+    }
+    Ok(args)
+}
+
+/// Parses the output of `cargo metadata` to extract workspace member package names.
+pub fn parse_workspace_members_from_metadata(json_bytes: &[u8]) -> Result<Vec<String>, String> {
+    let value: serde_json::Value = serde_json::from_slice(json_bytes)
+        .map_err(|e| format!("Error: Failed to parse `cargo metadata` JSON: {}", e))?;
+
+    let workspace_members = value
+        .get("workspace_members")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .collect::<std::collections::HashSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let packages = value
+        .get("packages")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "Error: `cargo metadata` missing `packages` array".to_string())?;
+
+    let mut member_names: Vec<String> = packages
+        .iter()
+        .filter_map(|pkg| {
+            let id = pkg.get("id").and_then(|i| i.as_str())?;
+            let name = pkg.get("name").and_then(|n| n.as_str())?;
+            if workspace_members.is_empty() || workspace_members.contains(id) {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    member_names.sort();
+    member_names.dedup();
+    Ok(member_names)
+}
+
+/// Discovers workspace package members by running `cargo metadata`.
+pub fn get_workspace_packages(dir: Option<&Path>) -> Result<Vec<String>, String> {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["metadata", "--no-deps", "--format-version", "1"]);
+    if let Some(d) = dir {
+        cmd.current_dir(d);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Error: Failed to run `cargo metadata`: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Error: `cargo metadata` failed: {}", stderr.trim()));
+    }
+
+    parse_workspace_members_from_metadata(&output.stdout)
+}
 
 /// Combines lint configurations from an optional `BudgetConfig` (budget.toml)
 /// with command-line overrides (`--allow`, `--warn`, `--deny`).
@@ -316,6 +424,30 @@ fn main() {
             }
         };
 
+    let package_args = if !cli.package.is_empty() || cli.workspace {
+        let available_packages = if !cli.package.is_empty() {
+            match get_workspace_packages(None) {
+                Ok(pkgs) => pkgs,
+                Err(e) => {
+                    eprintln!("{}", e);
+                    exit(1);
+                }
+            }
+        } else {
+            Vec::new()
+        };
+
+        match validate_and_build_package_args(&cli.package, cli.workspace, &available_packages) {
+            Ok(args) => args,
+            Err(e) => {
+                eprintln!("{}", e);
+                exit(1);
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
     let mut cmd = Command::new("cargo");
     cmd.arg("dylint");
     cmd.arg("--lib");
@@ -333,6 +465,21 @@ fn main() {
         cmd.env("DYLINT_RUSTFLAGS", &rustflags_value);
     }
 
+    let mut cargo_args = Vec::new();
+    cargo_args.extend(package_args);
+
+    if cli.format != OutputFormat::Text {
+        cargo_args.push("--message-format=json".to_string());
+        cmd.stdout(Stdio::piped());
+    }
+
+    if !cargo_args.is_empty() {
+        cmd.arg("--");
+        for arg in cargo_args {
+            cmd.arg(arg);
+        }
+    }
+
     if verbose {
         if let Some(ref p) = resolved_config_path {
             eprintln!("[verbose] config: {}", p.display());
@@ -345,12 +492,6 @@ fn main() {
             eprintln!("[verbose] DYLINT_RUSTFLAGS: (empty)");
         }
         eprintln!("[verbose] command: {:?}", cmd);
-    }
-
-    if cli.format != OutputFormat::Text {
-        cmd.arg("--");
-        cmd.arg("--message-format=json");
-        cmd.stdout(Stdio::piped());
     }
 
     let mut child = cmd
@@ -1117,5 +1258,118 @@ mod tests {
         let result = build_effective_lint_flags(None, &allow, &[], &[]);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), vec!["-A redundant_env_clone"]);
+    }
+
+    #[test]
+    fn cli_parses_package_flag() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--package", "my-contract"])
+            .expect("parsing should succeed");
+        assert_eq!(cli.package, vec!["my-contract"]);
+        assert!(!cli.workspace);
+
+        let cli_short = Cli::try_parse_from(["cargo-cost-lint", "-p", "my-contract"])
+            .expect("parsing should succeed");
+        assert_eq!(cli_short.package, vec!["my-contract"]);
+    }
+
+    #[test]
+    fn cli_parses_repeatable_package_flags() {
+        let cli = Cli::try_parse_from([
+            "cargo-cost-lint",
+            "-p",
+            "contract-a",
+            "--package",
+            "contract-b",
+        ])
+        .expect("parsing should succeed");
+        assert_eq!(cli.package, vec!["contract-a", "contract-b"]);
+    }
+
+    #[test]
+    fn cli_parses_workspace_flag() {
+        let cli = Cli::try_parse_from(["cargo-cost-lint", "--workspace"])
+            .expect("parsing should succeed");
+        assert!(cli.workspace);
+        assert!(cli.package.is_empty());
+    }
+
+    #[test]
+    fn test_validate_and_build_package_args_default() {
+        let pkgs = vec![];
+        let workspace = false;
+        let available = vec!["contract-a".to_string(), "contract-b".to_string()];
+        let args = validate_and_build_package_args(&pkgs, workspace, &available).unwrap();
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn test_validate_and_build_package_args_single_package() {
+        let pkgs = vec!["contract-a".to_string()];
+        let workspace = false;
+        let available = vec!["contract-a".to_string(), "contract-b".to_string()];
+        let args = validate_and_build_package_args(&pkgs, workspace, &available).unwrap();
+        assert_eq!(args, vec!["--package", "contract-a"]);
+    }
+
+    #[test]
+    fn test_validate_and_build_package_args_multiple_packages() {
+        let pkgs = vec!["contract-a".to_string(), "contract-b".to_string()];
+        let workspace = false;
+        let available = vec!["contract-a".to_string(), "contract-b".to_string()];
+        let args = validate_and_build_package_args(&pkgs, workspace, &available).unwrap();
+        assert_eq!(
+            args,
+            vec!["--package", "contract-a", "--package", "contract-b"]
+        );
+    }
+
+    #[test]
+    fn test_validate_and_build_package_args_workspace() {
+        let pkgs = vec![];
+        let workspace = true;
+        let available = vec!["contract-a".to_string(), "contract-b".to_string()];
+        let args = validate_and_build_package_args(&pkgs, workspace, &available).unwrap();
+        assert_eq!(args, vec!["--workspace"]);
+    }
+
+    #[test]
+    fn test_validate_and_build_package_args_unknown_package() {
+        let pkgs = vec!["nonexistent-contract".to_string()];
+        let workspace = false;
+        let available = vec!["contract-a".to_string(), "contract-b".to_string()];
+        let result = validate_and_build_package_args(&pkgs, workspace, &available);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Package 'nonexistent-contract' not found in workspace"));
+        assert!(err.contains("Valid workspace members are: contract-a, contract-b"));
+    }
+
+    #[test]
+    fn test_validate_and_build_package_args_conflicting_workspace_and_package() {
+        let pkgs = vec!["contract-a".to_string()];
+        let workspace = true;
+        let available = vec!["contract-a".to_string(), "contract-b".to_string()];
+        let result = validate_and_build_package_args(&pkgs, workspace, &available);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("cannot be used with '--package <SPEC>'"));
+    }
+
+    #[test]
+    fn test_parse_workspace_members_from_metadata() {
+        let sample_json = r#"{
+            "packages": [
+                {"name": "contract-a", "id": "path+file:///crates/contract-a#0.1.0"},
+                {"name": "contract-b", "id": "path+file:///crates/contract-b#0.1.0"},
+                {"name": "dep-c", "id": "registry+https://github.com/rust-lang/crates.io-index#0.1.0"}
+            ],
+            "workspace_members": [
+                "path+file:///crates/contract-a#0.1.0",
+                "path+file:///crates/contract-b#0.1.0"
+            ]
+        }"#;
+
+        let members = parse_workspace_members_from_metadata(sample_json.as_bytes()).unwrap();
+        assert_eq!(members, vec!["contract-a", "contract-b"]);
     }
 }


### PR DESCRIPTION
## Summary

- Added `--package` (`-p`) repeatable flag to restrict linting to specified package(s) in a Cargo workspace.
- Added `--workspace` flag to explicitly lint all member crates across the workspace.
- Implemented workspace package discovery and validation via `cargo metadata`, returning an informative error listing valid workspace members when an unknown package name is requested.
- Forwarded package selection arguments directly through to the underlying `cargo dylint` invocation (`--package <spec>` / `--workspace`).
- Added unit tests covering single package, multiple packages, workspace selection, conflicting selection rejection, metadata member parsing, and default behavior.
- Documented package selection flags, usage examples, and default resolution behavior in `README.md`.

## Why

In multi-crate workspaces (e.g. workspaces containing multiple contract crates alongside off-chain host tooling), `cargo cost-lint` previously linted every crate indiscriminately. Adding `--package` and `--workspace` provides standard Cargo package selection, speeding up iteration on individual contracts and avoiding unnecessary linting on non-contract crates.

## Implementation

- [`cargo-cost-lint/src/main.rs`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/soroban-cost-linter/cargo-cost-lint/src/main.rs):
  - Added `package: Vec<String>` (`--package`, `-p`, `ArgAction::Append`) and `workspace: bool` (`--workspace`) to the `Cli` struct.
  - Implemented `parse_workspace_members_from_metadata` and `get_workspace_packages` to discover member package names using `cargo metadata --no-deps --format-version 1`.
  - Implemented `validate_and_build_package_args` to validate requested package names against workspace members and enforce Cargo mutually-exclusive flag semantics.
  - Forwarded `--package <pkg>` and `--workspace` args after `--` to the underlying `cargo dylint` command.
  - Added unit tests for flag parsing, short alias, multiple packages, workspace flag, unknown package validation error, and metadata parsing.
- [`README.md`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/soroban-cost-linter/README.md):
  - Added `--package` and `--workspace` to the CLI flags summary table.
  - Added a "Package Selection" section with usage examples and documented the default resolution behavior when neither flag is passed.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p cargo-cost-lint --bin cargo-cost-lint` (84/84 tests passed)

*Note on integration test*: `tests/integration.rs::test_json_output` was not run locally because `dylint-link` is not pre-installed in the local environment.

## Scope / Risk

- Low risk, non-breaking change: When neither `--package` nor `--workspace` is passed, existing default Cargo resolution behavior is preserved.

## Issue

Closes #387
