### PR TITLE
feat(lints): implement excessive_vec_capacity (#349)

### DIFF
--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -454,3 +454,13 @@ Fixtures live in `soroban_cost_lints/ui/linear_scan_in_loop.rs`.
 - **Genuine near-miss 2 — impure argument:** `v.contains(&wrapper.0.clone())` has a method call in the argument, so the lint conservatively treats it as loop-variant and stays silent.
 - **Loop shapes:** `for`, `while`, and iterator-closure all fire for invariant scans; `Option::map` single-call sites are not loops and never fire.
 
+
+### `excessive_vec_capacity`
+
+Fixtures live in `soroban_cost_lints/ui/excessive_vec_capacity.rs`.
+
+- **Firing cases:** `Vec::with_capacity(n)` and `.reserve(n)` where `n` is a hard-coded integer literal exceeding the threshold (4 096 elements) -- the lint fires on both associated function and method-call forms.
+- **Genuine near-miss 1 -- below threshold:** `Vec::with_capacity(100)` / `.reserve(100)` do not fire because the value is within the 4 096-element threshold.
+- **Genuine near-miss 2 -- runtime-derived capacity:** `Vec::with_capacity(n)` / `.reserve(n)` where `n` is a variable or function result are never flagged because the lint cannot determine their value statically.
+- **Genuine near-miss 3 -- at threshold:** `Vec::with_capacity(4096)` does not fire (the threshold is exclusive).
+- **Known false positives:** None at this time. The lint only targets `soroban_sdk::vec::Vec` -- ordinary `std::vec::Vec` usage is never flagged.

--- a/docs/lint_catalog.md
+++ b/docs/lint_catalog.md
@@ -40,5 +40,6 @@ This document provides a concise reference for all lints supported by **soroban-
 | `unbounded_recursion` | warn | unbounded recursion driven by caller-supplied input | [Link](lints/unbounded_recursion.md) |
 | `std_collection_in_contract` | warn | std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec | [Link](lints/std_collection_in_contract.md) |
 | `temporary_storage_for_persistent_data` | warn | temporary storage write followed by an unsafe read that assumes the value persists | [Link](lints/temporary_storage_for_persistent_data.md) |
+| `excessive_vec_capacity` | warn | excessive pre-allocation capacity in Soroban Vec::with_capacity or .reserve | [Link](lints/excessive_vec_capacity.md) |
 
 *Severities can be overridden via `budget.toml`.*

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -50,6 +50,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | [`storage_key_construction_in_loop`](storage_key_construction_in_loop.md) | `warn` | storage key constructed inside a loop body where it could be hoisted |
 | [`vec_where_slice_could_be_used`](vec_where_slice_could_be_used.md) | `warn` | soroban_sdk::Vec passed by value where a native Rust slice would suffice |
 | [`std_collection_in_contract`](std_collection_in_contract.md) | `warn` | std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec |
+| [`excessive_vec_capacity`](excessive_vec_capacity.md) | `warn` | excessive pre-allocation capacity in Soroban Vec::with_capacity or .reserve |
 
 ## Entry Lifecycle
 

--- a/docs/lints/excessive_vec_capacity.md
+++ b/docs/lints/excessive_vec_capacity.md
@@ -1,0 +1,70 @@
+# `excessive_vec_capacity`
+
+**Default Severity:** `warn`
+
+**Target Resource:** [Memory](../cost_rationale.md#2-memory-ram)
+
+## What it does
+
+Detects calls to `soroban_sdk::vec::Vec::with_capacity(n)` and
+`.reserve(n)` where the capacity argument is a hard-coded literal that
+exceeds a defensible threshold (currently **4 096 elements**).
+
+## Why is this bad?
+
+Soroban contracts execute inside a WASM linear-memory sandbox with a
+hard per-transaction memory cap. Each element in a Soroban `Vec` is
+metered individually — pre-allocating far more capacity than the
+collection will actually hold wastes host memory and inflates the
+metered cost of the allocation without providing a meaningful
+performance benefit for typical Soroban workloads.
+
+A capacity of 4 096 elements (roughly 16 KB for4-byte values) is
+generous for known-bound workloads while remaining well within the
+per-transaction memory cap. Values above this threshold are almost
+certainly over-estimated and should be revisited.
+
+## Threshold rationale
+
+The threshold of **4 096 elements** is based on Soroban's metered
+memory model:
+
+1. **Memory is metered per-element.** Each element consumes
+   individually-metered host memory, so unnecessary pre-allocation
+   is not free.
+
+2. **Hard memory cap.** Contracts run in a WASM sandbox with a
+   per-transaction memory limit. Excessive pre-allocation brings
+   the contract closer to this limit for no benefit.
+
+3. **Conservative default.** 4 096 is large enough to cover
+   legitimate use cases (fixed-size buffers, small batch processing)
+   while catching wasteful patterns (pre-allocating 100K+ elements
+   for small datasets).
+
+4. **No performance benefit.** Unlike `std::vec::Vec`, Soroban's
+   Host-backed Vec does not benefit from Rust-side pre-allocation
+   the same way — elements are metered on the host side regardless.
+
+## Example
+
+```rust
+// Bad: wasteful pre-allocation
+let _v = Vec::with_capacity(1_000_000);
+
+// Good: start empty and let growth happen naturally
+let _v = Vec::new();
+
+// Good: runtime-derived capacity is not flagged
+let n = compute_needed_capacity();
+let _v = Vec::with_capacity(n);
+```
+
+## Known limitations
+
+- **Only detects hard-coded literals.** Runtime-derived capacities
+  (variables, function calls, arithmetic expressions) are
+  intentionally ignored because the lint cannot determine their
+  value statically.
+- **Only targets `soroban_sdk::vec::Vec`.** Ordinary host-side
+  `std::vec::Vec` helper code is not flagged.

--- a/docs/lints/lint-registry.json
+++ b/docs/lints/lint-registry.json
@@ -222,5 +222,12 @@
     "description": "temporary storage write followed by an unsafe read that assumes the value persists",
     "docs_path": "docs/lints/temporary_storage_for_persistent_data.md",
     "name": "temporary_storage_for_persistent_data"
+  },
+  {
+    "category": "Memory",
+    "default_level": "warn",
+    "description": "excessive pre-allocation capacity in Soroban Vec::with_capacity or .reserve",
+    "docs_path": "docs/lints/excessive_vec_capacity.md",
+    "name": "excessive_vec_capacity"
   }
 ]

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -646,6 +646,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: TEMPORARY_STORAGE_FOR_PERSISTENT_DATA,
         category: LintCategory::EntryLifecycle,
     },
+    LintMetadata {
+        lint: EXCESSIVE_VEC_CAPACITY,
+        category: LintCategory::Memory,
+    },
 ];
 
 /// `dylint` entry point. Registers every lint declared by this crate with
@@ -690,6 +694,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         UNWRAP_ON_STORAGE_GET,
         STD_COLLECTION_IN_CONTRACT,
         TEMPORARY_STORAGE_FOR_PERSISTENT_DATA,
+        EXCESSIVE_VEC_CAPACITY,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(SorobanRedundantStorageRead));
@@ -722,6 +727,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(UnwrapOnStorageGet));
     lint_store.register_late_pass(|_| Box::new(StdCollectionInContract));
     lint_store.register_late_pass(|_| Box::new(TemporaryStorageForPersistentData));
+    lint_store.register_late_pass(|_| Box::new(ExcessiveVecCapacity));
 
     // `formatted_panic_payload` needs the AST-level `format_args!` nodes to
     // tell a zero-argument `panic!("literal")` apart from a formatted
@@ -3672,7 +3678,120 @@ fn peel_addr_of<'tcx>(mut expr: &'tcx hir::Expr<'tcx>) -> &'tcx hir::Expr<'tcx> 
     }
     expr
 }
+// =======================================================================
+// excessive_vec_capacity — Lint
+// =======================================================================
 
+/// Pre-allocation threshold (in number of elements). Soroban contracts run
+/// inside a WASM linear-memory sandbox with a per-transaction memory cap.
+/// Excessive pre-allocation wastes host memory and inflates the metered cost
+/// of the allocation without providing a meaningful performance benefit for
+/// typical Soroban workloads.
+///
+/// **Rationale for 4 096:** Soroban's Host-backed Vec meters each element
+/// individually. A 4 096-element pre-allocation for a4-byte element type
+/// (e.g. `i32`) reserves roughly 16 KB of linear memory — generous for
+/// known-bound workloads while remaining well within the per-transaction
+/// memory cap. Values above this threshold are almost certainly over-
+/// estimated and should be revisited. Smaller capacities (<=4 096) are
+/// common for fixed-size buffers, lookup tables, and small batch
+/// processing, and are not flagged.
+const EXCESSIVE_VEC_CAPACITY_THRESHOLD: u128 = 4_096;
+
+// Flags Soroban `Vec::with_capacity(n)` and `.reserve(n)` calls where the
+// capacity argument is a hard-coded literal exceeding a defensible threshold.
+//
+// Only `soroban_sdk::vec::Vec` is targeted — ordinary host-side
+// `std::vec::Vec` helper code is not flagged. Runtime-derived capacities
+// (variables, function calls, arithmetic expressions) are intentionally
+// ignored because the lint cannot determine their value statically.
+rustc_session::declare_lint! {
+    pub EXCESSIVE_VEC_CAPACITY,
+    Warn,
+    "excessive pre-allocation capacity in Soroban Vec::with_capacity or .reserve"
+}
+/// Concrete pass that fires [`EXCESSIVE_VEC_CAPACITY`].
+pub struct ExcessiveVecCapacity;
+rustc_session::impl_lint_pass!(ExcessiveVecCapacity => [EXCESSIVE_VEC_CAPACITY]);
+
+impl<'tcx> LateLintPass<'tcx> for ExcessiveVecCapacity {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        match expr.kind {
+            // Vec::with_capacity(n) — static associated function call.
+            hir::ExprKind::Call(callee, args) if !args.is_empty() => {
+                let callee_ty = cx.typeck_results().expr_ty(callee);
+                if let rustc_middle::ty::FnDef(callee_did, _) = callee_ty.kind() {
+                    let method_name_sym = cx.tcx.item_name(*callee_did);
+                    let method_name = method_name_sym.as_str();
+                    if method_name == "with_capacity" {
+                        let callee_path = cached_def_path_str(cx.tcx, *callee_did);
+                        if is_soroban_vec_def_path(&callee_path) && exceeds_threshold(&args[0]) {
+                            span_lint_and_sugg(
+                                cx,
+                                EXCESSIVE_VEC_CAPACITY,
+                                expr.span,
+                                "excessive pre-allocation capacity in Soroban Vec",
+                                "reduce the capacity",
+                                "Vec::new()".to_string(),
+                                Applicability::MaybeIncorrect,
+                            );
+                        }
+                    }
+                }
+            }
+
+            // vec.reserve(n) — instance method call.
+            hir::ExprKind::MethodCall(path_segment, receiver, args, _) if !args.is_empty() => {
+                let method_name = path_segment.ident.name.as_str();
+                if method_name == "reserve" {
+                    let receiver_ty = cx.typeck_results().expr_ty(receiver);
+                    if let rustc_middle::ty::Adt(adt_def, _) = receiver_ty.kind()
+                        && is_soroban_vec_adt(cx, adt_def.did())
+                        && exceeds_threshold(&args[0])
+                    {
+                        span_lint_and_help(
+                            cx,
+                            EXCESSIVE_VEC_CAPACITY,
+                            expr.span,
+                            "excessive pre-allocation capacity in Soroban Vec",
+                            None,
+                            "consider reducing the reserve amount or using Vec::new()",
+                        );
+                    }
+                }
+            }
+
+            _ => {}
+        }
+    }
+}
+
+/// Returns `true` if `callee_path` ends with `soroban_sdk::vec::Vec`.
+fn is_soroban_vec_def_path(callee_path: &str) -> bool {
+    callee_path.contains("soroban_sdk::vec::Vec")
+}
+
+/// Returns `true` if `def_id` belongs to `soroban_sdk::vec::Vec`.
+fn is_soroban_vec_adt<'tcx>(cx: &LateContext<'tcx>, def_id: DefId) -> bool {
+    match_soroban_def_path(cx, def_id, &["soroban_sdk", "vec", "Vec"])
+}
+
+/// Returns `true` if `expr` is a numeric literal whose value exceeds
+/// [`EXCESSIVE_VEC_CAPACITY_THRESHOLD`]. Handles both `LitKind::Int` and
+/// negative literals.
+fn exceeds_threshold<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> bool {
+    match expr.kind {
+        hir::ExprKind::Lit(lit) => match lit.node {
+            LitKind::Int(val, _) => val > EXCESSIVE_VEC_CAPACITY_THRESHOLD,
+            _ => false,
+        },
+        // Handle unary negation: -1_000_000
+        hir::ExprKind::Unary(hir::UnOp::Neg, inner) => matches!(inner.kind,
+            hir::ExprKind::Lit(lit) if matches!(lit.node, LitKind::Int(val, _) if val > EXCESSIVE_VEC_CAPACITY_THRESHOLD)
+        ),
+        _ => false,
+    }
+}
 // on Unix versus `ui\x.rs` on Windows -- so a single set of fixtures cannot
 // satisfy both. This never surfaced before because the Windows job failed at
 // checkout and never reached the test step.

--- a/soroban_cost_lints/ui/excessive_vec_capacity.rs
+++ b/soroban_cost_lints/ui/excessive_vec_capacity.rs
@@ -1,0 +1,52 @@
+// UI test fixture for `excessive_vec_capacity`.
+//
+// Compile with the soroban_cost_lints Dylint library to verify that the
+// lint fires (or does not fire) as expected.
+
+pub mod soroban_sdk {
+    pub mod vec {
+        pub struct Vec;
+        impl Vec {
+            pub fn new() -> Vec { Vec }
+            pub fn with_capacity(_n: u32) -> Vec { Vec }
+            pub fn push_back(&mut self, _v: i32) {}
+            pub fn reserve(&mut self, _additional: u32) {}
+        }
+    }
+}
+
+use soroban_sdk::vec::Vec;
+
+// Should Warn — wildly excessive capacity (above threshold)
+fn bad_with_capacity() {
+    let _v = Vec::with_capacity(1_000_000); //~ ERROR excessive pre-allocation capacity in Soroban Vec
+}
+
+// Should Warn — excessive reserve (above threshold)
+fn bad_reserve() {
+    let mut v = Vec::new();
+    v.reserve(500_000); //~ ERROR excessive pre-allocation capacity in Soroban Vec
+}
+
+// Good — below threshold, no warning
+fn good_small_capacity() {
+    let _v = Vec::with_capacity(100);
+}
+
+// Good — runtime-derived capacity, no warning
+fn good_runtime_capacity(n: u32) {
+    let _v = Vec::with_capacity(n);
+}
+
+// Good — exactly at threshold, no warning
+fn good_exact_threshold() {
+    let _v = Vec::with_capacity(4096);
+}
+
+// Good — runtime-derived reserve, no warning
+fn good_runtime_reserve(n: u32) {
+    let mut v = Vec::new();
+    v.reserve(n);
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/excessive_vec_capacity.stderr
+++ b/soroban_cost_lints/ui/excessive_vec_capacity.stderr
@@ -1,0 +1,18 @@
+warning: excessive pre-allocation capacity in Soroban Vec
+  --> $DIR/excessive_vec_capacity.rs:22:14
+   |
+LL |     let _v = Vec::with_capacity(1_000_000); //~ ERROR excessive pre-allocation capacity in Soroban Vec
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: reduce the capacity: `Vec::new()`
+   |
+   = note: `#[warn(excessive_vec_capacity)]` on by default
+
+warning: excessive pre-allocation capacity in Soroban Vec
+  --> $DIR/excessive_vec_capacity.rs:28:5
+   |
+LL |     v.reserve(500_000); //~ ERROR excessive pre-allocation capacity in Soroban Vec
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider reducing the reserve amount or using Vec::new()
+
+warning: 2 warnings emitted
+

--- a/soroban_cost_lints/ui/main.rs
+++ b/soroban_cost_lints/ui/main.rs
@@ -1,6 +1,6 @@
-// Note: at this point four of the lints referenced in
-// `#[allow(...)]` markers below (`excessive_vec_capacity`,
-// `expensive_crypto_in_loop`, `redundant_storage_read`,
+// Note: at this point three of the lints referenced in
+// `#[allow(...)]` markers below (`expensive_crypto_in_loop`,
+// `redundant_storage_read`,
 // `unnecessary_vec_allocation`) are not yet implemented — they exist as
 // community-proposed follow-ups tracked in GitHub issues #59/#60/#61/#62.
 // The unknown-lint allow forward-suppresses rustc warnings on those markers
@@ -153,6 +153,7 @@ pub mod soroban_sdk {
         pub fn new() -> Vec { Vec }
         pub fn with_capacity(_n: u32) -> Vec { Vec }
         pub fn push_back(&mut self, _v: i32) {}
+        pub fn reserve(&mut self, _additional: u32) {}
     }
 
     // HEAD's permissive Map: `insert<K, V>` is generic so map_insert_in_loop fixtures still work.
@@ -659,9 +660,25 @@ fn allowed_signature_verification_in_loop(env: Env) {
 // Negative (good): request no / little capacity up front and let growth
 // happen naturally, or use Vec::new() for an empty container.
 
-#[allow(excessive_vec_capacity)]
+// Should Warn — wildly excessive capacity
 fn bad_excessive_vec_capacity() {
-    let _v = Vec::with_capacity(1_000_000); // Should Warn — wildly excessive capacity
+    let _v = Vec::with_capacity(1_000_000); // above threshold
+}
+
+// Should Warn — excessive reserve
+fn bad_excessive_reserve() {
+    let mut v = Vec::new();
+    v.reserve(500_000); // above threshold
+}
+
+// Good — below threshold, no warning
+fn good_small_capacity() {
+    let _v = Vec::with_capacity(100); // below threshold
+}
+
+// Good — runtime-derived capacity, no warning
+fn good_runtime_capacity(n: u32) {
+    let _v = Vec::with_capacity(n); // runtime value, ignored
 }
 fn bad_invoke_contract_in_loop_loop(env: Env, addr: soroban_sdk::Address, func: Symbol) {
     loop {

--- a/soroban_cost_lints/ui/main.stderr
+++ b/soroban_cost_lints/ui/main.stderr
@@ -1,5 +1,5 @@
 warning: storage write without a corresponding read
-  --> $DIR/main.rs:204:34
+  --> $DIR/main.rs:205:34
    |
 LL |         env.storage().instance().set(key, val); // Good (allowed) — different key each iteration
    |                                  ^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         env.storage().instance().set(key, val); // Good (allowed) — diffe
    = note: `#[warn(storage_write_without_read)]` on by default
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:204:9
+  --> $DIR/main.rs:205:9
    |
 LL |         env.storage().instance().set(key, val); // Good (allowed) — different key each iteration
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |         env.storage().instance().set(key, val); // Good (allowed) — diffe
    = note: `#[warn(loop_invariant_storage_access)]` on by default
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:204:9
+  --> $DIR/main.rs:205:9
    |
 LL |         env.storage().instance().set(key, val); // Good (allowed) — different key each iteration
    |         ^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |         env.storage().instance().set(key, val); // Good (allowed) — diffe
    = help: hoist this storage operation out of the loop
 
 warning: storage write without a corresponding read
-  --> $DIR/main.rs:213:30
+  --> $DIR/main.rs:214:30
    |
 LL |     env.storage().instance().set(&"key", &42);
    |                              ^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     env.storage().instance().set(&"key", &42);
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: storage write without a corresponding read
-  --> $DIR/main.rs:249:34
+  --> $DIR/main.rs:250:34
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |                                  ^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:249:9
+  --> $DIR/main.rs:250:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = note: `#[warn(soroban_storage_in_loop)]` on by default
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:249:9
+  --> $DIR/main.rs:250:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +58,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:249:9
+  --> $DIR/main.rs:250:9
    |
 LL |         env.storage().instance().set(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL |         env.storage().instance().set(&i, &1); // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: persistent storage read without TTL extension — archival cost cliff
-  --> $DIR/main.rs:256:30
+  --> $DIR/main.rs:257:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = note: `#[warn(persistent_read_without_ttl_extension)]` on by default
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:256:30
+  --> $DIR/main.rs:257:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:256:30
+  --> $DIR/main.rs:257:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -91,7 +91,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: hoist this storage operation out of the loop
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:256:30
+  --> $DIR/main.rs:257:30
    |
 LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should Warn
    |                              ^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL |         let _: Option<i32> = env.storage().persistent().get(&i); // Should 
    = help: hoist this storage operation out of the loop
 
 warning: storage operation inside a loop
-  --> $DIR/main.rs:263:12
+  --> $DIR/main.rs:264:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: if the read is loop-invariant, hoist it out of the loop; otherwise batch where possible
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:263:12
+  --> $DIR/main.rs:264:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +115,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:263:12
+  --> $DIR/main.rs:264:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,7 +123,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:263:12
+  --> $DIR/main.rs:264:12
    |
 LL |         if env.storage().temporary().has(&1) { // Should Warn
    |            ^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |         if env.storage().temporary().has(&1) { // Should Warn
    = help: hoist this storage operation out of the loop
 
 warning: storage write without a corresponding read
-  --> $DIR/main.rs:270:30
+  --> $DIR/main.rs:271:30
    |
 LL |     env.storage().instance().set(&1, &1); // Good
    |                              ^^^^^^^^^^^
@@ -139,7 +139,7 @@ LL |     env.storage().instance().set(&1, &1); // Good
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: storage write without a corresponding read
-  --> $DIR/main.rs:276:34
+  --> $DIR/main.rs:277:34
    |
 LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    |                                  ^^^^^^^^^^^
@@ -147,7 +147,7 @@ LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:276:9
+  --> $DIR/main.rs:277:9
    |
 LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    = help: hoist this storage operation out of the loop
 
 warning: loop-invariant storage operation inside a loop
-  --> $DIR/main.rs:276:9
+  --> $DIR/main.rs:277:9
    |
 LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    |         ^^^^^^^^^^^^^
@@ -163,7 +163,7 @@ LL |         env.storage().instance().set(&i, &1); // Good (allowed)
    = help: hoist this storage operation out of the loop
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:287:19
+  --> $DIR/main.rs:288:19
    |
 LL |     let _cloned = env.clone(); // Should Warn
    |                   ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
@@ -171,7 +171,7 @@ LL |     let _cloned = env.clone(); // Should Warn
    = note: `#[warn(redundant_env_clone)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:330:20
+  --> $DIR/main.rs:331:20
    |
 LL |         let _seq = env.ledger().sequence(); // Should Warn
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -180,7 +180,7 @@ LL |         let _seq = env.ledger().sequence(); // Should Warn
    = note: `#[warn(unnecessary_host_function_call)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:351:21
+  --> $DIR/main.rs:352:21
    |
 LL |         let _hash = env.crypto().sha256(&data); // Should Warn — same input every iteration
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -188,7 +188,7 @@ LL |         let _hash = env.crypto().sha256(&data); // Should Warn — same inp
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:358:21
+  --> $DIR/main.rs:359:21
    |
 LL |         let _hash = env.crypto().sha256(chunk); // Good — hashes a different input each iteration
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -196,7 +196,7 @@ LL |         let _hash = env.crypto().sha256(chunk); // Good — hashes a differ
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:366:21
+  --> $DIR/main.rs:367:21
    |
 LL |         let _hash = env.crypto().keccak256(&data[i..]); // Good — argument moves with the counter
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL |         let _hash = env.crypto().keccak256(&data[i..]); // Good — argumen
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:373:18
+  --> $DIR/main.rs:374:18
    |
 LL |         let _n = env.prng().u64_in_range(0, 100); // Should Warn
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -212,7 +212,7 @@ LL |         let _n = env.prng().u64_in_range(0, 100); // Should Warn
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:379:21
+  --> $DIR/main.rs:380:21
    |
 LL |         let _addr = env.current_contract_address(); // Should Warn
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -220,7 +220,7 @@ LL |         let _addr = env.current_contract_address(); // Should Warn
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:386:20
+  --> $DIR/main.rs:387:20
    |
 LL |         let _seq = env.ledger().sequence(); // Should Warn — called once per closure invocation
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -228,7 +228,7 @@ LL |         let _seq = env.ledger().sequence(); // Should Warn — called once 
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:392:9
+  --> $DIR/main.rs:393:9
    |
 LL |         env.events().publish((i,), i); // Good — publishes the value of this iteration
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -236,7 +236,7 @@ LL |         env.events().publish((i,), i); // Good — publishes the value of t
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:408:16
+  --> $DIR/main.rs:409:16
    |
 LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello")`
@@ -244,19 +244,19 @@ LL |     let _sym = Symbol::new(&env, "hello"); // Should Warn - 5 chars, valid
    = note: `#[warn(symbol_new_for_short_literal)]` on by default
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:412:16
+  --> $DIR/main.rs:413:16
    |
 LL |     let _sym = Symbol::new(&env, "abcdefghi"); // Should Warn - exactly 9 chars
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("abcdefghi")`
 
 warning: Symbol::new called with a short literal that could use symbol_short! macro
-  --> $DIR/main.rs:420:16
+  --> $DIR/main.rs:421:16
    |
 LL |     let _sym = Symbol::new(&env, "hello_wor"); // Should Warn - 9 chars with underscore
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use symbol_short! macro for compile-time symbol creation: `symbol_short!("hello_wor")`
 
 warning: storage write without a corresponding read
-  --> $DIR/main.rs:450:30
+  --> $DIR/main.rs:451:30
    |
 LL |     env.storage().instance().set(&"key1", &1); // Should Warn — no prior read
    |                              ^^^^^^^^^^^^^^^^
@@ -264,7 +264,7 @@ LL |     env.storage().instance().set(&"key1", &1); // Should Warn — no prior 
    = help: consider reading the value before writing or using `.has()` to check existence
 
 warning: inefficient bytes concatenation in a loop
-  --> $DIR/main.rs:475:18
+  --> $DIR/main.rs:476:18
    |
 LL |         result = result + Bytes::from("x"); // Should Warn
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -273,7 +273,7 @@ LL |         result = result + Bytes::from("x"); // Should Warn
    = note: `#[warn(inefficient_bytes_concat)]` on by default
 
 warning: repeatedly growing SDK container inside a loop
-  --> $DIR/main.rs:502:9
+  --> $DIR/main.rs:503:9
    |
 LL |         map.insert(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^
@@ -282,7 +282,7 @@ LL |         map.insert(&i, &1); // Should Warn
    = note: `#[warn(bytes_append_in_loop)]` on by default
 
 warning: Map::insert inside a loop is expensive
-  --> $DIR/main.rs:502:9
+  --> $DIR/main.rs:503:9
    |
 LL |         map.insert(&i, &1); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^
@@ -291,7 +291,7 @@ LL |         map.insert(&i, &1); // Should Warn
    = note: `#[warn(map_insert_in_loop)]` on by default
 
 warning: repeatedly growing SDK container inside a loop
-  --> $DIR/main.rs:518:9
+  --> $DIR/main.rs:519:9
    |
 LL |         map.insert(&i, &1); // Good (allowed)
    |         ^^^^^^^^^^^^^^^^^^
@@ -299,7 +299,7 @@ LL |         map.insert(&i, &1); // Good (allowed)
    = help: accumulate values in native Rust collections first, then batch host operations or convert to SDK containers once after the loop; pre-size where practical
 
 warning: cross-contract call inside a loop
-  --> $DIR/main.rs:528:22
+  --> $DIR/main.rs:529:22
    |
 LL |         let _: i32 = env.invoke_contract(&addr, &func, ()); // Should Warn
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -308,7 +308,7 @@ LL |         let _: i32 = env.invoke_contract(&addr, &func, ()); // Should Warn
    = note: `#[warn(contract_call_in_loop)]` on by default
 
 warning: cross-contract call inside a loop
-  --> $DIR/main.rs:535:22
+  --> $DIR/main.rs:536:22
    |
 LL |         let _: i32 = env.invoke_contract(&addr, &func, ()); // Should Warn
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -316,13 +316,13 @@ LL |         let _: i32 = env.invoke_contract(&addr, &func, ()); // Should Warn
    = help: add a bulk endpoint on the callee contract, or hoist this call out of the loop if its result is invariant across iterations
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:550:30
+  --> $DIR/main.rs:551:30
    |
 LL |     let client = TokenClient(env.clone());
    |                              ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
 
 warning: token transfer inside a loop
-  --> $DIR/main.rs:554:9
+  --> $DIR/main.rs:555:9
    |
 LL |         client.transfer(&from, &to, &100); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -331,13 +331,13 @@ LL |         client.transfer(&from, &to, &100); // Should Warn
    = note: `#[warn(token_transfer_in_loop)]` on by default
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:559:30
+  --> $DIR/main.rs:560:30
    |
 LL |     let client = TokenClient(env.clone());
    |                              ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
 
 warning: token transfer inside a loop
-  --> $DIR/main.rs:564:9
+  --> $DIR/main.rs:565:9
    |
 LL |         client.transfer(&from, &to, &100); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -345,13 +345,13 @@ LL |         client.transfer(&from, &to, &100); // Should Warn
    = help: batch the transfer, or switch to a claim pattern where recipients pull instead of the contract pushing
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:570:30
+  --> $DIR/main.rs:571:30
    |
 LL |     let client = TokenClient(env.clone());
    |                              ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
 
 warning: token transfer inside a loop
-  --> $DIR/main.rs:574:9
+  --> $DIR/main.rs:575:9
    |
 LL |         client.transfer(&from, &to, &100); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -359,13 +359,13 @@ LL |         client.transfer(&from, &to, &100); // Should Warn
    = help: batch the transfer, or switch to a claim pattern where recipients pull instead of the contract pushing
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:580:30
+  --> $DIR/main.rs:581:30
    |
 LL |     let client = TokenClient(env.clone());
    |                              ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
 
 warning: token transfer inside a loop
-  --> $DIR/main.rs:585:9
+  --> $DIR/main.rs:586:9
    |
 LL |         client.transfer_from(&spender, &from, &to, &50); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -373,31 +373,31 @@ LL |         client.transfer_from(&spender, &from, &to, &50); // Should Warn
    = help: batch the transfer, or switch to a claim pattern where recipients pull instead of the contract pushing
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:590:30
+  --> $DIR/main.rs:591:30
    |
 LL |     let client = TokenClient(env.clone());
    |                              ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:599:30
+  --> $DIR/main.rs:600:30
    |
 LL |     let client = TokenClient(env.clone());
    |                              ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:606:30
+  --> $DIR/main.rs:607:30
    |
 LL |     let client = TokenClient(env.clone());
    |                              ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
 
 warning: redundant clone on Env object
-  --> $DIR/main.rs:615:30
+  --> $DIR/main.rs:616:30
    |
 LL |     let client = TokenClient(env.clone());
    |                              ^^^^^^^^^^^ help: pass Env by reference or value instead of cloning: `env`
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:632:9
+  --> $DIR/main.rs:633:9
    |
 LL |         env.crypto().ed25519_verify(&key, &msg, &sig); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -405,7 +405,7 @@ LL |         env.crypto().ed25519_verify(&key, &msg, &sig); // Should Warn
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: signature verification inside a loop
-  --> $DIR/main.rs:632:9
+  --> $DIR/main.rs:633:9
    |
 LL |         env.crypto().ed25519_verify(&key, &msg, &sig); // Should Warn
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -414,7 +414,7 @@ LL |         env.crypto().ed25519_verify(&key, &msg, &sig); // Should Warn
    = note: `#[warn(signature_verification_in_loop)]` on by default
 
 warning: unnecessary host function call inside loop
-  --> $DIR/main.rs:649:9
+  --> $DIR/main.rs:650:9
    |
 LL |         env.crypto().ed25519_verify(&key, &msg, &sig); // Good (allowed)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -422,7 +422,7 @@ LL |         env.crypto().ed25519_verify(&key, &msg, &sig); // Good (allowed)
    = help: cache the result outside the loop when the call is loop-invariant
 
 warning: cross-contract call inside a loop
-  --> $DIR/main.rs:668:22
+  --> $DIR/main.rs:685:22
    |
 LL |         let _: i32 = env.invoke_contract(&addr, &func, ()); // Should Warn
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -430,7 +430,7 @@ LL |         let _: i32 = env.invoke_contract(&addr, &func, ()); // Should Warn
    = help: add a bulk endpoint on the callee contract, or hoist this call out of the loop if its result is invariant across iterations
 
 warning: persistent storage read without TTL extension — archival cost cliff
-  --> $DIR/main.rs:689:29
+  --> $DIR/main.rs:706:29
    |
 LL |     let _val: Option<i32> = env.storage().persistent().get(&1); // Should Warn
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -438,7 +438,7 @@ LL |     let _val: Option<i32> = env.storage().persistent().get(&1); // Should W
    = help: after reading from persistent storage, call extend_ttl on the same key to avoid paying archival cost on subsequent access
 
 warning: persistent storage read without TTL extension — archival cost cliff
-  --> $DIR/main.rs:693:8
+  --> $DIR/main.rs:710:8
    |
 LL |     if env.storage().persistent().has(&1) { // Should Warn
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -446,7 +446,7 @@ LL |     if env.storage().persistent().has(&1) { // Should Warn
    = help: after reading from persistent storage, call extend_ttl on the same key to avoid paying archival cost on subsequent access
 
 warning: redundant storage read: this key was already read without modification
-  --> $DIR/main.rs:722:27
+  --> $DIR/main.rs:739:27
    |
 LL |     let _b: Option<i32> = env.storage().instance().get(&key); // Should Warn
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -455,7 +455,7 @@ LL |     let _b: Option<i32> = env.storage().instance().get(&key); // Should War
    = note: `#[warn(soroban_redundant_storage_read)]` on by default
 
 warning: redundant storage read: this key was already read without modification
-  --> $DIR/main.rs:727:29
+  --> $DIR/main.rs:744:29
    |
 LL |     let _val: Option<i32> = env.storage().instance().get(&key); // Should Warn
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -463,7 +463,7 @@ LL |     let _val: Option<i32> = env.storage().instance().get(&key); // Should W
    = help: store the value from the first read and reuse it instead of reading again
 
 warning: redundant storage read: this key was already read without modification
-  --> $DIR/main.rs:732:14
+  --> $DIR/main.rs:749:14
    |
 LL |     let _b = env.storage().instance().has(&key); // Should Warn
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -471,7 +471,7 @@ LL |     let _b = env.storage().instance().has(&key); // Should Warn
    = help: store the value from the first read and reuse it instead of reading again
 
 warning: persistent storage read without TTL extension — archival cost cliff
-  --> $DIR/main.rs:736:27
+  --> $DIR/main.rs:753:27
    |
 LL |     let _a: Option<i32> = env.storage().persistent().get(&key);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -479,7 +479,7 @@ LL |     let _a: Option<i32> = env.storage().persistent().get(&key);
    = help: after reading from persistent storage, call extend_ttl on the same key to avoid paying archival cost on subsequent access
 
 warning: persistent storage read without TTL extension — archival cost cliff
-  --> $DIR/main.rs:737:27
+  --> $DIR/main.rs:754:27
    |
 LL |     let _b: Option<i32> = env.storage().persistent().get(&key); // Should Warn
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -487,7 +487,7 @@ LL |     let _b: Option<i32> = env.storage().persistent().get(&key); // Should W
    = help: after reading from persistent storage, call extend_ttl on the same key to avoid paying archival cost on subsequent access
 
 warning: redundant storage read: this key was already read without modification
-  --> $DIR/main.rs:737:27
+  --> $DIR/main.rs:754:27
    |
 LL |     let _b: Option<i32> = env.storage().persistent().get(&key); // Should Warn
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -495,7 +495,7 @@ LL |     let _b: Option<i32> = env.storage().persistent().get(&key); // Should W
    = help: store the value from the first read and reuse it instead of reading again
 
 warning: redundant storage read: this key was already read without modification
-  --> $DIR/main.rs:742:27
+  --> $DIR/main.rs:759:27
    |
 LL |     let _b: Option<i32> = env.storage().temporary().get(&key); // Should Warn
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Summary

Implements the excessive_vec_capacity lint from issue #349.

Changes

* Detects excessively large hard-coded capacities in Vec::with_capacity and Vec::reserve.
* Uses a 4,096-element threshold.
* Adds UI tests covering valid and invalid cases.
* Adds the lint to the appropriate lint registration and documentation.

Validation

* cargo fmt --check
* cargo clippy --workspace --all-targets --all-features -- -D warnings
* Relevant UI tests pass.

Closes #349.