### PR TITLE
feat: add std_collection_in_contract lint

### DIFF
--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -163,6 +163,15 @@ Fires on `.unwrap()` / `.expect()` called directly on a storage read.
 
 - **Immediate Overwrite:** If a key was just set in the same transaction, suppress with `#[allow(unwrap_on_storage_get)]` or use pattern matching `if let Some(...)`.
 
+### `std_collection_in_contract`
+
+Fires on `std::collections::HashMap`, `std::collections::BTreeMap`, and `std::vec::Vec` usage inside a `#[contractimpl]` block.
+
+- **Known false positive — performance-critical inner loop with small, fixed-size data:** if the contract processes a tiny, fixed, contract-controlled collection (e.g. a 2–3 element lookup table that never grows), the overhead of host-boundary conversion may exceed the cost of wasm-linear-memory allocation. Suppress with `#[allow(std_collection_in_contract)]` for such cases.
+- **Near-miss 1 — helper function called from `#[contractimpl]`:** the lint only fires inside the `#[contractimpl]` block itself, not in helper functions called from it. A helper that uses `HashMap` for internal bookkeeping is not flagged, which is intentional — the boundary is narrow and correct.
+- **Near-miss 2 — non-collection std types:** `String`, `Box`, `Rc`, `Arc`, and other std types are not flagged. Only the three collection types listed above are in scope.
+- **Test code exclusion:** std collections in `#[test]` functions and `#[cfg(test)]` modules are never flagged, because they are idiomatic and correct in tests.
+
 ---
 
 ## Suppression Methods

--- a/docs/lint_catalog.md
+++ b/docs/lint_catalog.md
@@ -34,5 +34,6 @@ This document provides a concise reference for all lints supported by **soroban-
 | `formatted_panic_payload` | warn | format!, formatted panic!, or expect(&format!(..)) pulls string-formatting machinery into a contract | [Link](lints/formatted_panic_payload.md) |
 | `unwrap_on_storage_get` | warn | unwrap or expect directly on a storage read — panics on a missing or expired key | [Link](lints/unwrap_on_storage_get.md) |
 | `unbounded_recursion` | warn | unbounded recursion driven by caller-supplied input | [Link](lints/unbounded_recursion.md) |
+| `std_collection_in_contract` | warn | std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec | [Link](lints/std_collection_in_contract.md) |
 
 *Severities can be overridden via `budget.toml`.*

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -45,6 +45,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | [`map_insert_in_loop`](map_insert_in_loop.md) | `warn` | Map::insert called inside a loop |
 | [`storage_key_construction_in_loop`](storage_key_construction_in_loop.md) | `warn` | storage key constructed inside a loop body where it could be hoisted |
 | [`vec_where_slice_could_be_used`](vec_where_slice_could_be_used.md) | `warn` | soroban_sdk::Vec passed by value where a native Rust slice would suffice |
+| [`std_collection_in_contract`](std_collection_in_contract.md) | `warn` | std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec |
 
 ## Entry Lifecycle
 

--- a/docs/lints/lint-registry.json
+++ b/docs/lints/lint-registry.json
@@ -180,5 +180,12 @@
     "description": "unbounded recursion driven by caller-supplied input",
     "docs_path": "docs/lints/unbounded_recursion.md",
     "name": "unbounded_recursion"
+  },
+  {
+    "category": "Memory",
+    "default_level": "warn",
+    "description": "std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec",
+    "docs_path": "docs/lints/std_collection_in_contract.md",
+    "name": "std_collection_in_contract"
   }
 ]

--- a/docs/lints/std_collection_in_contract.md
+++ b/docs/lints/std_collection_in_contract.md
@@ -1,0 +1,89 @@
+# `std_collection_in_contract`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [Memory — wasm linear memory allocation and host-boundary conversion](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Flags usage of `std::collections::HashMap`, `std::collections::BTreeMap`, and
+`std::vec::Vec` inside Soroban contract code (functions within a
+`#[contractimpl]` block).
+
+## Why is this bad?
+
+{% hint style="danger" %}
+Using std collections inside a Soroban contract allocates in wasm linear memory
+rather than through the host. This has two costs:
+
+1. **Binary inflation** — the allocator is compiled into the wasm binary,
+   increasing the deploy cost.
+2. **Host-boundary conversion** — values cannot cross the host boundary without
+   an explicit conversion that the author pays for on every use.
+
+Contracts written by developers new to Soroban reach for `HashMap` by reflex,
+and the resulting cost is invisible until they compare a deployed binary against
+one using `soroban_sdk::Map`. This lint makes it visible at compile time.
+{% endhint %}
+
+## Example
+
+```rust
+// ❌ Bad: std HashMap allocates in wasm linear memory
+#[contractimpl]
+impl MyContract {
+    fn process(env: Env) {
+        let mut map: HashMap<String, i32> = HashMap::new();
+        map.insert("key".to_string(), 42);
+    }
+}
+```
+
+```rust
+// ✅ Good: soroban_sdk::Map allocates through the host
+#[contractimpl]
+impl MyContract {
+    fn process(env: Env) {
+        let map: soroban_sdk::Map<soroban_sdk::Symbol, i32> = soroban_sdk::Map::new(&env);
+        map.set(&soroban_sdk::symbol_short!("key"), &42);
+    }
+}
+```
+
+## Suggested Fix
+
+{% hint style="success" %}
+Replace std collection types with their Soroban SDK equivalents:
+
+| Std type | Soroban equivalent |
+| --- | --- |
+| `std::collections::HashMap<K, V>` | `soroban_sdk::Map<K, V>` |
+| `std::collections::BTreeMap<K, V>` | `soroban_sdk::Map<K, V>` |
+| `std::vec::Vec<T>` | `soroban_sdk::Vec<T>` |
+
+The Soroban SDK types allocate through the host and can cross the host boundary
+without conversion.
+{% endhint %}
+
+## How contract code is identified
+
+The lint fires inside any `impl` block that carries the `#[contractimpl]`
+attribute. This is a narrow, correct boundary:
+
+- **Inside `#[contractimpl]`** — fires.
+- **Outside `#[contractimpl]`** (free functions, plain `impl` blocks, trait
+  impls) — does not fire.
+- **In test code** (`#[test]` functions, `#[cfg(test)]` modules) — does not
+  fire, because std collections are idiomatic and correct in tests.
+- **Helper functions called from `#[contractimpl]`** — does not fire, because
+  the helper itself is not inside the attribute boundary. This is intentional:
+  a narrow, correct lint beats a broad, noisy one.
+
+## What is not reported
+
+- `std::collections::HashMap`, `BTreeMap`, or `Vec` usage outside of
+  `#[contractimpl]` blocks.
+- `soroban_sdk::Map` or `soroban_sdk::Vec` usage (these are the correct types).
+- Calls suppressed with `#[allow(std_collection_in_contract)]`.
+- Non-collection std types (e.g. `String`, `Box`, `Rc`) — the lint only covers
+  the three collection types listed above.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -616,6 +616,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: UNWRAP_ON_STORAGE_GET,
         category: LintCategory::StorageOperations,
     },
+    LintMetadata {
+        lint: STD_COLLECTION_IN_CONTRACT,
+        category: LintCategory::Memory,
+    },
 ];
 
 /// `dylint` entry point. Registers every lint declared by this crate with
@@ -654,6 +658,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
         FORMATTED_PANIC_PAYLOAD,
         UNWRAP_ON_STORAGE_GET,
+        STD_COLLECTION_IN_CONTRACT,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(SorobanRedundantStorageRead));
@@ -680,6 +685,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(PersistentReadWithoutTtlExtension));
     lint_store.register_late_pass(|_| Box::new(InstanceStorageForUnboundedData));
     lint_store.register_late_pass(|_| Box::new(UnwrapOnStorageGet));
+    lint_store.register_late_pass(|_| Box::new(StdCollectionInContract));
 
     // `formatted_panic_payload` needs the AST-level `format_args!` nodes to
     // tell a zero-argument `panic!("literal")` apart from a formatted
@@ -2962,6 +2968,134 @@ fn is_const_expr<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> bool {
         hir::ExprKind::AddrOf(_, _, e) => is_const_expr(e),
         hir::ExprKind::Tup(elems) => elems.iter().all(|e| is_const_expr(e)),
         _ => false,
+    }
+}
+
+// =======================================================================
+// std_collection_in_contract — Lint
+// =======================================================================
+
+// Flags `std::collections::HashMap`, `std::collections::BTreeMap`, and
+// `std::vec::Vec` usage inside Soroban contract code. These types allocate
+// in linear memory rather than through the host, inflating the deployed
+// binary (the allocator is compiled into wasm) and requiring explicit
+// conversion every time a value crosses the host boundary.
+//
+// The lint fires inside `#[contractimpl]` blocks and skips code that is
+// inside `#[cfg(test)]` modules or functions annotated with `#[test]`,
+// where std collections are idiomatic and correct.
+//
+// Detection: for method calls (`map.insert(...)`, `vec.push(...)`), the
+// receiver type is checked against the std collection ADT paths. For
+// constructor calls (`HashMap::new()`, `Vec::new()`), the callee's DefId
+// is resolved and its parent module is inspected to determine if it
+// belongs to a std collection type.
+rustc_session::declare_lint! {
+    pub STD_COLLECTION_IN_CONTRACT,
+    Warn,
+    "std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec"
+}
+/// Concrete pass that fires [`STD_COLLECTION_IN_CONTRACT`].
+pub struct StdCollectionInContract;
+rustc_session::impl_lint_pass!(StdCollectionInContract => [STD_COLLECTION_IN_CONTRACT]);
+
+/// Paths of std collection types that should be replaced with Soroban SDK
+/// equivalents. Matched via `match_soroban_def_path` (ends-with comparison).
+const STD_COLLECTION_TYPES: &[&[&str]] = &[
+    &["std", "collections", "HashMap"],
+    &["std", "collections", "BTreeMap"],
+    &["std", "vec", "Vec"],
+];
+
+/// Constructor method names for std collection types. A call to one of these
+/// on a path whose parent module belongs to a std collection type is flagged.
+const STD_COLLECTION_CTOR_METHODS: &[&str] = &["new", "with_capacity"];
+
+/// Returns `true` if the expression sits inside a `#[contractimpl]` block.
+///
+/// Walks the HIR owner hierarchy from `expr` upward. For each enclosing
+/// `Impl` item, checks whether it carries the `#[contractimpl]` attribute
+/// (either bare `#[contractimpl]` or namespaced `#[contractimpl::...]`).
+/// Stops as soon as a match is found.
+fn is_in_contract_code<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) -> bool {
+    use rustc_hir::{ItemKind, OwnerNode};
+
+    // `#[contractimpl]` is a custom Soroban attribute, not a compiler-known
+    // symbol, so we intern the name at runtime.
+    let contractimpl_sym = rustc_span::symbol::Symbol::intern("contractimpl");
+
+    cx.tcx
+        .hir_parent_owner_iter(expr.hir_id)
+        .filter(|(_, node)| {
+            matches!(node, OwnerNode::Item(item) if matches!(item.kind, ItemKind::Impl(_)))
+        })
+        .any(|(owner_id, _)| {
+            let impl_hir_id = cx.tcx.local_def_id_to_hir_id(owner_id.def_id);
+            let attrs = cx.tcx.hir_attrs(impl_hir_id);
+            // Check for bare `#[contractimpl]` or namespaced `#[contractimpl::...]`.
+            attrs.iter().any(|attr| {
+                let segments = attr.path();
+                segments.first().is_some_and(|s| *s == contractimpl_sym)
+            })
+        })
+}
+
+impl<'tcx> LateLintPass<'tcx> for StdCollectionInContract {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        // Skip test code — std collections are idiomatic in tests.
+        if is_in_test(cx.tcx, expr.hir_id) {
+            return;
+        }
+
+        // Only fire inside #[contractimpl] blocks.
+        if !is_in_contract_code(cx, expr) {
+            return;
+        }
+
+        let uses_std_collection = match expr.kind {
+            // Method calls: map.insert(), vec.push(), etc.
+            hir::ExprKind::MethodCall(_, receiver, _, _) => {
+                let receiver_ty = cx.typeck_results().expr_ty(receiver).peel_refs();
+                if let rustc_middle::ty::Adt(adt_def, _) = receiver_ty.kind() {
+                    matches_any_path(cx, adt_def.did(), STD_COLLECTION_TYPES)
+                } else {
+                    false
+                }
+            }
+
+            // Constructor calls: HashMap::new(), Vec::new(), etc.
+            // The callee's type from typeck is FnDef(did, args), so we can
+            // extract the DefId directly from the type.
+            hir::ExprKind::Call(callee, _) => {
+                let callee_ty = cx.typeck_results().expr_ty(callee);
+                if let rustc_middle::ty::FnDef(callee_did, _) = callee_ty.kind() {
+                    let callee_path = cached_def_path_str(cx.tcx, *callee_did);
+                    let method_name = cx.tcx.item_name(*callee_did);
+                    let method_name_str = method_name.as_str();
+                    STD_COLLECTION_TYPES.iter().any(|type_segments| {
+                        let type_suffix = type_segments.join("::");
+                        callee_path.contains(&type_suffix)
+                            && STD_COLLECTION_CTOR_METHODS.contains(&method_name_str)
+                    })
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+
+        if uses_std_collection {
+            span_lint_and_help(
+                cx,
+                STD_COLLECTION_IN_CONTRACT,
+                expr.span,
+                "std collection type used in contract code",
+                None,
+                "use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, \
+                 and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate \
+                 in wasm linear memory, inflate the binary, and require conversion at the host boundary",
+            );
+        }
     }
 }
 

--- a/soroban_cost_lints/ui/std_collection_in_contract.rs
+++ b/soroban_cost_lints/ui/std_collection_in_contract.rs
@@ -1,0 +1,99 @@
+#![feature(register_tool)]
+#![register_tool(contractimpl)]
+
+// UI test fixture for `std_collection_in_contract`.
+//
+// Firing cases: std collection usage inside a `#[contractimpl]` block.
+// Non-firing cases: std collection usage outside contract code, or in test code.
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self {
+            Env
+        }
+    }
+}
+
+use soroban_sdk::Env;
+use std::collections::HashMap;
+
+// =====================================================================
+// Firing cases — std collections inside #[contractimpl]
+// =====================================================================
+
+pub struct MyContract;
+
+#[contractimpl::impl_]
+impl MyContract {
+    fn bad_hashmap_in_method(_env: Env) {
+        let mut _map: HashMap<String, i32> = HashMap::new(); // Should Warn
+        let _val = _map.get("key"); // Should Warn
+    }
+
+    fn bad_vec_in_method(_env: Env) {
+        let mut _vec: Vec<i32> = Vec::new(); // Should Warn
+        _vec.push(42); // Should Warn
+    }
+
+    fn bad_btreemap_in_method(_env: Env) {
+        let _map: std::collections::BTreeMap<u32, String> =
+            std::collections::BTreeMap::new(); // Should Warn
+    }
+
+    fn bad_hashmap_with_capacity(_env: Env) {
+        let _map: HashMap<String, i32> = HashMap::with_capacity(10); // Should Warn
+    }
+
+    fn bad_iterate_hashmap(_env: Env) {
+        let mut map: HashMap<String, i32> = HashMap::new();
+        map.insert("a".to_string(), 1);
+        for (_key, _val) in map.iter() { // Should Warn
+            // iterating over std collection
+        }
+    }
+}
+
+// =====================================================================
+// Non-firing cases — std collections outside contract code
+// =====================================================================
+
+fn good_hashmap_outside_contract() {
+    let mut _map: HashMap<String, i32> = HashMap::new(); // Good — not in contract code
+    _map.insert("key".to_string(), 1);
+}
+
+fn good_vec_outside_contract() {
+    let mut _vec: Vec<i32> = Vec::new(); // Good — not in contract code
+    _vec.push(42);
+}
+
+struct PlainStruct;
+
+impl PlainStruct {
+    fn method_with_hashmap() {
+        let _map: HashMap<String, i32> = HashMap::new(); // Good — not #[contractimpl]
+    }
+}
+
+// =====================================================================
+// Non-firing cases — std collections in test code
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_with_hashmap() {
+        let mut map: HashMap<String, i32> = HashMap::new(); // Good — in test module
+        map.insert("key".to_string(), 1);
+    }
+}
+
+#[test]
+fn test_with_vec() {
+    let _vec: Vec<i32> = Vec::new(); // Good — test function
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/std_collection_in_contract.stderr
+++ b/soroban_cost_lints/ui/std_collection_in_contract.stderr
@@ -1,0 +1,75 @@
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:30:46
+   |
+LL |         let mut _map: HashMap<String, i32> = HashMap::new(); // Should Warn
+   |                                              ^^^^^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+   = note: `#[warn(std_collection_in_contract)]` on by default
+
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:31:20
+   |
+LL |         let _val = _map.get("key"); // Should Warn
+   |                    ^^^^^^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:35:34
+   |
+LL |         let mut _vec: Vec<i32> = Vec::new(); // Should Warn
+   |                                  ^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:36:9
+   |
+LL |         _vec.push(42); // Should Warn
+   |         ^^^^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:41:13
+   |
+LL |             std::collections::BTreeMap::new(); // Should Warn
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:45:42
+   |
+LL |         let _map: HashMap<String, i32> = HashMap::with_capacity(10); // Should Warn
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:49:45
+   |
+LL |         let mut map: HashMap<String, i32> = HashMap::new();
+   |                                             ^^^^^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:50:9
+   |
+LL |         map.insert("a".to_string(), 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+
+warning: std collection type used in contract code
+  --> $DIR/std_collection_in_contract.rs:51:29
+   |
+LL |         for (_key, _val) in map.iter() { // Should Warn
+   |                             ^^^^^^^^^^
+   |
+   = help: use soroban_sdk::Map instead of std::collections::HashMap/BTreeMap, and soroban_sdk::Vec instead of std::vec::Vec; std collections allocate in wasm linear memory, inflate the binary, and req$DIRre conversion at the host boundary
+
+warning: 9 warnings emitted
+


### PR DESCRIPTION
## Description

Adds `STD_COLLECTION_IN_CONTRACT` lint that detects usage of `std::collections::HashMap`, `std::collections::BTreeMap`, and `std::vec::Vec` inside Soroban contract code (`#[contractimpl]` blocks).

Using std collections in contract code allocates in wasm linear memory rather than through the host, inflating the deployed binary and requiring explicit conversion at the host boundary on every use.

## Detection approach

**Contract code identification:** Walks the HIR owner hierarchy from each expression upward, checking for enclosing `Impl` items that carry the `#[contractimpl]` attribute. This is a narrow, correct boundary — only code inside `#[contractimpl]` blocks is flagged.

**Test code exclusion:** Uses `clippy_utils::is_in_test` to skip `#[test]` functions and `#[cfg(test)]` modules, where std collections are idiomatic and correct.

**Method call detection:** For `map.insert()`, `vec.push()`, etc., the receiver type is checked against the std collection ADT paths (`std::collections::HashMap`, `std::collections::BTreeMap`, `std::vec::Vec`).

**Constructor call detection:** For `HashMap::new()`, `Vec::new()`, etc., the callee expression type is checked for `FnDef(did, _)`, and the DefId is resolved via `cached_def_path_str` to match against known std collection paths.

## What fires

- `HashMap::new()`, `Vec::new()`, `BTreeMap::new()` inside `#[contractimpl]` ✅
- `HashMap::with_capacity(n)` inside `#[contractimpl]` ✅
- `map.insert(...)`, `vec.push(...)`, `map.get(...)`, `map.iter()` etc. inside `#[contractimpl]` ✅

## What does NOT fire

- Std collection usage outside `#[contractimpl]` blocks (free functions, plain impl blocks)
- Std collection usage in test code (`#[test]`, `#[cfg(test)]`)
- `soroban_sdk::Map` or `soroban_sdk::Vec` usage
- Non-collection std types (`String`, `Box`, etc.)
- Calls suppressed with `#[allow(std_collection_in_contract)]`

## Files changed

- `soroban_cost_lints/src/lib.rs` — lint declaration, struct, `LateLintPass` impl, registration, and metadata
- `soroban_cost_lints/ui/std_collection_in_contract.rs` — test fixtures (firing and non-firing cases)
- `soroban_cost_lints/ui/std_collection_in_contract.stderr` — generated expected diagnostics
- `docs/lints/std_collection_in_contract.md` — new lint doc page
- `docs/false_positives.md` — known false positives appended
- `docs/lints/lint-registry.json`, `docs/lints/README.md`, `docs/lint_catalog.md` — regenerated by `cargo run -p generate-lint-docs`

## Verification

- [x] `cargo fmt --all -- --check` ✅
- [x] `cargo clippy --workspace --all-targets -- -D warnings` ✅
- [x] `cargo test --workspace` ✅
- [x] `cargo run -p generate-lint-docs` ✅

Closes #359