### PR TITLE
Fix: test: add corpus contracts using instance storage for growing data (Auto-Generated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,8 @@ exclude = [
     "tests/corpus/contracts/memory_payload_serializer",
     "tests/corpus/contracts/memory_input_decoder",
     "tests/corpus/contracts/memory_clean_processor",
+    "tests/corpus/contracts/bad_instance_storage",
+    "tests/corpus/contracts/good_fixed_instance_storage",
+    "tests/corpus/contracts/good_persistent_storage",
 ]
 resolver = "2"

--- a/tests/corpus/contracts/bad_instance_storage/Cargo.toml
+++ b/tests/corpus/contracts/bad_instance_storage/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "bad-instance-storage"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"

--- a/tests/corpus/contracts/bad_instance_storage/src/lib.rs
+++ b/tests/corpus/contracts/bad_instance_storage/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn push(env: Env, val: Symbol) {
+        let mut vec: Vec<Symbol> = env.storage().instance().get(&Symbol::new(&env, "data")).unwrap_or(Vec::new(&env));
+        vec.push_back(val);
+        env.storage().instance().set(&Symbol::new(&env, "data"), &vec);
+    }
+}

--- a/tests/corpus/contracts/good_fixed_instance_storage/Cargo.toml
+++ b/tests/corpus/contracts/good_fixed_instance_storage/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "good-fixed-instance-storage"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"

--- a/tests/corpus/contracts/good_fixed_instance_storage/src/lib.rs
+++ b/tests/corpus/contracts/good_fixed_instance_storage/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn set_admin(env: Env, admin: Symbol) {
+        env.storage().instance().set(&Symbol::new(&env, "admin"), &admin);
+    }
+}

--- a/tests/corpus/contracts/good_persistent_storage/Cargo.toml
+++ b/tests/corpus/contracts/good_persistent_storage/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "good-persistent-storage"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"

--- a/tests/corpus/contracts/good_persistent_storage/src/lib.rs
+++ b/tests/corpus/contracts/good_persistent_storage/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec, Symbol};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add_item(env: Env, id: u32, val: Symbol) {
+        env.storage().persistent().set(&id, &val);
+    }
+}


### PR DESCRIPTION
Closes #415

This pull request was generated automatically and scoped strictly to issue #415.

### Changes
Added three new corpus contracts to tests/corpus/contracts to trigger or demonstrate the behavior of the instance_storage_for_unbounded_data lint: 'bad_instance_storage' (triggers lint), 'good_fixed_instance_storage' (should not trigger), and 'good_persistent_storage' (should not trigger). Added them to the Cargo.toml workspace exclusion list.

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #415` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->