### PR TITLE
Fix: ci: run the security audit on a schedule, not only on pull requests (Auto-Generated)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,9 @@ on:
       - "**/Cargo.toml"
       - "deny.toml"
       - ".github/workflows/security.yml"
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: "0 6 * * *"
   # Allow manual runs from the Actions tab.
   workflow_dispatch:
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ on:
       - "deny.toml"
       - ".github/workflows/security.yml"
   schedule:
-    # Run daily at 06:00 UTC
+    # Run daily at 06:00 UTC to catch newly disclosed vulnerabilities
     - cron: "0 6 * * *"
   # Allow manual runs from the Actions tab.
   workflow_dispatch:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,10 @@
 | 0.1.x   | :white_check_mark: |
 | < 0.1   | :x:                |
 
+## Dependency Auditing
+
+Dependencies are automatically audited for security vulnerabilities, license compliance, and maintenance status using `cargo-deny`. This check runs on every push and pull request to the `main` branch, as well as on a daily schedule (at 06:00 UTC) to catch newly disclosed advisories in existing dependencies even when no code changes are made.
+
 ## Reporting a Vulnerability
 
 Please do not report security vulnerabilities through public GitHub issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,9 +7,9 @@
 | 0.1.x   | :white_check_mark: |
 | < 0.1   | :x:                |
 
-## Dependency Auditing
+## Automated Security Audits
 
-Dependencies are automatically audited for security vulnerabilities, license compliance, and maintenance status using `cargo-deny`. This check runs on every push and pull request to the `main` branch, as well as on a daily schedule (at 06:00 UTC) to catch newly disclosed advisories in existing dependencies even when no code changes are made.
+Dependencies are automatically audited for security vulnerabilities, license compliance, and unmaintained crates using `cargo-deny`. In addition to running on every push and pull request to the `main` branch, the audit workflow runs on a daily schedule (`0 6 * * *`) against the default branch to catch newly disclosed vulnerabilities promptly.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Closes #404

This pull request was generated automatically and scoped strictly to issue #404.

### Changes
Run the security audit on a schedule in addition to push and pull requests, and document the schedule in SECURITY.md.

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #404` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->