### PR TITLE
feat: comprehensive linter improvements (#390, #378, #375, #376)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,9 +96,9 @@ jobs:
         with:
           shared-key: cost-linter-coverage
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Install Dylint
-        run: cargo install cargo-dylint dylint-link --version "^6.0.1" --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
       - name: Generate Coverage Report
         run: |
           echo "## Code Coverage Summary" >> $GITHUB_STEP_SUMMARY
@@ -111,4 +111,5 @@ jobs:
         with:
           name: lcov-report
           path: lcov.info
+
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,7 +64,7 @@ jobs:
   # reported and every PR waits on it forever. This job supplies that context
   # and stays correct if the matrix legs change.
   build-and-test:
-    needs: test
+    needs: [test, coverage]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -74,3 +74,41 @@ jobs:
             echo "Matrix job 'test' reported: ${{ needs.test.result }}"
             exit 1
           fi
+          if [ "${{ needs.coverage.result }}" != "success" ]; then
+            echo "Coverage job 'coverage' reported: ${{ needs.coverage.result }}"
+            exit 1
+          fi
+
+  coverage:
+    name: Coverage Report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate toolchain pins (Linux)
+        run: bash .github/scripts/validate-toolchain-pins.sh
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly-2026-04-16
+          components: rustc-dev, llvm-tools-preview, rustfmt, clippy
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cost-linter-coverage
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install Dylint
+        run: cargo install cargo-dylint dylint-link --version "^6.0.1" --locked
+      - name: Generate Coverage Report
+        run: |
+          echo "## Code Coverage Summary" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cargo llvm-cov --package cargo-cost-lint --bins --test integration >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cargo llvm-cov --package cargo-cost-lint --bins --test integration --lcov --output-path lcov.info
+      - name: Upload LCOV Report Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-report
+          path: lcov.info
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,6 +99,9 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
+      - name: Install Dylint
+        run: cargo install cargo-dylint dylint-link --version "^6.0.1" --locked
+
       - name: Generate Coverage Report
         run: |
           echo "## Code Coverage Summary" >> $GITHUB_STEP_SUMMARY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,11 @@ exclude = [
     "tests/corpus/contracts/storage_iter_closure",
     "tests/corpus/contracts/storage_iter_good",
     "tests/corpus/contracts/storage_iter_mixed",
+    "tests/corpus/contracts/compute_input_validation",
+    "tests/corpus/contracts/compute_batch_contract_call",
+    "tests/corpus/contracts/compute_collection_search",
+    "tests/corpus/contracts/symbol_key_boundary",
+    "tests/corpus/contracts/symbol_key_enum_storage",
+    "tests/corpus/contracts/symbol_key_event_topics",
 ]
 resolver = "2"

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -1626,8 +1626,11 @@ mod tests {
         assert_eq!(cli.color, ColorChoice::Never);
     }
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn resolve_color_explicit_always_overrides_no_color() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var("NO_COLOR", "1") };
         let resolved = resolve_color_choice(&ColorChoice::Always);
         assert_eq!(resolved, ColorChoice::Always);
@@ -1636,6 +1639,7 @@ mod tests {
 
     #[test]
     fn resolve_color_explicit_never_overrides_no_color() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var("NO_COLOR", "1") };
         let resolved = resolve_color_choice(&ColorChoice::Never);
         assert_eq!(resolved, ColorChoice::Never);
@@ -1644,6 +1648,7 @@ mod tests {
 
     #[test]
     fn resolve_color_auto_no_color_set_resolves_to_never() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var("NO_COLOR", "1") };
         let resolved = resolve_color_choice(&ColorChoice::Auto);
         assert_eq!(resolved, ColorChoice::Never);
@@ -1652,6 +1657,7 @@ mod tests {
 
     #[test]
     fn resolve_color_auto_no_color_empty_resolves_to_auto() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var("NO_COLOR", "") };
         let resolved = resolve_color_choice(&ColorChoice::Auto);
         assert_eq!(resolved, ColorChoice::Auto);
@@ -1660,6 +1666,7 @@ mod tests {
 
     #[test]
     fn resolve_color_auto_no_color_unset_resolves_to_auto() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::remove_var("NO_COLOR") };
         let resolved = resolve_color_choice(&ColorChoice::Auto);
         assert_eq!(resolved, ColorChoice::Auto);

--- a/cargo-cost-lint/tests/integration.rs
+++ b/cargo-cost-lint/tests/integration.rs
@@ -122,7 +122,10 @@ fn test_json_output() {
 
     // Find the workspace target directory dynamically based on the binary path
     let mut target_dir = PathBuf::from(env!("CARGO_BIN_EXE_cargo-cost-lint"));
-    target_dir.pop(); // Remove the binary name, leaving the profile directory (e.g., target/debug)
+    target_dir.pop(); // Remove the binary name
+    if target_dir.ends_with("deps") {
+        target_dir.pop(); // Pop "deps" to reach the profile directory (e.g., target/debug)
+    }
 
     // Build the soroban_cost_lints cdylib first from its own directory so it picks up .cargo/config.toml
     let mut lint_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/cargo-cost-lint/tests/integration.rs
+++ b/cargo-cost-lint/tests/integration.rs
@@ -120,13 +120,6 @@ fn test_json_output() {
         fixture_dir
     );
 
-    // Find the workspace target directory dynamically based on the binary path
-    let mut target_dir = PathBuf::from(env!("CARGO_BIN_EXE_cargo-cost-lint"));
-    target_dir.pop(); // Remove the binary name
-    if target_dir.ends_with("deps") {
-        target_dir.pop(); // Pop "deps" to reach the profile directory (e.g., target/debug)
-    }
-
     // Build the soroban_cost_lints cdylib first from its own directory so it picks up .cargo/config.toml
     let mut lint_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     lint_dir.pop();
@@ -134,19 +127,33 @@ fn test_json_output() {
 
     let status = Command::new(env!("CARGO"))
         .arg("build")
-        .arg("--target-dir")
-        .arg(&target_dir)
         .current_dir(&lint_dir)
         .status()
         .expect("Failed to build soroban_cost_lints");
     assert!(status.success(), "Failed to build soroban_cost_lints");
+
+    // Determine where the lint cdylib was built.  `cargo build` above
+    // honours CARGO_TARGET_DIR when set (e.g. by cargo-llvm-cov) and
+    // falls back to the workspace default `<root>/target/` otherwise.
+    // We must point DYLINT_LIBRARY_PATH to the same profile directory
+    // so cargo-dylint can find the library.
+    let lib_dir = match std::env::var("CARGO_TARGET_DIR") {
+        Ok(dir) => PathBuf::from(dir).join("debug"),
+        Err(_) => {
+            let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            d.pop(); // workspace root
+            d.push("target");
+            d.push("debug");
+            d
+        }
+    };
 
     // Run the built wrapper binary in the fixture directory with --format json
     let output = Command::new(bin_path)
         .arg("--format")
         .arg("json")
         .current_dir(fixture_dir)
-        .env("DYLINT_LIBRARY_PATH", target_dir)
+        .env("DYLINT_LIBRARY_PATH", &lib_dir)
         .output()
         .expect("Failed to execute cargo-cost-lint");
 

--- a/cargo-cost-lint/tests/integration.rs
+++ b/cargo-cost-lint/tests/integration.rs
@@ -131,6 +131,8 @@ fn test_json_output() {
 
     let status = Command::new(env!("CARGO"))
         .arg("build")
+        .arg("--target-dir")
+        .arg(&target_dir)
         .current_dir(&lint_dir)
         .status()
         .expect("Failed to build soroban_cost_lints");

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,3 +34,10 @@
 ## Branding
 
 * [Brand & Design Guide](branding.md)
+
+## History
+
+* [Phase 1 Analysis (Task 27)](history/PHASE_1_ANALYSIS_TASK_27.md)
+* [Phase 1 Reconnaissance Analysis](history/PHASE_1_RECONNAISSANCE_ANALYSIS.md)
+* [Roadmap MVP](history/roadmap_mvp.md)
+

--- a/docs/history/PHASE_1_ANALYSIS_TASK_27.md
+++ b/docs/history/PHASE_1_ANALYSIS_TASK_27.md
@@ -1,5 +1,8 @@
 # Phase 1: Reconnaissance Analysis — Issue #197 / Task #27
 
+> **Note**: This is a historical document from early project planning and does not reflect current architecture or guidance.
+
+
 ## Executive Summary
 
 This document captures the Phase 1 reconnaissance for:

--- a/docs/history/PHASE_1_RECONNAISSANCE_ANALYSIS.md
+++ b/docs/history/PHASE_1_RECONNAISSANCE_ANALYSIS.md
@@ -1,5 +1,8 @@
 # Phase 1: Reconnaissance Analysis — Issue #206 / Task #18
 
+> **Note**: This is a historical document from early project planning and does not reflect current architecture or guidance.
+
+
 ## Executive Summary
 
 This document captures the reconnaissance phase analysis for resolving the issue:

--- a/docs/history/roadmap_mvp.md
+++ b/docs/history/roadmap_mvp.md
@@ -1,5 +1,8 @@
 # MVP Roadmap: `soroban-cost-linter`
 
+> **Note**: This is a historical document from early project planning and does not reflect current architecture or guidance.
+
+
 This document details the roadmap for developing a functional MVP of `soroban-cost-linter`, designed to statically catch input-independent, structurally expensive patterns in Soroban smart contracts.
 
 ---

--- a/tests/corpus/baseline.json
+++ b/tests/corpus/baseline.json
@@ -1,7 +1,79 @@
 {
   "version": 1,
-  "description": "Baseline lint findings for real-world corpus. Generated on t=1787652652 with 64 findings across 9 contracts.\nRegenerate by running: BLESS=1 cargo test --test real_world_corpus --workspace",
+  "description": "Baseline lint findings for real-world corpus. Generated on t=1787741592 with 86 findings across 15 contracts.\nRegenerate by running: BLESS=1 cargo test --test real_world_corpus --workspace",
   "contracts": {
+    "compute_batch_contract_call": {
+      "total": 2,
+      "true_positives": [],
+      "false_positives": [
+        {
+          "lint_name": "vec_where_slice_could_be_used",
+          "file": "src/lib.rs",
+          "line": 9,
+          "message": "soroban_sdk::Vec parameter could be replaced with a native Rust slice"
+        },
+        {
+          "lint_name": "contract_call_in_loop",
+          "file": "src/lib.rs",
+          "line": 11,
+          "message": "cross-contract call inside a loop"
+        }
+      ]
+    },
+    "compute_collection_search": {
+      "total": 1,
+      "true_positives": [],
+      "false_positives": [
+        {
+          "lint_name": "vec_where_slice_could_be_used",
+          "file": "src/lib.rs",
+          "line": 9,
+          "message": "soroban_sdk::Vec parameter could be replaced with a native Rust slice"
+        }
+      ]
+    },
+    "compute_input_validation": {
+      "total": 6,
+      "true_positives": [],
+      "false_positives": [
+        {
+          "lint_name": "vec_where_slice_could_be_used",
+          "file": "src/lib.rs",
+          "line": 11,
+          "message": "soroban_sdk::Vec parameter could be replaced with a native Rust slice"
+        },
+        {
+          "lint_name": "soroban_storage_in_loop",
+          "file": "src/lib.rs",
+          "line": 14,
+          "message": "storage operation inside a loop"
+        },
+        {
+          "lint_name": "loop_invariant_storage_access",
+          "file": "src/lib.rs",
+          "line": 14,
+          "message": "loop-invariant storage operation inside a loop"
+        },
+        {
+          "lint_name": "loop_invariant_storage_access",
+          "file": "src/lib.rs",
+          "line": 14,
+          "message": "loop-invariant storage operation inside a loop"
+        },
+        {
+          "lint_name": "loop_invariant_storage_access",
+          "file": "src/lib.rs",
+          "line": 14,
+          "message": "loop-invariant storage operation inside a loop"
+        },
+        {
+          "lint_name": "vec_where_slice_could_be_used",
+          "file": "src/lib.rs",
+          "line": 24,
+          "message": "soroban_sdk::Vec parameter could be replaced with a native Rust slice"
+        }
+      ]
+    },
     "storage_iter_closure": {
       "total": 3,
       "true_positives": [],
@@ -215,6 +287,104 @@
           "file": "src/lib.rs",
           "line": 72,
           "message": "repeatedly growing SDK container inside a loop"
+        }
+      ]
+    },
+    "symbol_key_boundary": {
+      "total": 2,
+      "true_positives": [
+        {
+          "lint_name": "symbol_new_for_short_literal",
+          "file": "src/lib.rs",
+          "line": 10,
+          "message": "Symbol::new called with a short literal that could use symbol_short! macro"
+        },
+        {
+          "lint_name": "symbol_new_for_short_literal",
+          "file": "src/lib.rs",
+          "line": 11,
+          "message": "Symbol::new called with a short literal that could use symbol_short! macro"
+        }
+      ],
+      "false_positives": []
+    },
+    "symbol_key_enum_storage": {
+      "total": 6,
+      "true_positives": [
+        {
+          "lint_name": "symbol_new_for_short_literal",
+          "file": "src/lib.rs",
+          "line": 17,
+          "message": "Symbol::new called with a short literal that could use symbol_short! macro"
+        }
+      ],
+      "false_positives": [
+        {
+          "lint_name": "storage_write_without_read",
+          "file": "src/lib.rs",
+          "line": 18,
+          "message": "storage write without a corresponding read"
+        },
+        {
+          "lint_name": "storage_key_construction_in_loop",
+          "file": "src/lib.rs",
+          "line": 17,
+          "message": "storage key constructed inside a loop body"
+        },
+        {
+          "lint_name": "soroban_storage_in_loop",
+          "file": "src/lib.rs",
+          "line": 18,
+          "message": "storage operation inside a loop"
+        },
+        {
+          "lint_name": "loop_invariant_storage_access",
+          "file": "src/lib.rs",
+          "line": 18,
+          "message": "loop-invariant storage operation inside a loop"
+        },
+        {
+          "lint_name": "loop_invariant_storage_access",
+          "file": "src/lib.rs",
+          "line": 18,
+          "message": "loop-invariant storage operation inside a loop"
+        }
+      ]
+    },
+    "symbol_key_event_topics": {
+      "total": 5,
+      "true_positives": [
+        {
+          "lint_name": "symbol_new_for_short_literal",
+          "file": "src/lib.rs",
+          "line": 11,
+          "message": "Symbol::new called with a short literal that could use symbol_short! macro"
+        },
+        {
+          "lint_name": "symbol_new_for_short_literal",
+          "file": "src/lib.rs",
+          "line": 12,
+          "message": "Symbol::new called with a short literal that could use symbol_short! macro"
+        },
+        {
+          "lint_name": "unnecessary_host_function_call",
+          "file": "src/lib.rs",
+          "line": 13,
+          "message": "unnecessary host function call inside loop"
+        }
+      ],
+      "false_positives": [
+        {
+          "lint_name": "storage_key_construction_in_loop",
+          "file": "src/lib.rs",
+          "line": 11,
+          "message": "storage key constructed inside a loop body"
+        },
+        {
+          "lint_name": "storage_key_construction_in_loop",
+          "file": "src/lib.rs",
+          "line": 12,
+          "message": "storage key constructed inside a loop body"
         }
       ]
     },

--- a/tests/corpus/contracts/compute_batch_contract_call/Cargo.toml
+++ b/tests/corpus/contracts/compute_batch_contract_call/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "compute-batch-contract-call-fixture"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"
+
+[workspace]

--- a/tests/corpus/contracts/compute_batch_contract_call/src/lib.rs
+++ b/tests/corpus/contracts/compute_batch_contract_call/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, IntoVal, Address, Env, Vec};
+
+#[contract]
+pub struct ComputeBatchContractCallContract;
+
+#[contractimpl]
+impl ComputeBatchContractCallContract {
+    pub fn process_batch(env: Env, target: Address, amounts: Vec<i128>) {
+        for amount in amounts.iter() {
+            let _: () = env.invoke_contract(&target, &symbol_short!("process"), (amount,).into_val(&env));
+        }
+    }
+}

--- a/tests/corpus/contracts/compute_collection_search/Cargo.toml
+++ b/tests/corpus/contracts/compute_collection_search/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "compute-collection-search-fixture"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"
+
+[workspace]

--- a/tests/corpus/contracts/compute_collection_search/src/lib.rs
+++ b/tests/corpus/contracts/compute_collection_search/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Map, Symbol, Vec};
+
+#[contract]
+pub struct ComputeCollectionSearchContract;
+
+#[contractimpl]
+impl ComputeCollectionSearchContract {
+    pub fn find_in_collection(_env: Env, keys: Vec<Symbol>, map: Map<Symbol, i32>) -> i32 {
+        let mut sum = 0i32;
+        for key in keys.iter() {
+            if map.contains_key(key.clone()) {
+                if let Some(val) = map.get(key) {
+                    sum += val;
+                }
+            }
+        }
+        sum
+    }
+}

--- a/tests/corpus/contracts/compute_input_validation/Cargo.toml
+++ b/tests/corpus/contracts/compute_input_validation/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "compute-input-validation-fixture"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"
+
+[workspace]

--- a/tests/corpus/contracts/compute_input_validation/src/lib.rs
+++ b/tests/corpus/contracts/compute_input_validation/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol, Vec};
+
+const LIMIT_KEY: Symbol = symbol_short!("limit");
+
+#[contract]
+pub struct ComputeInputValidationContract;
+
+#[contractimpl]
+impl ComputeInputValidationContract {
+    pub fn validate_inputs(env: Env, inputs: Vec<i32>) -> i32 {
+        let mut total = 0i32;
+        for val in inputs.iter() {
+            let max_limit: i32 = env.storage().instance().get(&LIMIT_KEY).unwrap_or(100);
+            if val > max_limit {
+                total += max_limit;
+            } else {
+                total += val;
+            }
+        }
+        total
+    }
+
+    pub fn validate_bounded(env: Env, inputs: Vec<i32>) -> i32 {
+        let max_limit: i32 = env.storage().instance().get(&LIMIT_KEY).unwrap_or(100);
+        let mut total = 0i32;
+        let len = inputs.len().min(10);
+        for i in 0..len {
+            if let Some(val) = inputs.get(i) {
+                if val > max_limit {
+                    total += max_limit;
+                } else {
+                    total += val;
+                }
+            }
+        }
+        total
+    }
+}

--- a/tests/corpus/contracts/symbol_key_boundary/Cargo.toml
+++ b/tests/corpus/contracts/symbol_key_boundary/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "symbol-key-boundary-fixture"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"
+
+[workspace]

--- a/tests/corpus/contracts/symbol_key_boundary/src/lib.rs
+++ b/tests/corpus/contracts/symbol_key_boundary/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct SymbolKeyBoundaryContract;
+
+#[contractimpl]
+impl SymbolKeyBoundaryContract {
+    pub fn test_symbols(env: Env) {
+        let _s1 = Symbol::new(&env, "short_9");
+        let _s2 = Symbol::new(&env, "a");
+        let _l1 = Symbol::new(&env, "longer_than_nine");
+        let _m1 = symbol_short!("short_9");
+    }
+}

--- a/tests/corpus/contracts/symbol_key_enum_storage/Cargo.toml
+++ b/tests/corpus/contracts/symbol_key_enum_storage/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "symbol-key-enum-storage-fixture"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"
+
+[workspace]

--- a/tests/corpus/contracts/symbol_key_enum_storage/src/lib.rs
+++ b/tests/corpus/contracts/symbol_key_enum_storage/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Env, Symbol};
+
+#[contracttype]
+pub enum DataKey {
+    User(Symbol),
+    Admin,
+}
+
+#[contract]
+pub struct SymbolKeyEnumStorageContract;
+
+#[contractimpl]
+impl SymbolKeyEnumStorageContract {
+    pub fn construct_keys_in_loop(env: Env, count: u32) {
+        for i in 0..count {
+            let key = DataKey::User(Symbol::new(&env, "user_key"));
+            env.storage().instance().set(&key, &i);
+        }
+    }
+}

--- a/tests/corpus/contracts/symbol_key_event_topics/Cargo.toml
+++ b/tests/corpus/contracts/symbol_key_event_topics/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "symbol-key-event-topics-fixture"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"
+
+[workspace]

--- a/tests/corpus/contracts/symbol_key_event_topics/src/lib.rs
+++ b/tests/corpus/contracts/symbol_key_event_topics/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct SymbolKeyEventTopicsContract;
+
+#[contractimpl]
+impl SymbolKeyEventTopicsContract {
+    pub fn emit_events_in_loop(env: Env, count: u32) {
+        for i in 0..count {
+            let topic1 = Symbol::new(&env, "topic_one");
+            let topic2 = Symbol::new(&env, "topic_two");
+            env.events().publish((topic1, topic2), i);
+        }
+    }
+}


### PR DESCRIPTION
- Closes #390 ci: add cargo-llvm-cov coverage reporting job
- Closes #378 chore: move phase-one analysis notes to docs/history/
- Closes #375 test: add corpus contracts for compute lints
- Closes #376 test: add corpus contracts for symbol & key-construction lints
- regenerated and blessed real-world corpus baseline

