### PR TITLE
feat: budget.toml walk-up discovery, macOS CI matrix, and .lintignorsupport

### DIFF
--- a/.github/scripts/validate-toolchain-pins.sh
+++ b/.github/scripts/validate-toolchain-pins.sh
@@ -78,10 +78,20 @@ else
     echo "::error file=soroban_cost_lints/Cargo.toml::Invalid or unreachable clippy_utils rev ${CLIPPY_REV}. Update the rev in soroban_cost_lints/Cargo.toml."
     FAILED=1
   else
-    COMMIT_TS=$(date -d "$COMMIT_DATE" +%s 2>/dev/null)
-    NIGHTLY_TS=$(date -d "$NIGHTLY_DATE" +%s 2>/dev/null)
+    parse_ts() {
+      local d="$1"
+      if date -u -d "$d" +%s 2>/dev/null; then
+        return 0
+      elif date -j -f "%Y-%m-%d" "$d" +%s 2>/dev/null; then
+        return 0
+      fi
+      return 1
+    }
+
+    COMMIT_TS=$(parse_ts "$COMMIT_DATE" || true)
+    NIGHTLY_TS=$(parse_ts "$NIGHTLY_DATE" || true)
     if [ -z "$COMMIT_TS" ] || [ -z "$NIGHTLY_TS" ]; then
-      echo "::error::Cannot compare dates (date command may not support -d flag)"
+      echo "::error::Cannot compare dates (date command failed)"
       FAILED=1
     else
       DIFF=$((COMMIT_TS - NIGHTLY_TS))

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - name: Validate toolchain pins (Linux)
         if: runner.os == 'Linux'
+        run: bash .github/scripts/validate-toolchain-pins.sh
+      - name: Validate toolchain pins (macOS)
+        if: runner.os == 'macOS'
         run: bash .github/scripts/validate-toolchain-pins.sh
       - name: Validate toolchain pins (Windows)
         if: runner.os == 'Windows'

--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ cargo cost-lint --deny soroban_storage_in_loop --allow redundant_env_clone
 2. **`budget.toml`** defines project-wide defaults for unoverridden lints.
 3. **Built-in lint defaults** apply when neither the command line nor `budget.toml` specifies a level.
 
+#### Configuration Discovery Order
+When resolving `budget.toml`, `cargo cost-lint` uses the following order:
+1. **Explicit `--config <PATH>` CLI option**: Loads the specified configuration file. Fails with an error if the path does not exist.
+2. **Current working directory**: Checks for `budget.toml` in the current working directory.
+3. **Walk-up discovery**: If not found in the current directory, walks up parent directories until it finds the workspace root.
+4. **Safe defaults**: If no `budget.toml` is found up to the workspace root, safe default lint levels are used.
+
+You can inspect the resolved configuration path by running with `--verbose`.
+
 Passing conflicting levels for the same lint (e.g. `--allow <LINT> --deny <LINT>`) or an unknown lint name will be rejected with an error before execution.
 
 ### Running the linter

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -365,18 +365,129 @@ fn validate_and_build_flags(config: &BudgetConfig) -> Result<Vec<String>, String
     build_effective_lint_flags(Some(config), &[], &[], &[])
 }
 
-fn resolve_config(config: Option<&str>) -> Option<PathBuf> {
-    if let Some(path) = config {
-        let p = PathBuf::from(path);
-        if p.exists() {
-            return Some(p);
+/// Container for `.lintignore` suppression patterns.
+#[derive(Clone, Debug)]
+pub struct LintIgnore {
+    gitignore: ignore::gitignore::Gitignore,
+    pub path: PathBuf,
+}
+
+impl LintIgnore {
+    /// Discovers `.lintignore` by searching `cwd` and walking up to `workspace_root`.
+    #[allow(clippy::collapsible_if)]
+    pub fn discover(cwd: &Path, workspace_root: &Path) -> Option<Self> {
+        let mut current = cwd.to_path_buf();
+        loop {
+            let path = current.join(".lintignore");
+            if path.exists() {
+                let mut builder = ignore::gitignore::GitignoreBuilder::new(&current);
+                if builder.add(&path).is_none() {
+                    let build_res = builder.build();
+                    if let Ok(gitignore) = build_res {
+                        return Some(LintIgnore { gitignore, path });
+                    }
+                }
+            }
+            if current == workspace_root {
+                break;
+            }
+            match current.parent() {
+                Some(parent) => current = parent.to_path_buf(),
+                None => break,
+            }
+        }
+        None
+    }
+
+    /// Checks if a file path matches any `.lintignore` rule.
+    pub fn is_ignored<P: AsRef<Path>>(&self, file_path: P) -> bool {
+        let path = file_path.as_ref();
+        let rel_path = if let Ok(current) = std::env::current_dir() {
+            if let Ok(stripped) = path.strip_prefix(&current) {
+                stripped
+            } else {
+                path
+            }
+        } else {
+            path
+        };
+        self.gitignore.matched(rel_path, false).is_ignore()
+            || self.gitignore.matched(path, false).is_ignore()
+    }
+}
+
+/// Helper to find workspace root directory by invoking `cargo metadata` or walking up parent directories.
+#[allow(clippy::collapsible_if)]
+pub fn find_workspace_root_path(start_dir: &Path) -> PathBuf {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["metadata", "--no-deps", "--format-version", "1"]);
+    cmd.current_dir(start_dir);
+    if let Ok(output) = cmd.output() {
+        if output.status.success() {
+            let json_res = serde_json::from_slice::<serde_json::Value>(&output.stdout);
+            if let Ok(val) = json_res {
+                if let Some(root_str) = val.get("workspace_root").and_then(|v| v.as_str()) {
+                    return PathBuf::from(root_str);
+                }
+            }
         }
     }
-    let budget = PathBuf::from("budget.toml");
-    if budget.exists() {
-        return Some(budget);
+    let mut current = start_dir.to_path_buf();
+    let mut candidate = current.clone();
+    loop {
+        let manifest = current.join("Cargo.toml");
+        if manifest.exists() {
+            candidate = current.clone();
+            let read_res = fs::read_to_string(&manifest);
+            if let Ok(content) = read_res {
+                if content.contains("[workspace]") {
+                    return current;
+                }
+            }
+        }
+        match current.parent() {
+            Some(parent) => current = parent.to_path_buf(),
+            None => break,
+        }
+    }
+    candidate
+}
+
+/// Discovers `budget.toml` by searching `cwd` and walking up to `workspace_root`.
+pub fn discover_config_file(cwd: &Path, workspace_root: &Path) -> Option<PathBuf> {
+    let mut current = cwd.to_path_buf();
+    loop {
+        let budget = current.join("budget.toml");
+        if budget.exists() {
+            return Some(budget);
+        }
+        if current == workspace_root {
+            break;
+        }
+        match current.parent() {
+            Some(parent) => current = parent.to_path_buf(),
+            None => break,
+        }
     }
     None
+}
+
+/// Resolves config path based on CLI `--config` option or by walking up from `cwd` to `workspace_root`.
+/// An explicit `--config <PATH>` wins and errors if the specified file does not exist.
+pub fn resolve_config(config_arg: Option<&str>) -> Result<Option<PathBuf>, String> {
+    if let Some(path_str) = config_arg {
+        let path = PathBuf::from(path_str);
+        if path.exists() {
+            Ok(Some(path))
+        } else {
+            Err(format!("Error: Config file '{}' does not exist", path_str))
+        }
+    } else {
+        let cwd = std::env::current_dir()
+            .map_err(|e| format!("Error: Failed to get current directory: {}", e))?;
+        let workspace_root = find_workspace_root_path(&cwd);
+        Ok(discover_config_file(&cwd, &workspace_root))
+    }
 }
 
 /// Loads `path` as a validated `BudgetConfig` and formats its `[lints]`
@@ -498,9 +609,23 @@ fn main() {
     let mut resolved_config_path: Option<PathBuf> = None;
     let mut config_opt: Option<BudgetConfig> = None;
 
-    if let Some(ref path) = resolve_config(cli.config.as_deref()) {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let workspace_root = find_workspace_root_path(&cwd);
+    let lintignore_opt = LintIgnore::discover(&cwd, &workspace_root);
+
+    let resolved_config = match resolve_config(cli.config.as_deref()) {
+        Ok(path_opt) => path_opt,
+        Err(e) => {
+            eprintln!("{}", e);
+            exit(1);
+        }
+    };
+
+    if let Some(ref path) = resolved_config {
         resolved_config_path = Some(path.clone());
-        if !quiet {
+        if verbose {
+            eprintln!("Using config file: {}", path.display());
+        } else if !quiet {
             eprintln!("Using config: {}", path.display());
         }
         if let Ok(config_str) = fs::read_to_string(path) {
@@ -513,7 +638,9 @@ fn main() {
             }
         }
     } else {
-        if !quiet && cli.allow.is_empty() && cli.warn.is_empty() && cli.deny.is_empty() {
+        if verbose {
+            eprintln!("No budget.toml found, using default lint levels.");
+        } else if !quiet && cli.allow.is_empty() && cli.warn.is_empty() && cli.deny.is_empty() {
             eprintln!("Warning: budget.toml not found, using default lint levels.");
         }
     }
@@ -615,7 +742,8 @@ fn main() {
     let mut cargo_args = Vec::new();
     cargo_args.extend(package_args);
 
-    if cli.format != OutputFormat::Text {
+    let has_lintignore = lintignore_opt.is_some();
+    if cli.format != OutputFormat::Text || has_lintignore {
         cargo_args.push("--message-format=json".to_string());
     }
 
@@ -632,6 +760,9 @@ fn main() {
         } else {
             eprintln!("[verbose] config: (none — using default lint levels)");
         }
+        if let Some(ref li) = lintignore_opt {
+            eprintln!("[verbose] .lintignore: {}", li.path.display());
+        }
         if !rustflags_value.is_empty() {
             eprintln!("[verbose] DYLINT_RUSTFLAGS: {}", rustflags_value);
         } else {
@@ -640,7 +771,7 @@ fn main() {
         eprintln!("[verbose] command: {:?}", cmd);
     }
 
-    if cli.format != OutputFormat::Text {
+    if cli.format != OutputFormat::Text || has_lintignore {
         cmd.stdout(Stdio::piped());
         let mut child = cmd
             .spawn()
@@ -659,18 +790,6 @@ fn main() {
                         if let Some(code) = message.get("code") {
                             if let Some(lint_name) = code.get("code").and_then(|c| c.as_str()) {
                                 if LINT_NAMES.contains(&lint_name) {
-                                    let level = message
-                                        .get("level")
-                                        .and_then(|l| l.as_str())
-                                        .unwrap_or("unknown");
-                                    if level == "error" || level == "deny" {
-                                        highest_exit_code = 1;
-                                    }
-
-                                    let msg_text = message
-                                        .get("message")
-                                        .and_then(|m| m.as_str())
-                                        .unwrap_or("");
                                     let mut file = String::new();
                                     let mut span_obj = Span {
                                         line_start: 0,
@@ -717,6 +836,31 @@ fn main() {
                                         }
                                     }
 
+                                    if let Some(ref lintignore) = lintignore_opt {
+                                        if !file.is_empty() && lintignore.is_ignored(&file) {
+                                            if verbose {
+                                                eprintln!(
+                                                    "[verbose] Suppressing finding in {} due to .lintignore pattern",
+                                                    file
+                                                );
+                                            }
+                                            continue;
+                                        }
+                                    }
+
+                                    let level = message
+                                        .get("level")
+                                        .and_then(|l| l.as_str())
+                                        .unwrap_or("unknown");
+                                    if level == "error" || level == "deny" {
+                                        highest_exit_code = 1;
+                                    }
+
+                                    let msg_text = message
+                                        .get("message")
+                                        .and_then(|m| m.as_str())
+                                        .unwrap_or("");
+
                                     let mut help_text = None;
                                     if let Some(children) =
                                         message.get("children").and_then(|c| c.as_array())
@@ -745,6 +889,14 @@ fn main() {
                                     };
 
                                     match cli.format {
+                                        OutputFormat::Text => {
+                                            if let Some(rendered) =
+                                                message.get("rendered").and_then(|r| r.as_str())
+                                            {
+                                                eprint!("{}", rendered);
+                                                recorded_stdout.push_str(rendered);
+                                            }
+                                        }
                                         OutputFormat::Json => {
                                             if let Ok(json_str) = serde_json::to_string(&finding) {
                                                 println!("{}", json_str);
@@ -767,7 +919,6 @@ fn main() {
                                         OutputFormat::Sarif => {
                                             sarif_findings.push(finding);
                                         }
-                                        OutputFormat::Text => {}
                                     }
                                 }
                             }
@@ -1716,5 +1867,91 @@ mod tests {
     #[test]
     fn color_choice_as_cargo_arg_never_returns_never() {
         assert_eq!(ColorChoice::Never.as_cargo_arg(), Some("never"));
+    }
+
+    #[test]
+    fn test_discover_config_in_cwd() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path();
+        let budget_path = cwd.join("budget.toml");
+        std::fs::write(&budget_path, "[lints]\n").unwrap();
+
+        let found = discover_config_file(cwd, cwd);
+        assert_eq!(found, Some(budget_path));
+    }
+
+    #[test]
+    fn test_discover_config_in_ancestor() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path();
+        let member_dir = workspace_root.join("member");
+        std::fs::create_dir_all(&member_dir).unwrap();
+
+        let budget_path = workspace_root.join("budget.toml");
+        std::fs::write(&budget_path, "[lints]\n").unwrap();
+
+        let found = discover_config_file(&member_dir, workspace_root);
+        assert_eq!(found, Some(budget_path));
+    }
+
+    #[test]
+    fn test_discover_config_none_found() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path();
+        let member_dir = workspace_root.join("member");
+        std::fs::create_dir_all(&member_dir).unwrap();
+
+        let found = discover_config_file(&member_dir, workspace_root);
+        assert_eq!(found, None);
+    }
+
+    #[test]
+    fn test_discover_config_stops_at_workspace_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent_dir = temp.path();
+        let workspace_root = parent_dir.join("workspace");
+        let member_dir = workspace_root.join("member");
+        std::fs::create_dir_all(&member_dir).unwrap();
+
+        // Create budget.toml in parent_dir (OUTSIDE workspace)
+        std::fs::write(parent_dir.join("budget.toml"), "[lints]\n").unwrap();
+
+        let found = discover_config_file(&member_dir, &workspace_root);
+        assert_eq!(found, None);
+    }
+
+    #[test]
+    fn test_resolve_config_explicit_override_and_missing_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let valid_config = temp.path().join("my_budget.toml");
+        std::fs::write(&valid_config, "[lints]\n").unwrap();
+
+        let res_ok = resolve_config(valid_config.to_str());
+        assert!(res_ok.is_ok());
+        assert_eq!(res_ok.unwrap(), Some(valid_config));
+
+        let res_err = resolve_config(Some("/nonexistent/file/path/budget.toml"));
+        assert!(res_err.is_err());
+        assert!(res_err.unwrap_err().contains("does not exist"));
+    }
+
+    #[test]
+    fn test_lintignore_matching() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let lintignore_path = root.join(".lintignore");
+        std::fs::write(
+            &lintignore_path,
+            "src/generated/*.rs\nsrc/legacy_batch.rs\n*.tmp.rs\n",
+        )
+        .unwrap();
+
+        let lintignore = LintIgnore::discover(root, root).expect(".lintignore should be loaded");
+        assert!(lintignore.is_ignored(root.join("src/generated/foo.rs")));
+        assert!(lintignore.is_ignored(root.join("src/legacy_batch.rs")));
+        assert!(lintignore.is_ignored(root.join("test.tmp.rs")));
+
+        assert!(!lintignore.is_ignored(root.join("src/main.rs")));
+        assert!(!lintignore.is_ignored(root.join("src/lib.rs")));
     }
 }

--- a/docs/macos_setup.md
+++ b/docs/macos_setup.md
@@ -1,0 +1,36 @@
+# macOS Setup Guide
+
+This page complements [`CONTRIBUTING.md`](../CONTRIBUTING.md) with macOS-specific setup instructions for `soroban-cost-linter`.
+
+## Environment & Prerequisites
+
+1. **Rust Toolchain**: Install via [`rustup`](https://rustup.rs):
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+2. **Apple Command Line Tools / Xcode**:
+   ```bash
+   xcode-select --install
+   ```
+
+## Installing Dylint and the Linter
+
+```bash
+# Install Dylint (matching version pin)
+cargo install cargo-dylint dylint-link --version "^6.0.1" --locked
+
+# Install cargo-cost-lint wrapper
+cargo install --path cargo-cost-lint
+```
+
+## Running the Linter on macOS
+
+```bash
+cd path/to/my-soroban-contract
+cargo cost-lint
+```
+
+## CI Matrix & Cache Notes
+
+- The project CI test matrix includes `macos-latest`.
+- Dynamic library compilation (`cargo-dylint` and `dylint-link`) on macOS utilizes shared rust-cache keys (`cost-linter`) to maintain fast CI build times.


### PR DESCRIPTION


- Implement budget.toml walk-up discovery from cwd to workspace root with explicit --config error handling (#386)
- Add macos-latest leg to lint workflow matrix and update validate-toolchain-pins.sh for BSD date (#394)
- Add .lintignore file pattern discovery and suppression matching across output formats (#389)
- Document discovery order in README.md and add docs/macos_setup.md
- Add comprehensive test coverage for config discovery, overrides, and .lintignore matching

Closes #386
Closes #394
Closes #389
