### PR TITLE
test: add ui fixtures and false-positive notes for symbol and key-construction lints

### DIFF
--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -103,19 +103,31 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = ColorChoice::Auto, value_name = "WHEN")]
     color: ColorChoice,
 
-    #[arg(long, help = "Path to baseline file for suppressing pre-existing findings")]
+    #[arg(
+        long,
+        help = "Path to baseline file for suppressing pre-existing findings"
+    )]
     baseline: Option<String>,
 
-    #[arg(long, help = "Update or create the baseline file with current findings")]
+    #[arg(
+        long,
+        help = "Update or create the baseline file with current findings"
+    )]
     bless: bool,
 
     #[arg(long, help = "Automatically apply machine-applicable suggestions")]
     fix: bool,
 
-    #[arg(long, help = "Allow --fix to run on a dirty working tree with unstaged changes")]
+    #[arg(
+        long,
+        help = "Allow --fix to run on a dirty working tree with unstaged changes"
+    )]
     allow_dirty: bool,
 
-    #[arg(long, help = "Allow --fix to run on a dirty working tree with staged changes")]
+    #[arg(
+        long,
+        help = "Allow --fix to run on a dirty working tree with staged changes"
+    )]
     allow_staged: bool,
 }
 
@@ -236,7 +248,8 @@ fn apply_machine_fixes(fixes: &[MachineFix]) -> Result<(usize, usize), String> {
         return Ok((0, 0));
     }
 
-    let mut file_map: std::collections::HashMap<String, Vec<&MachineFix>> = std::collections::HashMap::new();
+    let mut file_map: std::collections::HashMap<String, Vec<&MachineFix>> =
+        std::collections::HashMap::new();
     for fix in fixes {
         file_map.entry(fix.file_path.clone()).or_default().push(fix);
     }
@@ -1057,27 +1070,64 @@ fn main() {
                                             }
 
                                             // Extract MachineApplicable suggestions
-                                            if let Some(suggs) = child_item.get("suggestions").and_then(|s| s.as_array()) {
+                                            if let Some(suggs) = child_item
+                                                .get("suggestions")
+                                                .and_then(|s| s.as_array())
+                                            {
                                                 for sug in suggs {
-                                                    if sug.get("applicability").and_then(|a| a.as_str()) == Some("MachineApplicable") {
-                                                        if let Some(parts) = sug.get("parts").and_then(|p| p.as_array()) {
+                                                    if sug
+                                                        .get("applicability")
+                                                        .and_then(|a| a.as_str())
+                                                        == Some("MachineApplicable")
+                                                    {
+                                                        if let Some(parts) = sug
+                                                            .get("parts")
+                                                            .and_then(|p| p.as_array())
+                                                        {
                                                             for part in parts {
-                                                                let f = part.get("file_name").and_then(|f| f.as_str()).unwrap_or("");
-                                                                let ls = part.get("line_start").and_then(|l| l.as_u64()).unwrap_or(0) as usize;
-                                                                let cs = part.get("column_start").and_then(|c| c.as_u64()).unwrap_or(0) as usize;
-                                                                let le = part.get("line_end").and_then(|l| l.as_u64()).unwrap_or(0) as usize;
-                                                                let ce = part.get("column_end").and_then(|c| c.as_u64()).unwrap_or(0) as usize;
-                                                                let rep = part.get("snippet").and_then(|s| s.as_str()).unwrap_or("").to_string();
+                                                                let f = part
+                                                                    .get("file_name")
+                                                                    .and_then(|f| f.as_str())
+                                                                    .unwrap_or("");
+                                                                let ls = part
+                                                                    .get("line_start")
+                                                                    .and_then(|l| l.as_u64())
+                                                                    .unwrap_or(0)
+                                                                    as usize;
+                                                                let cs = part
+                                                                    .get("column_start")
+                                                                    .and_then(|c| c.as_u64())
+                                                                    .unwrap_or(0)
+                                                                    as usize;
+                                                                let le = part
+                                                                    .get("line_end")
+                                                                    .and_then(|l| l.as_u64())
+                                                                    .unwrap_or(0)
+                                                                    as usize;
+                                                                let ce = part
+                                                                    .get("column_end")
+                                                                    .and_then(|c| c.as_u64())
+                                                                    .unwrap_or(0)
+                                                                    as usize;
+                                                                let rep = part
+                                                                    .get("snippet")
+                                                                    .and_then(|s| s.as_str())
+                                                                    .unwrap_or("")
+                                                                    .to_string();
                                                                 if !f.is_empty() {
-                                                                    machine_fixes.push(MachineFix {
-                                                                        file_path: f.to_string(),
-                                                                        line_start: ls,
-                                                                        column_start: cs,
-                                                                        line_end: le,
-                                                                        column_end: ce,
-                                                                        replacement: rep,
-                                                                        _lint_name: lint_name.to_string(),
-                                                                    });
+                                                                    machine_fixes.push(
+                                                                        MachineFix {
+                                                                            file_path: f
+                                                                                .to_string(),
+                                                                            line_start: ls,
+                                                                            column_start: cs,
+                                                                            line_end: le,
+                                                                            column_end: ce,
+                                                                            replacement: rep,
+                                                                            _lint_name: lint_name
+                                                                                .to_string(),
+                                                                        },
+                                                                    );
                                                                 }
                                                             }
                                                         }
@@ -1097,7 +1147,11 @@ fn main() {
                                         suggestion: None,
                                     };
 
-                                    let rendered = message.get("rendered").and_then(|r| r.as_str()).unwrap_or("").to_string();
+                                    let rendered = message
+                                        .get("rendered")
+                                        .and_then(|r| r.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
                                     raw_findings.push((finding, rendered));
                                 }
                             }
@@ -1130,13 +1184,18 @@ fn main() {
 
         if let Some(ref b_path_str) = cli.baseline {
             let b_path = PathBuf::from(b_path_str);
-            let mut occ_map: std::collections::HashMap<(String, String, String), usize> = std::collections::HashMap::new();
+            let mut occ_map: std::collections::HashMap<(String, String, String), usize> =
+                std::collections::HashMap::new();
 
             if is_blessing {
                 let mut b_list = Vec::new();
                 for (finding, _) in &raw_findings {
                     let rel_file = normalize_file_path(&finding.file);
-                    let (snippet, context) = extract_finding_context(&finding.file, finding.span.line_start, finding.span.line_end);
+                    let (snippet, context) = extract_finding_context(
+                        &finding.file,
+                        finding.span.line_start,
+                        finding.span.line_end,
+                    );
                     let ctx_hash = compute_context_hash(&finding.name, &rel_file, &context);
                     let key = (finding.name.clone(), rel_file.clone(), ctx_hash.clone());
                     let count = occ_map.entry(key).or_insert(0);
@@ -1150,19 +1209,28 @@ fn main() {
                     });
                 }
                 b_list.sort_by(|a, b| {
-                    a.file.cmp(&b.file)
+                    a.file
+                        .cmp(&b.file)
                         .then_with(|| a.lint_name.cmp(&b.lint_name))
                         .then_with(|| a.code_snippet.cmp(&b.code_snippet))
                         .then_with(|| a.occurrence.cmp(&b.occurrence))
                 });
-                let baseline = Baseline { version: 1, findings: b_list };
-                let json_out = serde_json::to_string_pretty(&baseline).expect("Failed to serialize baseline");
+                let baseline = Baseline {
+                    version: 1,
+                    findings: b_list,
+                };
+                let json_out =
+                    serde_json::to_string_pretty(&baseline).expect("Failed to serialize baseline");
                 if let Err(e) = fs::write(&b_path, json_out) {
                     eprintln!("Error writing baseline file {}: {}", b_path.display(), e);
                     exit(1);
                 }
                 if !quiet {
-                    eprintln!("Baseline saved to {} ({} findings)", b_path.display(), baseline.findings.len());
+                    eprintln!(
+                        "Baseline saved to {} ({} findings)",
+                        b_path.display(),
+                        baseline.findings.len()
+                    );
                 }
                 final_findings = raw_findings;
                 exit_code = 0;
@@ -1170,7 +1238,11 @@ fn main() {
                 let content = match fs::read_to_string(&b_path) {
                     Ok(c) => c,
                     Err(e) => {
-                        eprintln!("Error: Baseline file not found or unreadable {}: {}", b_path.display(), e);
+                        eprintln!(
+                            "Error: Baseline file not found or unreadable {}: {}",
+                            b_path.display(),
+                            e
+                        );
                         exit(1);
                     }
                 };
@@ -1188,7 +1260,11 @@ fn main() {
                 for item in raw_findings {
                     let (ref finding, _) = item;
                     let rel_file = normalize_file_path(&finding.file);
-                    let (_snippet, context) = extract_finding_context(&finding.file, finding.span.line_start, finding.span.line_end);
+                    let (_snippet, context) = extract_finding_context(
+                        &finding.file,
+                        finding.span.line_start,
+                        finding.span.line_end,
+                    );
                     let ctx_hash = compute_context_hash(&finding.name, &rel_file, &context);
                     let key = (finding.name.clone(), rel_file.clone(), ctx_hash.clone());
                     let count = occ_map.entry(key).or_insert(0);
@@ -1216,7 +1292,10 @@ fn main() {
 
                 for (idx, b_item) in baseline.findings.iter().enumerate() {
                     if !matched_base[idx] && !quiet {
-                        eprintln!("Fixed finding (no longer present): {} in {}", b_item.lint_name, b_item.file);
+                        eprintln!(
+                            "Fixed finding (no longer present): {} in {}",
+                            b_item.lint_name, b_item.file
+                        );
                     }
                 }
 
@@ -1224,7 +1303,9 @@ fn main() {
                     eprintln!("Suppressed {} baseline finding(s)", suppressed_count);
                 }
 
-                let has_errors = final_findings.iter().any(|(f, _)| f.level == "error" || f.level == "deny");
+                let has_errors = final_findings
+                    .iter()
+                    .any(|(f, _)| f.level == "error" || f.level == "deny");
                 exit_code = if has_errors { 1 } else { 0 };
             }
         } else {
@@ -1836,11 +1917,7 @@ mod tests {
 
         // 3. Valid file -> Ok(Some(BudgetConfig))
         let valid = dir.join("valid_budget.toml");
-        fs::write(
-            &valid,
-            "[lints]\nsoroban_storage_in_loop = \"deny\"\n",
-        )
-        .unwrap();
+        fs::write(&valid, "[lints]\nsoroban_storage_in_loop = \"deny\"\n").unwrap();
         let res_valid = load_budget_config_lenient(&valid);
         assert!(res_valid.is_ok());
         let cfg = res_valid.unwrap().expect("should parse config");

--- a/cargo-cost-lint/tests/integration.rs
+++ b/cargo-cost-lint/tests/integration.rs
@@ -314,7 +314,7 @@ fn test_list_lints_json_and_text_consistency_and_descriptions() {
         let level = lint["default_level"].as_str().unwrap();
         let desc = lint["description"].as_str().unwrap();
         let cat = lint["category"].as_str().unwrap();
-        let url = lint["documentation_url"].as_str().unwrap();
+        let _url = lint["documentation_url"].as_str().unwrap();
 
         assert!(!name.is_empty(), "Empty name in lint entry");
         assert!(!level.is_empty(), "Empty level in lint entry: {}", name);

--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -147,6 +147,25 @@ Fires on `.clone()` calls on `Env`. `Env` is a lightweight copyable handle.
 Fires when `Symbol::new(&env, "short")` is used with a literal string <= 9 characters.
 
 - **Remedy:** Replace with `symbol_short!("short")` for zero host overhead at runtime.
+- **Boundary:** the fixture pins the length boundary — a literal of exactly 9 characters fires (the maximum accepted by `symbol_short!`), a 10-character literal does not.
+- **Near-miss — invalid characters:** literals containing characters outside `[a-zA-Z0-9_]` (e.g. `-`, spaces) are not flagged, because `symbol_short!` would not accept them either.
+- **Near-miss — non-literal argument:** `Symbol::new(&env, s)` where `s` is a variable is not flagged; the lint only matches string-literal arguments.
+- **Near-miss — empty literal:** `Symbol::new(&env, "")` is not flagged.
+
+### `map_insert_in_loop`
+
+Flags `Map::insert` calls on `soroban_sdk::Map` inside any loop body.
+
+- **Host reallocation cost:** each `insert` mutates a host-side map object, and per-iteration inserts are increasingly expensive as the map grows.
+- **Handling:** accumulate mutations in a native `Vec<(K, V)>` inside the loop and build the `Map` once after the loop, or suppress with `#[allow(map_insert_in_loop)]` when per-iteration insertion is intentional.
+
+### `storage_key_construction_in_loop`
+
+Flags `Symbol::new(&env, ...)` calls inside a loop body whose key does not depend on the loop variable.
+
+- **Genuine finding — loop-invariant key:** `let key = Symbol::new(&env, "my_key");` inside a loop reconstructs the same host object every iteration. Hoist the construction outside the loop.
+- **Near-miss — loop-variant key:** `Symbol::new(&env, &format!("key_{}", i))` inside a loop reads the loop variable `i`, so the lint correctly does not fire — the key genuinely varies per iteration.
+- **Handling:** hoist invariant key construction outside the loop. Suppress with `#[allow(storage_key_construction_in_loop)]` when per-iteration key construction is intentional.
 
 ### `unbounded_recursion`
 

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -1101,7 +1101,8 @@ impl<'tcx> LateLintPass<'tcx> for RedundantEnvClone {
                 return;
             }
 
-            let receiver_snippet = snippet_opt(cx, receiver.span).unwrap_or_else(|| "env".to_string());
+            let receiver_snippet =
+                snippet_opt(cx, receiver.span).unwrap_or_else(|| "env".to_string());
             span_lint_and_sugg(
                 cx,
                 REDUNDANT_ENV_CLONE,

--- a/soroban_cost_lints/ui/map_insert_in_loop.rs
+++ b/soroban_cost_lints/ui/map_insert_in_loop.rs
@@ -1,0 +1,91 @@
+#![allow(bytes_append_in_loop)]
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+        }
+    }
+
+    pub struct Map;
+    impl Map {
+        pub fn new() -> Map { Map }
+        pub fn insert<K, V>(&mut self, _k: K, _v: V) {}
+        pub fn get<K: ?Sized, V>(&self, _k: &K) -> Option<V> { None }
+    }
+}
+
+use soroban_sdk::{Env, Map};
+
+// =======================================================================
+// map_insert_in_loop — Fixtures
+// =======================================================================
+
+// --- Positive (should warn): Map::insert inside a loop ---
+
+fn bad_map_insert_in_for_loop(env: Env) {
+    let mut map = Map::new();
+    for i in 0..10 {
+        map.insert(i, i * 2); // Should Warn
+    }
+    let _ = env;
+}
+
+fn bad_map_insert_in_while_loop(env: Env) {
+    let mut map = Map::new();
+    let mut i = 0;
+    while i < 10 {
+        map.insert(i, i + 1); // Should Warn
+        i += 1;
+    }
+    let _ = env;
+}
+
+fn bad_map_insert_in_loop_loop(env: Env) {
+    let mut map = Map::new();
+    let mut count = 0;
+    loop {
+        map.insert(count, count); // Should Warn
+        count += 1;
+        if count >= 5 {
+            break;
+        }
+    }
+    let _ = env;
+}
+
+// --- Negative (should not warn): Map::insert outside a loop ---
+
+fn good_map_insert_outside_loop(env: Env) {
+    let mut map = Map::new();
+    map.insert(1, 10); // Good — not in a loop
+    map.insert(2, 20); // Good — not in a loop
+    let _ = env;
+}
+
+// --- Suppression test ---
+
+#[allow(map_insert_in_loop)]
+fn allowed_map_insert_in_loop(env: Env) {
+    let mut map = Map::new();
+    for i in 0..10 {
+        map.insert(i, i); // Good (allowed)
+    }
+    let _ = env;
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/map_insert_in_loop.stderr
+++ b/soroban_cost_lints/ui/map_insert_in_loop.stderr
@@ -1,0 +1,27 @@
+warning: Map::insert inside a loop is expensive
+  --> $DIR/map_insert_in_loop.rs:43:9
+   |
+LL |         map.insert(i, i * 2); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: accumulate mutations in memory first and write once after the loop
+   = note: `#[warn(map_insert_in_loop)]` on by default
+
+warning: Map::insert inside a loop is expensive
+  --> $DIR/map_insert_in_loop.rs:52:9
+   |
+LL |         map.insert(i, i + 1); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: accumulate mutations in memory first and write once after the loop
+
+warning: Map::insert inside a loop is expensive
+  --> $DIR/map_insert_in_loop.rs:62:9
+   |
+LL |         map.insert(count, count); // Should Warn
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: accumulate mutations in memory first and write once after the loop
+
+warning: 3 warnings emitted
+

--- a/soroban_cost_lints/ui/storage_key_construction_in_loop.rs
+++ b/soroban_cost_lints/ui/storage_key_construction_in_loop.rs
@@ -1,0 +1,92 @@
+#![allow(symbol_new_for_short_literal, soroban_storage_in_loop, loop_invariant_storage_access, storage_write_without_read)]
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+        }
+    }
+
+    pub struct Symbol;
+    impl Symbol {
+        pub fn new(_env: &Env, _s: &str) -> Symbol { Symbol }
+    }
+}
+
+use soroban_sdk::{Env, Symbol};
+
+// =======================================================================
+// storage_key_construction_in_loop — Fixtures
+// =======================================================================
+
+// --- Positive (should warn): invariant key constructed inside loop ---
+
+fn bad_invariant_key_in_for_loop(env: Env) {
+    for i in 0..10 {
+        let key = Symbol::new(&env, "my_key"); // Should Warn — same key every iteration
+        env.storage().instance().set(&key, &i);
+    }
+}
+
+fn bad_invariant_key_in_while_loop(env: Env) {
+    let mut i = 0;
+    while i < 10 {
+        let key = Symbol::new(&env, "counter"); // Should Warn — same key every iteration
+        env.storage().instance().set(&key, &i);
+        i += 1;
+    }
+}
+
+fn bad_invariant_key_in_loop_loop(env: Env) {
+    let mut count = 0;
+    loop {
+        let key = Symbol::new(&env, "fixed_key"); // Should Warn — same key every iteration
+        env.storage().instance().set(&key, &count);
+        count += 1;
+        if count >= 5 {
+            break;
+        }
+    }
+}
+
+// --- Negative (should not warn): iteration-dependent key ---
+
+fn good_variant_key_in_for_loop(env: Env) {
+    for i in 0..10 {
+        let key = Symbol::new(&env, &format!("key_{}", i)); // Good — key depends on loop variable
+        env.storage().instance().set(&key, &i);
+    }
+}
+
+fn good_key_construction_outside_loop(env: Env) {
+    let key = Symbol::new(&env, "my_key"); // Good — constructed once outside loop
+    for i in 0..10 {
+        env.storage().instance().set(&key, &i);
+    }
+}
+
+// --- Suppression test ---
+
+#[allow(storage_key_construction_in_loop)]
+fn allowed_key_construction_in_loop(env: Env) {
+    for i in 0..10 {
+        let key = Symbol::new(&env, "my_key"); // Good (allowed)
+        env.storage().instance().set(&key, &i);
+    }
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/storage_key_construction_in_loop.rs
+++ b/soroban_cost_lints/ui/storage_key_construction_in_loop.rs
@@ -1,4 +1,4 @@
-#![allow(symbol_new_for_short_literal, soroban_storage_in_loop, loop_invariant_storage_access, storage_write_without_read)]
+#![allow(symbol_new_for_short_literal, soroban_storage_in_loop, loop_invariant_storage_access, storage_write_without_read, formatted_panic_payload)]
 
 pub mod soroban_sdk {
     pub struct Env;

--- a/soroban_cost_lints/ui/storage_key_construction_in_loop.stderr
+++ b/soroban_cost_lints/ui/storage_key_construction_in_loop.stderr
@@ -1,0 +1,27 @@
+warning: storage key constructed inside a loop body
+  --> $DIR/storage_key_construction_in_loop.rs:40:19
+   |
+LL |         let key = Symbol::new(&env, "my_key"); // Should Warn — same key every iteration
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: hoist the key construction outside the loop to avoid repeated host allocations
+   = note: `#[warn(storage_key_construction_in_loop)]` on by default
+
+warning: storage key constructed inside a loop body
+  --> $DIR/storage_key_construction_in_loop.rs:48:19
+   |
+LL |         let key = Symbol::new(&env, "counter"); // Should Warn — same key every iteration
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: hoist the key construction outside the loop to avoid repeated host allocations
+
+warning: storage key constructed inside a loop body
+  --> $DIR/storage_key_construction_in_loop.rs:57:19
+   |
+LL |         let key = Symbol::new(&env, "fixed_key"); // Should Warn — same key every iteration
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: hoist the key construction outside the loop to avoid repeated host allocations
+
+warning: 3 warnings emitted
+

--- a/soroban_cost_lints/ui/symbol_new_for_short_literal.rs
+++ b/soroban_cost_lints/ui/symbol_new_for_short_literal.rs
@@ -1,0 +1,85 @@
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+        }
+    }
+
+    pub struct Symbol;
+    impl Symbol {
+        pub fn new(_env: &Env, _s: &str) -> Symbol { Symbol }
+    }
+}
+
+use soroban_sdk::{Env, Symbol};
+
+// =======================================================================
+// symbol_new_for_short_literal — Fixtures
+// =======================================================================
+
+// --- Positive (should warn): short literal <= 9 chars, valid chars ---
+
+fn bad_symbol_new_short_literal(env: Env) {
+    let _sym = Symbol::new(&env, "hello"); // Should Warn — 5 chars
+}
+
+fn bad_symbol_new_exactly_9_chars(env: Env) {
+    let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn — exactly 9 chars
+}
+
+fn bad_symbol_new_1_char(env: Env) {
+    let _sym = Symbol::new(&env, "x"); // Should Warn — 1 char
+}
+
+fn bad_symbol_new_with_underscore(env: Env) {
+    let _sym = Symbol::new(&env, "hello_wor"); // Should Warn — 9 chars with underscore
+}
+
+// --- Negative (should not warn): boundary and invalid cases ---
+
+fn good_symbol_new_10_chars(env: Env) {
+    let _sym = Symbol::new(&env, "abcdefghij"); // Good — 10 chars > 9
+}
+
+fn good_symbol_new_11_chars(env: Env) {
+    let _sym = Symbol::new(&env, "hello_world"); // Good — 11 chars > 9
+}
+
+fn good_symbol_new_invalid_chars_hyphen(env: Env) {
+    let _sym = Symbol::new(&env, "hello-world"); // Good — contains invalid char '-'
+}
+
+fn good_symbol_new_invalid_chars_space(env: Env) {
+    let _sym = Symbol::new(&env, "hello world"); // Good — contains space
+}
+
+fn good_symbol_new_non_literal(env: Env) {
+    let s = "hello";
+    let _sym = Symbol::new(&env, s); // Good — not a string literal
+}
+
+fn good_symbol_new_empty(env: Env) {
+    let _sym = Symbol::new(&env, ""); // Good — empty string
+}
+
+// --- Suppression test ---
+
+#[allow(symbol_new_for_short_literal)]
+fn allowed_symbol_new_short_literal(env: Env) {
+    let _sym = Symbol::new(&env, "hello"); // Good (allowed)
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/symbol_new_for_short_literal.stderr
+++ b/soroban_cost_lints/ui/symbol_new_for_short_literal.stderr
@@ -10,19 +10,19 @@ warning: Symbol::new called with a short literal that could use symbol_short! ma
   --> $DIR/symbol_new_for_short_literal.rs:40:16
    |
 LL |     let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn — exactly 9 chars
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
   --> $DIR/symbol_new_for_short_literal.rs:44:16
    |
 LL |     let _sym = Symbol::new(&env, "x"); // Should Warn — 1 char
-   |                ^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("x")`
+   |                ^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("x")`
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
   --> $DIR/symbol_new_for_short_literal.rs:48:16
    |
 LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn — 9 chars with underscore
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
 
 warning: 4 warnings emitted
 

--- a/soroban_cost_lints/ui/symbol_new_for_short_literal.stderr
+++ b/soroban_cost_lints/ui/symbol_new_for_short_literal.stderr
@@ -1,0 +1,28 @@
+warning: Symbol::new called with a short literal that could use symbol_short! macro
+  --> $DIR/symbol_new_for_short_literal.rs:36:16
+   |
+LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn — 5 chars
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello")`
+   |
+   = note: `#[warn(symbol_new_for_short_literal)]` on by default
+
+warning: Symbol::new called with a short literal that could use symbol_short! macro
+  --> $DIR/symbol_new_for_short_literal.rs:40:16
+   |
+LL |     let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn — exactly 9 chars
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
+
+warning: Symbol::new called with a short literal that could use symbol_short! macro
+  --> $DIR/symbol_new_for_short_literal.rs:44:16
+   |
+LL |     let _sym = Symbol::new(&env, "x"); // Should Warn — 1 char
+   |                ^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("x")`
+
+warning: Symbol::new called with a short literal that could use symbol_short! macro
+  --> $DIR/symbol_new_for_short_literal.rs:48:16
+   |
+LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn — 9 chars with underscore
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
## Summary
- Add ui fixtures + `.stderr` for `symbol_new_for_short_literal`, `storage_key_construction_in_loop`, `map_insert_in_loop`
- symbol boundary pinned: 9-char literal fires, 10-char does not; every documented false positive gets a fixture case
- storage_key distinguishes loop-invariant key (fires) from loop-variable-derived key (does not)
- Append `map_insert_in_loop` and `storage_key_construction_in_loop` sections, plus boundary/near-miss detail for `symbol_new_for_short_literal`, in `docs/false_positives.md`

## UI test output
`cargo test --workspace` passes on Linux/macOS. On Windows the `ui` snapshot test is `#[cfg(not(target_os = "windows"))]` and is skipped; the `ui_fixtures_match_registered_lints_and_have_no_unknown_lint_warnings` constraint test passes on all platforms.

Closes #345