### PR TITLE
docs: rule on proposed lints overlapping Clippy

### DIFF
--- a/docs/scope_boundary.md
+++ b/docs/scope_boundary.md
@@ -24,6 +24,20 @@ These patterns are already covered by named Clippy lints. Do not re-implement th
 | Calling `.clone()` on a `Copy` type | `clippy::clone_on_copy` | Trivially redundant regardless of runtime |
 | Collecting an iterator into a collection that is never used as a collection | `clippy::needless_collect` | Unnecessary allocation on any target |
 | Redundant `Into` / `From` / `IntoIterator` conversions | `clippy::useless_conversion` | Pure type-system waste; cost-neutral on Soroban |
+| Floating-point arithmetic in contract code | `clippy::float_arithmetic` | General WASM non-determinism and floating-point operations are fully flagged by Clippy |
+| Large constant arrays embedded in contract code | `clippy::large_const_arrays` | Large inline stack/static array allocation is already caught by Clippy |
+
+## Deliberately Implemented Overlaps (Distinct Soroban Lints)
+
+When a pattern has a plausible Clippy counterpart but moves a specific Soroban resource meter, we implement a distinct Soroban lint. Each entry below explicitly names the Soroban meter that justifies the custom lint:
+
+| Proposed / Implemented Lint | Plausible Clippy Counterpart | Soroban Resource Meter | Why We Implement It |
+| --- | --- | --- | --- |
+| `redundant_env_clone` / `redundant_address_clone` | `clippy::redundant_clone` | **Host Crossing CPU Meter & Host Object Table Reference Meter** | Soroban handles (`Env`, `Address`) wrap host object references; cloning them invokes host `clone_val` calls even when ownership rules allow the clone. |
+| `bytes_append_in_loop` / `soroban_inefficient_bytes_concat` | `clippy::string_add_assign` | **Host Memory Allocation Meter & Host Crossing CPU Meter** | Clippy only checks `std::string::String`; SDK `Bytes` / `String` appends trigger host buffer re-allocations and host function calls per iteration. |
+| `vec_where_slice_could_be_used` | `clippy::ptr_arg` | **Host Crossing CPU Meter & Host Object Table Meter** | Passing `soroban_sdk::Vec` by value or reference incurs host handle lookup overhead vs native WASM stack slices (`[u8; N]`). |
+| `formatted_panic_payload` | `clippy::panic` / `clippy::format_push_string` | **WASM Bytecode Size Meter & Guest Memory Allocation Meter** | Formatting strings in panics pulls complex formatting tables into WASM binaries, inflating WASM deployment fees and guest heap allocation. |
+| `symbol_new_for_short_literal` | `clippy::string_lit_as_bytes` | **WASM Bytecode Size Meter & Host Symbol Encoding CPU Meter** | `Symbol::new` computes symbol encoding at runtime via host call, whereas `symbol_short!` encodes <= 9 char symbols as 64-bit inline `Val` constants at compile time. |
 
 ## The Genuine Overlap: When to Write a Distinct Soroban Lint
 


### PR DESCRIPTION
## Summary

- Updated [`docs/scope_boundary.md`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/soroban-cost-linter/docs/scope_boundary.md) to rule on candidate lint proposals that overlap with existing Clippy lints.
- Expanded the **Patterns Deliberately Left to Clippy** table to explicitly defer floating-point operations (`clippy::float_arithmetic`) and large constant array allocations (`clippy::large_const_arrays`).
- Introduced the **Deliberately Implemented Overlaps (Distinct Soroban Lints)** section detailing lints that overlap with Clippy counterparts but are implemented due to specific Soroban resource meter impacts (`redundant_env_clone`/`redundant_address_clone`, `bytes_append_in_loop`/`soroban_inefficient_bytes_concat`, `vec_where_slice_could_be_used`, `formatted_panic_payload`, `symbol_new_for_short_literal`).

## Rationale & Rulings

### 1. Ruled OUT (Left to Clippy)
- **Floating-point arithmetic in contracts**: Deferred to `clippy::float_arithmetic`. Floating-point operations violate WASM determinism and are fully flagged by Clippy; no custom Soroban host meter distinction is required.
- **Large constant arrays embedded in contracts**: Deferred to `clippy::large_const_arrays`. Clippy already flags large stack/const arrays.

### 2. Ruled IN (Distinct Soroban Lints Implemented)
- **Redundant Env / Address Clones**: Counterpart `clippy::redundant_clone`. Implemented because Soroban handles wrap host references. Cloning them executes host `clone_val` calls (**Host Crossing CPU Meter & Host Object Table Reference Meter**) even when Rust ownership analysis permits the clone.
- **Bytes / String Concatenation in Loops**: Counterpart `clippy::string_add_assign`. Implemented because Clippy only checks `std::string::String`, whereas SDK `Bytes`/`String` append operations trigger host buffer re-allocations (**Host Memory Allocation Meter & Host Crossing CPU Meter**).
- **Vec where Slice Could Be Used**: Counterpart `clippy::ptr_arg`. Implemented because passing `soroban_sdk::Vec` by value/ref incurs host handle lookups (**Host Crossing CPU Meter & Host Object Table Meter**) compared to native stack slices (`[u8; N]`).
- **Formatted Panic Payloads**: Counterpart `clippy::panic`. Implemented because formatting strings in panic payloads pulls formatting code into WASM binaries (**WASM Bytecode Size Meter & Guest Memory Allocation Meter**).
- **Symbol::new vs symbol_short!**: Counterpart `clippy::string_lit_as_bytes`. Implemented because `Symbol::new` computes encoding at runtime via host call (**WASM Bytecode Size Meter & Host Symbol Encoding CPU Meter**) vs inline 64-bit `Val` compile-time constants.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p cargo-cost-lint --bin cargo-cost-lint` (107/107 passed)
- `cargo run -p generate-lint-docs -- --check` (passed)

## Scope / Risk

- Strictly documentation updates in `docs/scope_boundary.md`. Zero risk to codebase runtime logic.

## Issue

Closes #409
