### PR TITLE
feat: add NESTED_LOOP_STORAGE_ACCESS cost lint

### DIFF
--- a/.github/scripts/validate-toolchain-pins.sh
+++ b/.github/scripts/validate-toolchain-pins.sh
@@ -73,6 +73,9 @@ else
       COMMIT_DATE=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['commit']['committer']['date'].split('T')[0])" 2>/dev/null)
     fi
   fi
+  if [ -z "$COMMIT_DATE" ] || [ "$COMMIT_DATE" = "null" ]; then
+    COMMIT_DATE=$(echo "$RESPONSE" | sed -n '/"committer": {/,/}/ s/.*"date": "\([^"]*\)".*/\1/p' | head -n 1 | cut -d'T' -f1)
+  fi
 
   if [ -z "$COMMIT_DATE" ] || [ "$COMMIT_DATE" = "null" ]; then
     echo "::error file=soroban_cost_lints/Cargo.toml::Invalid or unreachable clippy_utils rev ${CLIPPY_REV}. Update the rev in soroban_cost_lints/Cargo.toml."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clippy_utils"
 version = "0.1.97"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=f6d310692116e9a527ce6d0b3526c965d9c5d7b9#f6d310692116e9a527ce6d0b3526c965d9c5d7b9"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=f9c23c1fcb96fb42e8706fa9c61043dc70423ba9#f9c23c1fcb96fb42e8706fa9c61043dc70423ba9"
 dependencies = [
  "arrayvec",
  "itertools",

--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -70,6 +70,14 @@ Every storage read or write inside any loop body is flagged.
 - **Counting or scanning patterns** — using a loop to count entries or scan through storage with `has()`.
 - **Handling:** Suppress intentional batch operations using `#[allow(soroban_storage_in_loop)]`.
 
+### `nested_loop_storage_access`
+
+Fires on storage operations at loop nesting depth ≥ 2 — i.e., a storage access inside two or more nested loops.
+
+- **Nested loop with intentional per-iteration writes** — writing to different keys in both loops where the multiplicative cost is inherent to the algorithm.
+- **Closures inside nested loops** — a closure body inside a nested loop that performs a storage access; the closure is the inner loop's body, not a separate nesting level.
+- **Handling:** If the nested storage access is intentional and the multiplicative cost is acceptable, suppress with `#[allow(nested_loop_storage_access)]`.
+
 ### `storage_write_without_read`
 
 Fires on any `set` whose `(receiver, key)` snippet has no matching `get`/`has` anywhere in the same function.

--- a/docs/lint_catalog.md
+++ b/docs/lint_catalog.md
@@ -9,6 +9,7 @@ This document provides a concise reference for all lints supported by **soroban-
 | Lint | Default Severity | Description | Docs |
 |------|------------------|-------------|------|
 | `soroban_storage_in_loop` | warn | storage operations inside a loop | [Link](lints/soroban_storage_in_loop.md) |
+| `nested_loop_storage_access` | deny | storage operation inside a nested loop — O(n·m) cost | [Link](lints/nested_loop_storage_access.md) |
 | `loop_invariant_storage_access` | warn | storage operation inside a loop whose operands are provably loop-invariant | [Link](lints/loop_invariant_storage_access.md) |
 | `soroban_inefficient_bytes_concat` | warn | inefficient Bytes concatenation inside a loop | [Link](lints/soroban_inefficient_bytes_concat.md) |
 | `soroban_redundant_storage_read` | warn | multiple sequential reads of the same storage key without modification | [Link](lints/soroban_redundant_storage_read.md) |

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -13,6 +13,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | Lint | Default Severity | Catches |
 | --- | --- | --- |
 | [`soroban_storage_in_loop`](soroban_storage_in_loop.md) | `warn` | storage operations inside a loop |
+| [`nested_loop_storage_access`](nested_loop_storage_access.md) | `deny` | storage operation inside a nested loop — O(n·m) cost |
 | [`loop_invariant_storage_access`](loop_invariant_storage_access.md) | `warn` | storage operation inside a loop whose operands are provably loop-invariant |
 | [`soroban_redundant_storage_read`](soroban_redundant_storage_read.md) | `warn` | multiple sequential reads of the same storage key without modification |
 | [`storage_write_without_read`](storage_write_without_read.md) | `warn` | storage write without a corresponding read |

--- a/docs/lints/lint-registry.json
+++ b/docs/lints/lint-registry.json
@@ -8,6 +8,13 @@
   },
   {
     "category": "StorageOperations",
+    "default_level": "deny",
+    "description": "storage operation inside a nested loop — O(n·m) cost",
+    "docs_path": "docs/lints/nested_loop_storage_access.md",
+    "name": "nested_loop_storage_access"
+  },
+  {
+    "category": "StorageOperations",
     "default_level": "warn",
     "description": "storage operation inside a loop whose operands are provably loop-invariant",
     "docs_path": "docs/lints/loop_invariant_storage_access.md",

--- a/docs/lints/nested_loop_storage_access.md
+++ b/docs/lints/nested_loop_storage_access.md
@@ -1,0 +1,153 @@
+# `nested_loop_storage_access`
+
+**Default Severity:** `deny`
+
+**Target Resource:** [Storage — ledger entry accesses and ledger I/O bytes](../cost_rationale.md#per-lint-resource-summary)
+
+## What it does
+
+Detects storage operations (reads or writes) that are executed inside **nested**
+loop bodies — i.e., at a loop nesting depth of 2 or more. A storage access at
+depth 1 is linear in one dimension; at depth 2 it becomes multiplicative
+(O(n·m)).
+
+## Why is this bad?
+
+{% hint style="danger" %}
+Storage operations are the **single most expensive resource** Soroban charges
+for. Each write consumes a ledger entry write access, I/O bytes, serialization
+cost, and (for new entries) space rent. Placing them inside a loop multiplies
+every dimension by the iteration count. Placing them inside **nested** loops
+makes the cost **multiplicative** — a contract that passes testing with small
+inputs can exceed the ledger's resource limits on real data. See the
+[Cost Rationale — Storage](../cost_rationale.md#3-storage-ledger-entry-accesses-and-ledger-io)
+for details.
+{% endhint %}
+
+## Example
+
+### Nested `for` loops
+
+```rust
+// ❌ Bad: storage write at O(n·m) — every iteration of both loops
+for i in 0..n {
+    for j in 0..m {
+        env.storage().instance().set(&(i + j), &1);
+    }
+}
+```
+
+### `for` loop containing a `while` loop
+
+```rust
+// ❌ Bad: storage read at O(n·m)
+for i in 0..n {
+    let mut j = 0;
+    while j < m {
+        let _val = env.storage().persistent().get(&i);
+        j += 1;
+    }
+}
+```
+
+## Cost impact
+
+| Pattern | Iterations | Cost model |
+| --- | --- | --- |
+| Storage in single loop | n | O(n) |
+| Storage in nested loops | n × m | O(n·m) |
+
+A 10×10 nested loop with a storage write in the inner body issues 100 storage
+operations. The same operation in a single loop with 100 iterations issues 100
+storage operations, but the nested version is harder to reason about and more
+likely to be a mistake — the author typically intended the inner operation to
+apply to a single aggregated result.
+
+## Suggested Fix
+
+{% hint style="success" %}
+Hoist the storage operation out of at least one loop, or accumulate mutations
+in memory and write once after the loops complete.
+{% endhint %}
+
+```rust
+// ✅ Fixed: accumulate in memory, single write after loops
+let mut total = 0i128;
+for i in 0..n {
+    for j in 0..m {
+        total += i + j;
+    }
+}
+env.storage().instance().set(&COUNTER, &total);
+```
+
+## How loop nesting depth is computed
+
+Depth is computed by walking up the HIR parent chain from the storage
+operation:
+
+- **`for`, `while`, `loop`** — each increments the depth counter.
+- **Closures** (e.g., `.iter().for_each(|x| { ... })`) — **not** counted as
+  additional nesting. A closure body inside a loop is still inside the same
+  loop; the closure is the loop's callback, not a separate nesting level.
+- **Function definitions** — stop the walk. A `fn` defined inside a loop is a
+  separate function that may be called from anywhere, so its internal loops
+  are independent.
+
+### Examples of correct depth computation
+
+| Pattern | Computed depth | Fires? |
+| --- | --- | --- |
+| `for i in 0..n { storage.set() }` | 1 | No |
+| `for i in 0..n { for j in 0..m { storage.set() } }` | 2 | **Yes** |
+| `for i in 0..n { items.iter().for_each(\|x\| { storage.set() }) }` | 1 | No |
+| `for i in 0..n { for j in 0..m { items.iter().for_each(\|x\| { storage.set() }) } }` | 2 | **Yes** |
+| `for i in 0..n { fn inner() { for j in 0..m { storage.set() } } inner(); }` | 1 | No |
+
+## Relationship to `soroban_storage_in_loop`
+
+| Lint | Default Severity | What it flags |
+| --- | --- | --- |
+| [`soroban_storage_in_loop`](soroban_storage_in_loop.md) | `warn` | **Every** storage operation inside any loop, regardless of nesting depth |
+| `nested_loop_storage_access` | `deny` | Storage operations at **depth ≥ 2** — the multiplicative-cost case |
+
+`soroban_storage_in_loop` fires on all storage-in-loop patterns, including
+depth-1 cases where the cost is linear. `nested_loop_storage_access` is a
+strict subset that fires only when the storage access is inside nested loops,
+where the cost becomes multiplicative. The two lints are complementary:
+`soroban_storage_in_loop` catches the general case;
+`nested_loop_storage_access` highlights the shape most likely to exceed
+resource limits on real data.
+
+When a storage operation is at depth ≥ 2, **both** lints may fire. This is
+deliberate — `nested_loop_storage_access` carries a stronger severity (`deny`)
+and a more specific diagnostic to make the quadratic cost explicit.
+
+## What is **not** reported
+
+- A storage operation inside a single loop (depth 1) — handled by
+  [`soroban_storage_in_loop`](soroban_storage_in_loop.md).
+- A storage operation inside a closure passed to an iterator method inside a
+  single loop — the closure is the loop body, not a separate nesting level.
+- A storage operation inside a function definition that itself sits inside a
+  loop — the inner function may be called from anywhere.
+- A storage operation outside all loops.
+
+## Known False Positives
+
+This lint is intentionally conservative about what constitutes a nesting level.
+The following patterns are correctly **not** flagged but may look surprising:
+
+- A closure passed to `.iter().for_each()` inside a loop — the closure is the
+  loop's iteration callback, not a nested loop.
+- A storage operation inside a `match` arm within a loop — `match` is not a
+  loop construct.
+
+If a pattern is intentionally nested and the multiplicative cost is desired,
+suppress with `#[allow(nested_loop_storage_access)]`.
+
+## See also
+
+- [`soroban_storage_in_loop`](soroban_storage_in_loop.md) — the broader lint that catches all storage-in-loop patterns
+- [`loop_invariant_storage_access`](loop_invariant_storage_access.md) — loop-invariant storage operations that can be hoisted
+- [Cost Rationale](../cost_rationale.md) — why storage operations dominate Soroban fees

--- a/soroban_cost_lints/Cargo.toml
+++ b/soroban_cost_lints/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "f6d310692116e9a527ce6d0b3526c965d9c5d7b9" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "f9c23c1fcb96fb42e8706fa9c61043dc70423ba9" }
 dylint_linting = "6.0.1"
 
 [dev-dependencies]

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -513,6 +513,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         category: LintCategory::StorageOperations,
     },
     LintMetadata {
+        lint: NESTED_LOOP_STORAGE_ACCESS,
+        category: LintCategory::StorageOperations,
+    },
+    LintMetadata {
         lint: LOOP_INVARIANT_STORAGE_ACCESS,
         category: LintCategory::StorageOperations,
     },
@@ -629,6 +633,7 @@ pub const LINT_METADATA: &[LintMetadata] = &[
 pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore) {
     lint_store.register_lints(&[
         SOROBAN_STORAGE_IN_LOOP,
+        NESTED_LOOP_STORAGE_ACCESS,
         SOROBAN_REDUNDANT_STORAGE_READ,
         REDUNDANT_ENV_CLONE,
         UNNECESSARY_HOST_FUNCTION_CALL,
@@ -656,6 +661,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         UNWRAP_ON_STORAGE_GET,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
+    lint_store.register_late_pass(|_| Box::new(NestedLoopStorageAccess));
     lint_store.register_late_pass(|_| Box::new(SorobanRedundantStorageRead));
     lint_store.register_late_pass(|_| Box::new(RedundantEnvClone));
     lint_store.register_late_pass(|_| Box::new(UnnecessaryHostFunctionCall));
@@ -785,6 +791,124 @@ impl<'tcx> LateLintPass<'tcx> for SorobanStorageInLoop {
                     "move storage operations out of the loop or accumulate mutations in memory first",
                 );
             }
+        }
+    }
+}
+
+// =======================================================================
+// nested_loop_storage_access — Lint
+// =======================================================================
+
+// Flags storage operations at nesting depth >= 2. A single loop with a
+// storage op is already caught by `soroban_storage_in_loop`; this lint
+// separates the quadratic case (nested loops) so it can carry a stronger
+// message and a different default severity. Depth is computed correctly
+// across for, while, loop, and iterator-closure bodies. A closure body
+// inside a loop is still inside the loop; a loop inside a nested function
+// definition is not.
+rustc_session::declare_lint! {
+    pub NESTED_LOOP_STORAGE_ACCESS,
+    Deny,
+    "storage operation inside a nested loop — O(n·m) cost"
+}
+/// Concrete pass that fires [`NESTED_LOOP_STORAGE_ACCESS`].
+pub struct NestedLoopStorageAccess;
+rustc_session::impl_lint_pass!(NestedLoopStorageAccess => [NESTED_LOOP_STORAGE_ACCESS]);
+
+/// Visitor that computes the loop nesting depth of a target expression by
+/// walking the HIR tree. Increments the counter for `for`, `while`, and
+/// `loop` constructs. Closures are **not** counted as additional nesting —
+/// a closure body inside a loop is still inside the same loop. The visitor
+/// stops at function definitions (`fn`, closures) since a nested function
+/// may be called from anywhere.
+struct LoopDepthVisitor<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    target: HirId,
+    depth: u32,
+    found: bool,
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for LoopDepthVisitor<'a, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        if self.found {
+            return;
+        }
+
+        match expr.kind {
+            hir::ExprKind::Loop(body, _, _, _) => {
+                self.depth += 1;
+                self.visit_expr(body);
+                if !self.found {
+                    self.depth -= 1;
+                }
+                return;
+            }
+            hir::ExprKind::Closure(_) => {
+                // Closure body inside a loop is still inside the loop;
+                // do not count the closure as an additional nesting level.
+                // Visit the closure body to find the target inside it.
+                intravisit::walk_expr(self, expr);
+                return;
+            }
+            _ => {}
+        }
+
+        // Check if this is the target expression.
+        if expr.hir_id == self.target {
+            self.found = true;
+            return;
+        }
+
+        intravisit::walk_expr(self, expr);
+    }
+
+    // Don't descend into nested function definitions.
+    fn visit_item(&mut self, _item: &'tcx hir::Item<'tcx>) {}
+}
+
+impl<'tcx> LateLintPass<'tcx> for NestedLoopStorageAccess {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        let is_storage_access = if let hir::ExprKind::MethodCall(
+            path_segment, receiver, _args, _span,
+        ) = expr.kind
+        {
+            let method_name = path_segment.ident.name.as_str();
+            let is_terminal = matches!(method_name, "get" | "has" | "set" | "remove");
+            is_terminal && is_type_match(cx, cx.typeck_results().expr_ty(receiver), SOROBAN_STORAGE_TYPES)
+        } else {
+            false
+        };
+
+        if !is_storage_access {
+            return;
+        }
+
+        // Walk the HIR tree from the crate root to find the target expression
+        // and compute its loop nesting depth.
+        let mut visitor = LoopDepthVisitor {
+            cx,
+            target: expr.hir_id,
+            depth: 0,
+            found: false,
+        };
+
+        // Start walking from the enclosing function body.
+        let owner = cx.tcx.hir_enclosing_body_owner(expr.hir_id);
+        let body_id = cx.tcx.hir_body_owned_by(owner);
+        let body = cx.tcx.hir_body(body_id);
+        visitor.visit_body(body);
+
+        if visitor.found && visitor.depth >= 2 {
+            span_lint_and_help(
+                cx,
+                NESTED_LOOP_STORAGE_ACCESS,
+                expr.span,
+                "storage operation inside a nested loop — cost is O(n·m)",
+                None,
+                "this storage access runs on every iteration of both loops, so its cost is \
+                 multiplicative rather than linear; hoist it out of at least one loop or \
+                 accumulate mutations in memory",
+            );
         }
     }
 }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -821,14 +821,13 @@ rustc_session::impl_lint_pass!(NestedLoopStorageAccess => [NESTED_LOOP_STORAGE_A
 /// a closure body inside a loop is still inside the same loop. The visitor
 /// stops at function definitions (`fn`, closures) since a nested function
 /// may be called from anywhere.
-struct LoopDepthVisitor<'a, 'tcx> {
-    cx: &'a LateContext<'tcx>,
+struct LoopDepthVisitor {
     target: HirId,
     depth: u32,
     found: bool,
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for LoopDepthVisitor<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for LoopDepthVisitor {
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
         if self.found {
             return;
@@ -837,7 +836,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LoopDepthVisitor<'a, 'tcx> {
         match expr.kind {
             hir::ExprKind::Loop(body, _, _, _) => {
                 self.depth += 1;
-                self.visit_expr(body);
+                self.visit_block(body);
                 if !self.found {
                     self.depth -= 1;
                 }
@@ -868,16 +867,19 @@ impl<'a, 'tcx> Visitor<'tcx> for LoopDepthVisitor<'a, 'tcx> {
 
 impl<'tcx> LateLintPass<'tcx> for NestedLoopStorageAccess {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
-        let is_storage_access = if let hir::ExprKind::MethodCall(
-            path_segment, receiver, _args, _span,
-        ) = expr.kind
-        {
-            let method_name = path_segment.ident.name.as_str();
-            let is_terminal = matches!(method_name, "get" | "has" | "set" | "remove");
-            is_terminal && is_type_match(cx, cx.typeck_results().expr_ty(receiver), SOROBAN_STORAGE_TYPES)
-        } else {
-            false
-        };
+        let is_storage_access =
+            if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
+                let method_name = path_segment.ident.name.as_str();
+                let is_terminal = matches!(method_name, "get" | "has" | "set" | "remove");
+                is_terminal
+                    && is_type_match(
+                        cx,
+                        cx.typeck_results().expr_ty(receiver),
+                        SOROBAN_STORAGE_TYPES,
+                    )
+            } else {
+                false
+            };
 
         if !is_storage_access {
             return;
@@ -886,7 +888,6 @@ impl<'tcx> LateLintPass<'tcx> for NestedLoopStorageAccess {
         // Walk the HIR tree from the crate root to find the target expression
         // and compute its loop nesting depth.
         let mut visitor = LoopDepthVisitor {
-            cx,
             target: expr.hir_id,
             depth: 0,
             found: false,
@@ -894,8 +895,7 @@ impl<'tcx> LateLintPass<'tcx> for NestedLoopStorageAccess {
 
         // Start walking from the enclosing function body.
         let owner = cx.tcx.hir_enclosing_body_owner(expr.hir_id);
-        let body_id = cx.tcx.hir_body_owned_by(owner);
-        let body = cx.tcx.hir_body(body_id);
+        let body = cx.tcx.hir_body_owned_by(owner);
         visitor.visit_body(body);
 
         if visitor.found && visitor.depth >= 2 {

--- a/soroban_cost_lints/ui/nested_loop_storage_access.rs
+++ b/soroban_cost_lints/ui/nested_loop_storage_access.rs
@@ -1,0 +1,185 @@
+#![allow(
+    soroban_storage_in_loop,
+    loop_invariant_storage_access,
+    storage_write_without_read,
+    persistent_read_without_ttl_extension,
+    instance_storage_for_unbounded_data,
+    unbounded_input_loop,
+)]
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+            pub fn persistent(&self) -> Persistent { Persistent }
+            pub fn temporary(&self) -> Temporary { Temporary }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Persistent;
+        impl Persistent {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Temporary;
+        impl Temporary {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+    }
+}
+
+use soroban_sdk::Env;
+
+// =======================================================================
+// nested_loop_storage_access — Fixtures
+// =======================================================================
+
+// ── Depth 2: should fire ──────────────────────────────────────────────
+
+fn nested_for_for(env: Env) {
+    for i in 0..5 {
+        for j in 0..5 {
+            env.storage().instance().set(&(i + j), &1); // Should Warn (depth 2)
+        }
+    }
+}
+
+fn nested_for_while(env: Env) {
+    for i in 0..5 {
+        let mut j = 0;
+        while j < 5 {
+            let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn (depth 2)
+            j += 1;
+        }
+    }
+}
+
+fn nested_while_for(env: Env) {
+    let mut i = 0;
+    while i < 5 {
+        for j in 0..5 {
+            env.storage().instance().has(&(i + j)); // Should Warn (depth 2)
+        }
+        i += 1;
+    }
+}
+
+fn nested_loop_loop(env: Env) {
+    loop {
+        loop {
+            if env.storage().temporary().has(&1) { // Should Warn (depth 2)
+                break;
+            }
+            break;
+        }
+        break;
+    }
+}
+
+// ── Closure inside loop (depth 1 only — should NOT fire) ──────────────
+
+fn closure_inside_for(env: Env) {
+    let items = vec![1, 2, 3];
+    items.iter().for_each(|x| {
+        env.storage().instance().set(x, &1); // Good — depth 1 (closure doesn't add nesting)
+    });
+}
+
+fn nested_loop_with_closure(env: Env) {
+    for i in 0..5 {
+        let items = vec![1, 2, 3];
+        items.iter().for_each(|x| {
+            env.storage().instance().set(&(i + x), &1); // Good — depth 1 (for_each closure is not a loop)
+        });
+    }
+}
+
+// ── Depth 1: should NOT fire ─────────────────────────────────────────
+
+fn single_for_loop(env: Env) {
+    for i in 0..10 {
+        env.storage().instance().set(&i, &1); // Good — depth 1
+    }
+}
+
+fn single_while_loop(env: Env) {
+    let mut i = 0;
+    while i < 10 {
+        let _: Option<i32> = env.storage().persistent().get(&i); // Good — depth 1
+        i += 1;
+    }
+}
+
+fn single_loop_loop(env: Env) {
+    loop {
+        if env.storage().temporary().has(&1) { // Good — depth 1
+            break;
+        }
+    }
+}
+
+// ── Function definition inside loop (depth should reset) ──────────────
+
+fn nested_function_not_counted(env: Env) {
+    for i in 0..5 {
+        fn inner_func(env: Env, x: i32) {
+            for j in 0..5 {
+                env.storage().instance().set(&(x + j), &1); // Good — inner_func's loops are not nested inside outer
+            }
+        }
+        inner_func(env, i);
+    }
+}
+
+// ── No storage operation: should NOT fire ─────────────────────────────
+
+fn nested_loops_no_storage(env: Env) {
+    for i in 0..5 {
+        for j in 0..5 {
+            let _ = i + j; // Good — no storage operation
+        }
+    }
+}
+
+// ── Storage outside all loops: should NOT fire ────────────────────────
+
+fn storage_outside_loops(env: Env) {
+    for i in 0..5 {
+        for j in 0..5 {
+            let _ = i + j;
+        }
+    }
+    env.storage().instance().set(&1, &1); // Good — outside all loops
+}
+
+#[allow(nested_loop_storage_access)]
+fn allowed_nested(env: Env) {
+    for i in 0..5 {
+        for j in 0..5 {
+            env.storage().instance().set(&(i + j), &1); // Good (allowed)
+        }
+    }
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/nested_loop_storage_access.rs
+++ b/soroban_cost_lints/ui/nested_loop_storage_access.rs
@@ -143,12 +143,12 @@ fn single_loop_loop(env: Env) {
 
 fn nested_function_not_counted(env: Env) {
     for i in 0..5 {
-        fn inner_func(env: Env, x: i32) {
+        fn inner_func(env: &Env, x: i32) {
             for j in 0..5 {
                 env.storage().instance().set(&(x + j), &1); // Good — inner_func's loops are not nested inside outer
             }
         }
-        inner_func(env, i);
+        inner_func(&env, i);
     }
 }
 

--- a/soroban_cost_lints/ui/nested_loop_storage_access.stderr
+++ b/soroban_cost_lints/ui/nested_loop_storage_access.stderr
@@ -1,21 +1,22 @@
 error: storage operation inside a nested loop — cost is O(n·m)
-  --> $DIR/nested_loop_storage_access.rs:48:13
+  --> $DIR/nested_loop_storage_access.rs:63:13
    |
 LL |             env.storage().instance().set(&(i + j), &1); // Should Warn (depth 2)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
+   = note: `#[deny(nested_loop_storage_access)]` on by default
+
+error: storage operation inside a nested loop — cost is O(n·m)
+  --> $DIR/nested_loop_storage_access.rs:72:34
+   |
+LL |             let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn (depth 2)
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
 
 error: storage operation inside a nested loop — cost is O(n·m)
-  --> $DIR/nested_loop_storage_access.rs:55:20
-   |
-LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn (depth 2)
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
-
-error: storage operation inside a nested loop — cost is O(n·m)
-  --> $DIR/nested_loop_storage_access.rs:62:13
+  --> $DIR/nested_loop_storage_access.rs:82:13
    |
 LL |             env.storage().instance().has(&(i + j)); // Should Warn (depth 2)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,12 +24,12 @@ LL |             env.storage().instance().has(&(i + j)); // Should Warn (depth 2
    = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
 
 error: storage operation inside a nested loop — cost is O(n·m)
-  --> $DIR/nested_loop_storage_access.rs:69:13
+  --> $DIR/nested_loop_storage_access.rs:91:16
    |
 LL |             if env.storage().temporary().has(&1) { // Should Warn (depth 2)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
 
-error: aborting due to 4 previous errors; 1 note emitted
+error: aborting due to 4 previous errors
 

--- a/soroban_cost_lints/ui/nested_loop_storage_access.stderr
+++ b/soroban_cost_lints/ui/nested_loop_storage_access.stderr
@@ -1,0 +1,34 @@
+error: storage operation inside a nested loop — cost is O(n·m)
+  --> $DIR/nested_loop_storage_access.rs:48:13
+   |
+LL |             env.storage().instance().set(&(i + j), &1); // Should Warn (depth 2)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
+
+error: storage operation inside a nested loop — cost is O(n·m)
+  --> $DIR/nested_loop_storage_access.rs:55:20
+   |
+LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn (depth 2)
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
+
+error: storage operation inside a nested loop — cost is O(n·m)
+  --> $DIR/nested_loop_storage_access.rs:62:13
+   |
+LL |             env.storage().instance().has(&(i + j)); // Should Warn (depth 2)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
+
+error: storage operation inside a nested loop — cost is O(n·m)
+  --> $DIR/nested_loop_storage_access.rs:69:13
+   |
+LL |             if env.storage().temporary().has(&1) { // Should Warn (depth 2)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: this storage access runs on every iteration of both loops, so its cost is multiplicative rather than linear; hoist it out of at least one loop or accumulate mutations in memory
+
+error: aborting due to 4 previous errors; 1 note emitted
+

--- a/soroban_cost_lints/ui/soroban_storage_in_loop.rs
+++ b/soroban_cost_lints/ui/soroban_storage_in_loop.rs
@@ -68,6 +68,7 @@ fn bad_storage_in_loop_loop(env: Env) {
     }
 }
 
+#[allow(nested_loop_storage_access)]
 fn bad_storage_in_nested_loop(env: Env) {
     for i in 0..5 {
         for _ in 0..5 {

--- a/soroban_cost_lints/ui/soroban_storage_in_loop.stderr
+++ b/soroban_cost_lints/ui/soroban_storage_in_loop.stderr
@@ -99,7 +99,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:74:13
+  --> $DIR/soroban_storage_in_loop.rs:75:13
    |
 LL |             env.storage().instance().has(&i); // Should Warn
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ LL |             env.storage().instance().has(&i); // Should Warn
    = help: if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:74:13
+  --> $DIR/soroban_storage_in_loop.rs:75:13
    |
 LL |             env.storage().instance().has(&i); // Should Warn
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +115,7 @@ LL |             env.storage().instance().has(&i); // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:74:13
+  --> $DIR/soroban_storage_in_loop.rs:75:13
    |
 LL |             env.storage().instance().has(&i); // Should Warn
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,7 +123,7 @@ LL |             env.storage().instance().has(&i); // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:74:13
+  --> $DIR/soroban_storage_in_loop.rs:75:13
    |
 LL |             env.storage().instance().has(&i); // Should Warn
    |             ^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |             env.storage().instance().has(&i); // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: storage write without a corresponding read
-  --> $DIR/soroban_storage_in_loop.rs:80:30
+  --> $DIR/soroban_storage_in_loop.rs:81:30
    |
 LL |     env.storage().instance().set(&1, &1); // Good
    |                              ^^^^^^^^^^^
@@ -139,7 +139,7 @@ LL |     env.storage().instance().set(&1, &1); // Good
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: storage write without a corresponding read
-  --> $DIR/soroban_storage_in_loop.rs:86:30
+  --> $DIR/soroban_storage_in_loop.rs:87:30
    |
 LL |     env.storage().instance().set(&2, &2); // Good
    |                              ^^^^^^^^^^^
@@ -147,7 +147,7 @@ LL |     env.storage().instance().set(&2, &2); // Good
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: persistent storage read without TTL extension — archival cost cliff
-  --> $DIR/soroban_storage_in_loop.rs:85:13
+  --> $DIR/soroban_storage_in_loop.rs:86:13
    |
 LL |     let _ = env.storage().persistent().get::<i32, i32>(&1); // Good
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     let _ = env.storage().persistent().get::<i32, i32>(&1); // Good
    = help: after reading from persistent storage, call extend_ttl on the same key to avoid paying archival cost on subsequent access
 
 warning: storage write without a corresponding read
-  --> $DIR/soroban_storage_in_loop.rs:91:34
+  --> $DIR/soroban_storage_in_loop.rs:92:34
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |                                  ^^^^^^^^^^^
@@ -163,7 +163,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:91:9
+  --> $DIR/soroban_storage_in_loop.rs:92:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -171,7 +171,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage write without a corresponding read
-  --> $DIR/soroban_storage_in_loop.rs:98:34
+  --> $DIR/soroban_storage_in_loop.rs:99:34
    |
 LL |         env.storage().instance().set(x, &1); // Should Warn
    |                                  ^^^^^^^^^^
@@ -179,7 +179,7 @@ LL |         env.storage().instance().set(x, &1); // Should Warn
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:98:9
+  --> $DIR/soroban_storage_in_loop.rs:99:9
    |
 LL |         env.storage().instance().set(x, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -187,7 +187,7 @@ LL |         env.storage().instance().set(x, &1); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage write without a corresponding read
-  --> $DIR/soroban_storage_in_loop.rs:105:34
+  --> $DIR/soroban_storage_in_loop.rs:106:34
    |
 LL |         env.storage().instance().set(x, &acc); // Should Warn
    |                                  ^^^^^^^^^^^^
@@ -195,7 +195,7 @@ LL |         env.storage().instance().set(x, &acc); // Should Warn
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:105:9
+  --> $DIR/soroban_storage_in_loop.rs:106:9
    |
 LL |         env.storage().instance().set(x, &acc); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -203,7 +203,7 @@ LL |         env.storage().instance().set(x, &acc); // Should Warn
    = help: move storage operations out of the loop or accumulate mutations in memory first
 
 warning: storage write without a corresponding read
-  --> $DIR/soroban_storage_in_loop.rs:113:34
+  --> $DIR/soroban_storage_in_loop.rs:114:34
    |
 LL |         env.storage().instance().set(&x, &1); // Good — Option::map calls at most once
    |                                  ^^^^^^^^^^^
@@ -211,7 +211,7 @@ LL |         env.storage().instance().set(&x, &1); // Good — Option::map calls
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: storage write without a corresponding read
-  --> $DIR/soroban_storage_in_loop.rs:120:34
+  --> $DIR/soroban_storage_in_loop.rs:121:34
    |
 LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    |                                  ^^^^^^^^^^^
@@ -219,7 +219,7 @@ LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:120:9
+  --> $DIR/soroban_storage_in_loop.rs:121:9
    |
 LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -227,7 +227,7 @@ LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    = help: hoist this storage operation out of the loop
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/soroban_storage_in_loop.rs:120:9
+  --> $DIR/soroban_storage_in_loop.rs:121:9
    |
 LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    |         ^^^^^^^^^^^^^


### PR DESCRIPTION
Add a deny-level lint that flags storage operations at loop nesting depth >= 2 (O(n·m) cost). The lint uses a LoopDepthVisitor to walk the HIR tree, counting for/while/loop constructs while treating closures as part of the same loop and stopping at function definitions.

🤖 Generated with Codebuff

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- If this PR addresses an existing issue, please link it here. -->
Closes #

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
- [ ] Passed `cargo fmt --all -- --check`
- [ ] Passed `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Passed `cargo test --workspace`
- [ ] _If you added or changed a lint:_ Regenerated UI fixtures with `UPDATE_EXPECT=1 cargo test --workspace` and reviewed every changed `.stderr` file
- [ ] _If you added or changed a lint:_ Regenerated baseline with `BLESS=1 cargo test --test real_world_corpus --workspace`
- [ ] _If you added or changed a lint:_ Added a CHANGELOG.md entry under the `[Unreleased]` section

## Types of changes
<!-- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

Closes #357 
