### PR TITLE
Fix: test: add corpus contracts with formatted panic payloads (Auto-Generated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 members = [
     "soroban_cost_lints",
     "cargo-cost-lint",
-    "tools/generate-lint-docs"
+    "tools/generate-lint-docs",
+    "tests/corpus/contracts/panic_formatted",
+    "tests/corpus/contracts/panic_in_test_mod",
+    "tests/corpus/contracts/panic_with_contracterror"
 ]
 exclude = [
     "soroban_cost_lints/test_fixtures/real_sdk",

--- a/tests/corpus/contracts/panic_formatted/Cargo.toml
+++ b/tests/corpus/contracts/panic_formatted/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "panic-formatted"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"

--- a/tests/corpus/contracts/panic_formatted/src/lib.rs
+++ b/tests/corpus/contracts/panic_formatted/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_std]
+use soroban_sdk::contractimpl;
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn trigger(x: u32) {
+        panic!("formatted panic: {}", x);
+    }
+}

--- a/tests/corpus/contracts/panic_in_test_mod/Cargo.toml
+++ b/tests/corpus/contracts/panic_in_test_mod/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "panic-in-test-mod"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"

--- a/tests/corpus/contracts/panic_in_test_mod/src/lib.rs
+++ b/tests/corpus/contracts/panic_in_test_mod/src/lib.rs
@@ -1,0 +1,9 @@
+#![no_std]
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_panic() {
+        panic!("this should not trigger linter: {}", 1);
+    }
+}

--- a/tests/corpus/contracts/panic_with_contracterror/Cargo.toml
+++ b/tests/corpus/contracts/panic_with_contracterror/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "panic-with-contracterror"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "26"

--- a/tests/corpus/contracts/panic_with_contracterror/src/lib.rs
+++ b/tests/corpus/contracts/panic_with_contracterror/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contracterror, contractimpl, panic_with_error, Env};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    Bad = 1,
+}
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn safe_error(env: Env) {
+        panic_with_error!(env, Error::Bad);
+    }
+}


### PR DESCRIPTION
Closes #414

This pull request was generated automatically and scoped strictly to issue #414.

### Changes
Created three new corpus contracts to test `formatted_panic_payload` behavior: 1. `panic_formatted` (should trigger lint), 2. `panic_in_test_mod` (should not trigger lint, confirming #[cfg(test)] heuristic), 3. `panic_with_contracterror` (should not trigger lint). Added entries for these to the `Cargo.toml` workspace members and re-ordered/cleaned up accordingly.

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #414` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->