### PR TITLE
Fix: ci: smoke-test the published container image (Auto-Generated)

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -37,3 +37,16 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Pull and smoke test published container image
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}-dev:latest"
+          echo "Pulling published image: $IMAGE"
+          docker pull "$IMAGE"
+          
+          echo "Running smoke test against test_fixtures/smoke_test/ inside container"
+          OUTPUT=$(docker run --rm -v "$(pwd)/test_fixtures/smoke_test:/workspace/smoke_test" -w /workspace/smoke_test "$IMAGE" cargo cost-lint --format json 2>&1 || true)
+          echo "Container output:"
+          echo "$OUTPUT"
+          
+          echo "Asserting expected findings are present..."
+          echo "$OUTPUT" | grep -q "soroban_storage_in_loop"


### PR DESCRIPTION
Closes #403

This pull request was generated automatically and scoped strictly to issue #403.

### Changes
Add a smoke test step to container-publish.yml that pulls the published container image from ghcr.io and runs cargo-cost-lint inside it against the test_fixtures/smoke_test/ fixture, verifying real lint findings and ensuring release safety.

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #403` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->