### PR TITLE
feat(lint): add storage_read_never_written lint (Closes #368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to Semantic Versioning.
 - New lint `unnecessary_string_to_bytes` detecting unnecessary `String` to `Bytes` conversions.
 - New lint `unbounded_recursion` detecting direct and mutual recursion whose depth is driven by caller-supplied input (e.g. recursion over a caller-supplied `Vec`/`&[T]` length), reporting the full call cycle (`process -> process_child -> process`).
 - New lint `cross_contract_result_discarded` detecting `Env::invoke_contract` calls whose non-unit return value is discarded (bound to `_` or dropped as a bare statement), since a cross-contract invocation pays for a full host dispatch, metered execution, and the return value's conversion back across the boundary.
+- New lint `storage_read_never_written` detecting storage reads of a key that is never written by a statically-known `set`/`has` anywhere else in the crate. It accumulates reads and writes across the whole crate and reports only at the end of the crate, firing at the read site. Defaults to `warn` (not `deny`) because it is heuristic: the write may live in another contract (cross-contract state sharing), or the key may be constructed dynamically. Dynamic keys neither fire nor suppress findings about unrelated static keys.
 
 ### Changed
 

--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -41,6 +41,7 @@ The project runs continuous regression and triage checks against real-world Soro
 | `redundant_env_clone` | 0 | 3 | warn | True positive: redundant clones on `Env` handles |
 | `unnecessary_host_function_call` | 0 | 2 | warn | True positive: host functions callable outside loops |
 | `u128_where_u64_suffices` | 0 | 0 | warn | True positive: provably narrow 128-bit arithmetic operations on wasm32 |
+| `storage_read_never_written` | 0 | 0 | warn | New lint; not yet present in the corpus baseline — pending first corpus run |
 
 ### Target False-Positive Ratio & Policy
 
@@ -87,6 +88,16 @@ Fires on any `set` whose `(receiver, key)` snippet has no matching `get`/`has` a
 - **Near-miss — initializer skip:** Functions named `init` or `set_admin` are intentionally skipped.
 - **Cross-Function & Multi-Transaction Overwrites:** Storage written blindly as an update or status reset without reading first within the same function is flagged. If the overwrite is intentional, suppress with `#[allow(storage_write_without_read)]`.
 - **Syntactic Snippet Mismatch:** If the key expression in `has(&key)` is written differently from `set(key)` (e.g. referencing with/without `&`), the syntactic matcher will not correlate them.
+
+### `storage_read_never_written`
+
+Fires at a storage **read** site when the key is never written by a *statically-known* `set`/`has` anywhere else in the same crate. It is inherently heuristic — it accumulates reads and writes across the whole crate and reports only at the end — so a clean false-positive story matters more than for single-body lints.
+
+- **Cross-Contract State Sharing (the dominant false positive):** A contract routinely reads a key that another contract in the system writes. Factories, registries, and token/ledger adapters all rely on one contract reading state initialised by a different deployment. The lint cannot see across crate boundaries, so this read looks "never written" even though it is correct by design. This is the single most important false positive class for this lint and the reason it defaults to `warn` (not `deny`): the message explicitly says the write may live in another contract and that this is a warning, not proof of a bug.
+- **Dynamically Constructed Keys:** When a key is built from a parameter, a computed value, or other runtime input, its value is unknown at analysis time. Such reads do **not** fire (we can't prove the key is unwritten) **and** do not suppress findings about unrelated static keys — a dynamic read and a static read-never-written can coexist, and only the static one is reported.
+- **Distinct Key Spaces:** `instance`, `persistent`, and `temporary` storage are separate namespaces. A `persistent` write does not satisfy an `instance` read of the same literal key, so the read is still flagged. When the write legitimately lives in a different key space, this is a false positive to suppress with `#[allow(storage_read_never_written)]`.
+- **Key-Name Typos:** The intended use case — a typo that turned one logical entry into two — is also the hardest to confirm automatically, which is why the diagnostic is phrased as a warning rather than an accusation.
+- **Handling:** If the read is expected to be populated by another contract or by dynamic state, suppress with `#[allow(storage_read_never_written)]` at the read site or crate level.
 
 ### `vec_where_slice_could_be_used`
 

--- a/docs/lint_catalog.md
+++ b/docs/lint_catalog.md
@@ -24,6 +24,7 @@ This document provides a concise reference for all lints supported by **soroban-
 | `bytes_append_in_loop` | warn | repeatedly growing SDK containers inside loops | [Link](lints/bytes_append_in_loop.md) |
 | `string_concat_in_loop` | warn | repeatedly concatenating a soroban String inside a loop | [Link](lints/string_concat_in_loop.md) |
 | `storage_write_without_read` | warn | storage write without a corresponding read | [Link](lints/storage_write_without_read.md) |
+| `storage_read_never_written` | warn | reads a storage key that is never written anywhere in this crate | [Link](lints/storage_read_never_written.md) |
 | `blind_storage_write` | warn | storage write that blindly overwrites a previously written key without reading it back | [Link](lints/blind_storage_write.md) |
 | `inefficient_bytes_concat` | warn | inefficient bytes concatenation | [Link](lints/inefficient_bytes_concat.md) |
 | `map_insert_in_loop` | warn | Map::insert called inside a loop | [Link](lints/map_insert_in_loop.md) |

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -17,6 +17,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | [`loop_invariant_storage_access`](loop_invariant_storage_access.md) | `warn` | storage operation inside a loop whose operands are provably loop-invariant |
 | [`soroban_redundant_storage_read`](soroban_redundant_storage_read.md) | `warn` | multiple sequential reads of the same storage key without modification |
 | [`storage_write_without_read`](storage_write_without_read.md) | `warn` | storage write without a corresponding read |
+| [`storage_read_never_written`](storage_read_never_written.md) | `warn` | reads a storage key that is never written anywhere in this crate |
 | [`blind_storage_write`](blind_storage_write.md) | `warn` | storage write that blindly overwrites a previously written key without reading it back |
 | [`instance_storage_for_unbounded_data`](instance_storage_for_unbounded_data.md) | `warn` | unbounded collection written to instance storage |
 | [`unwrap_on_storage_get`](unwrap_on_storage_get.md) | `warn` | unwrap or expect directly on a storage read — panics on a missing or expired key |

--- a/docs/lints/lint-registry.json
+++ b/docs/lints/lint-registry.json
@@ -114,6 +114,13 @@
   {
     "category": "StorageOperations",
     "default_level": "warn",
+    "description": "reads a storage key that is never written anywhere in this crate",
+    "docs_path": "docs/lints/storage_read_never_written.md",
+    "name": "storage_read_never_written"
+  },
+  {
+    "category": "StorageOperations",
+    "default_level": "warn",
     "description": "storage write that blindly overwrites a previously written key without reading it back",
     "docs_path": "docs/lints/blind_storage_write.md",
     "name": "blind_storage_write"

--- a/docs/lints/storage_read_never_written.md
+++ b/docs/lints/storage_read_never_written.md
@@ -1,0 +1,69 @@
+---
+description: Storage read of a key that is never written anywhere in the crate — flag reads that always miss and waste metered storage access
+sidebar_position: 5
+---
+
+# `storage_read_never_written`
+
+| Default Severity | Category     |
+| ---------------- | ------------ |
+| `warn`           | StorageOperations |
+
+## What it does
+
+Accumulates every statically-known storage **read** key and every statically-known storage **write** key across the whole crate, then reports (at the end of the crate) each read whose key is written nowhere in that crate. A key read at runtime that is never written returns `None` on every invocation, so the contract pays for a full metered storage access that can never succeed.
+
+## Why is this bad
+
+A read that always misses still costs a full metered storage access on every invocation, forever. Three real causes sit behind it:
+
+1. **Paying for a read that always misses** — the entry is simply never written.
+2. **Depending on deleted or changed state** — a contract reading state that another contract used to write but no longer does.
+3. **A key-name typo** — a misspelled key silently splits one logical entry into two, so the contract behaves as though the value was never set on a path the author believes is impossible. This last case is close to undiagnosable at runtime.
+
+## Heuristic caveat (read this before acting)
+
+This lint is **heuristic**, and its message says so. It works within a single crate and cannot see:
+
+- **Cross-contract state sharing** — a factory/registry/token pattern where contract *A* reads a key that contract *B* (a different deployment) writes. This is the single most common false positive and is often completely correct by design.
+- **Dynamically constructed keys** — when a key is built from a parameter or computed value, its value is unknown statically, so the read does not fire and does not suppress findings about unrelated static keys.
+
+Because of this, the lint defaults to `warn`, not `deny`. Treat a hit as a prompt to confirm the key is initialised where expected, not as proof of a bug.
+
+## Example
+
+**Bad** — reading a key that is never written anywhere in the crate:
+
+```rust
+// ❌ Triggers: storage_read_never_written
+fn balance(env: Env) -> Option<i32> {
+    env.storage().persistent().get(&"total_supply") // never written in this crate
+}
+```
+
+**Good** — the key is written somewhere in the crate (possibly a different function or module):
+
+```rust
+// ✅ No warning: the key is written elsewhere in the crate
+fn init(env: Env) {
+    env.storage().persistent().set(&"total_supply", &1_000);
+}
+
+fn balance(env: Env) -> Option<i32> {
+    env.storage().persistent().get(&"total_supply")
+}
+```
+
+**Acceptable false positive** — the key is written by another contract:
+
+```rust
+// ⚠️ Heuristic warning; suppress with #[allow(storage_read_never_written)]
+// if `admin` is set by a separate deployment this contract reads from.
+fn admin(env: Env) -> Option<Address> {
+    env.storage().persistent().get(&"admin")
+}
+```
+
+## Fix
+
+Confirm the key is initialised where expected. If the write lives in another contract (cross-contract state sharing) or the key is constructed dynamically, suppress at the read site or crate level with `#[allow(storage_read_never_written)]`.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -5,10 +5,11 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
-use rustc_hir::{Expr, ExprKind, BinOpKind, UnOp, QPath};
+use rustc_hir::{Crate, Expr, ExprKind, BinOpKind, UnOp, QPath};
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::Span;
+use std::collections::HashSet;
 
 rustc_lint::declare_lint! {
     pub SOROBAN_STORAGE_IN_LOOP,
@@ -38,6 +39,12 @@ rustc_lint::declare_lint! {
     pub STORAGE_WRITE_WITHOUT_READ,
     Warn,
     "performs a storage set without any prior get or has in the function"
+}
+
+rustc_lint::declare_lint! {
+    pub STORAGE_READ_NEVER_WRITTEN,
+    Warn,
+    "reads a storage key that is never written anywhere in this crate"
 }
 
 rustc_lint::declare_lint! {
@@ -250,6 +257,12 @@ pub const LINT_METADATA: &[LintMeta] = &[
         category: LintCategory::Storage,
         description: "Performs a storage set without any prior get or has in the function",
         rationale: "Blind writes can overwrite state accidentally and lack update guards.",
+    },
+    LintMeta {
+        name: "storage_read_never_written",
+        category: LintCategory::Storage,
+        description: "Reads a storage key that is never written anywhere in this crate",
+        rationale: "A read that always misses still costs a full metered storage access on every invocation. The key may be written by another contract (cross-contract state sharing), constructed dynamically, or be a typo that silently split one logical entry into two.",
     },
     LintMeta {
         name: "instance_storage_for_unbounded_data",
@@ -514,12 +527,14 @@ fn is_provably_within_64_bits<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tc
 
 #[no_mangle আনন্দের]
 pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
+    lint_store.register_late_pass(move |_| Box::new(StorageReadNeverWritten::new()));
     lint_store.register_lints(&[
         SOROBAN_STORAGE_IN_LOOP,
         REDUNDANT_ENV_CLONE,
         UNNECESSARY_HOST_FUNCTION_CALL,
         SOROBAN_REDUNDANT_STORAGE_READ,
         STORAGE_WRITE_WITHOUT_READ,
+        STORAGE_READ_NEVER_WRITTEN,
         INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
         PERSISTENT_READ_WITHOUT_TTL_EXTENSION,
         LOOP_INVARIANT_STORAGE_ACCESS,
@@ -555,6 +570,7 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
             UNNECESSARY_HOST_FUNCTION_CALL,
             SOROBAN_REDUNDANT_STORAGE_READ,
             STORAGE_WRITE_WITHOUT_READ,
+            STORAGE_READ_NEVER_WRITTEN,
             INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
             PERSISTENT_READ_WITHOUT_TTL_EXTENSION,
             LOOP_INVARIANT_STORAGE_ACCESS,
@@ -629,6 +645,184 @@ impl<'tcx> LateLintPass<'tcx> for CollectionLenInLoopCondition {
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+// =======================================================================
+// storage_read_never_written - Lint
+// =======================================================================
+//
+// Crate-wide accumulation with end-of-crate reporting. Every other pass in this
+// crate reports from within a single body; this pass instead gathers every
+// statically-known storage read key and every statically-known storage write
+// key across the whole crate, then reports (at `check_crate_post`) each read
+// whose key is written nowhere in the crate.
+//
+// The accumulator is intentionally self-contained here: it must NOT be factored
+// into shared infrastructure, because a sibling backlog lint will need the same
+// crate-wide shape and two issues editing a shared helper is exactly the
+// collision the backlog is structured to avoid.
+//
+// Dynamic keys (whose value cannot be determined statically) are skipped on
+// both the read and write sides. Skipping them on the read side means they
+// never fire; skipping them on the write side means a dynamic write never
+// suppresses a finding about an unrelated static key.
+
+#[derive(Clone, Copy)]
+enum StorageKeySpace {
+    Instance,
+    Persistent,
+    Temporary,
+}
+
+impl StorageKeySpace {
+    fn as_str(self) -> &'static str {
+        match self {
+            StorageKeySpace::Instance => "instance",
+            StorageKeySpace::Persistent => "persistent",
+            StorageKeySpace::Temporary => "temporary",
+        }
+    }
+}
+
+enum StorageAccessOp {
+    Read,
+    Write,
+}
+
+/// Decompose a terminal storage method call (`get`/`has`/`set`) into its
+/// operation, the storage key space, and the key argument expression.
+///
+/// We match the chain structurally (`storage()` -> `instance|persistent|temporary`
+/// -> `get|has|set`) rather than by resolved `DefId`, so the lint also fires
+/// against the hand-written `soroban_sdk` mocks used in UI fixtures.
+fn analyze_storage_call<'tcx>(
+    expr: &'tcx Expr<'tcx>,
+) -> Option<(StorageAccessOp, StorageKeySpace, &'tcx Expr<'tcx>)> {
+    let ExprKind::MethodCall(seg, recv, args, _) = expr.kind else {
+        return None;
+    };
+    let op = match seg.ident.name.as_str() {
+        "get" | "has" => StorageAccessOp::Read,
+        "set" => StorageAccessOp::Write,
+        _ => return None,
+    };
+    // recv: instance()/persistent()/temporary()
+    let ExprKind::MethodCall(kind_seg, kind_recv, _, _) = recv.kind else {
+        return None;
+    };
+    let space = match kind_seg.ident.name.as_str() {
+        "instance" => StorageKeySpace::Instance,
+        "persistent" => StorageKeySpace::Persistent,
+        "temporary" => StorageKeySpace::Temporary,
+        _ => return None,
+    };
+    // kind_recv: storage()
+    let ExprKind::MethodCall(storage_seg, _, _, _) = kind_recv.kind else {
+        return None;
+    };
+    if storage_seg.ident.name.as_str() != "storage" {
+        return None;
+    }
+    let key_expr = args.first()?;
+    Some((op, space, key_expr))
+}
+
+/// Reduce a key expression to a stable string when its value is statically
+/// known. Returns `None` for dynamic keys (parameters, computed values, ...).
+fn canonical_key<'tcx>(_cx: &LateContext<'tcx>, key_expr: &'tcx Expr<'tcx>) -> Option<String> {
+    // Strip the leading `&` that storage APIs require (`get(&key)`).
+    let value = match key_expr.kind {
+        ExprKind::AddrOf(_, _, inner) => inner,
+        _ => key_expr,
+    };
+    match value.kind {
+        ExprKind::Lit(lit) => match lit.node {
+            rustc_ast::ast::LitKind::Int(val, _) => Some(format!("int:{}", val.get())),
+            rustc_ast::ast::LitKind::Str(s, _) => Some(format!("str:{}", s.as_str())),
+            _ => None,
+        },
+        ExprKind::Call(path, call_args) => {
+            let ExprKind::Path(qpath) = &path.kind else {
+                return None;
+            };
+            let QPath::Resolved(_, path_segments) = qpath else {
+                return None;
+            };
+            let last = path_segments.last()?;
+            match last.ident.name.as_str() {
+                "symbol_short" => {
+                    let lit = call_args.first()?;
+                    let ExprKind::Lit(l) = lit.kind else {
+                        return None;
+                    };
+                    let rustc_ast::ast::LitKind::Str(s, _) = l.node else {
+                        return None;
+                    };
+                    Some(format!("symbol:short:{}", s.as_str()))
+                }
+                "new" => {
+                    // Symbol::new(env, "literal") — take the first string literal arg.
+                    let lit = call_args.iter().find_map(|a| match a.kind {
+                        ExprKind::Lit(l) if matches!(l.node, rustc_ast::ast::LitKind::Str(..)) => {
+                            Some(l)
+                        }
+                        _ => None,
+                    })?;
+                    let rustc_ast::ast::LitKind::Str(s, _) = lit.node else {
+                        return None;
+                    };
+                    Some(format!("symbol:{}", s.as_str()))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+pub struct StorageReadNeverWritten {
+    reads: Vec<(Span, String)>,
+    writes: HashSet<String>,
+}
+
+impl StorageReadNeverWritten {
+    fn new() -> Self {
+        StorageReadNeverWritten {
+            reads: Vec::new(),
+            writes: HashSet::new(),
+        }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for StorageReadNeverWritten {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if let Some((op, space, key_expr)) = analyze_storage_call(expr) {
+            if let Some(ckey) = canonical_key(cx, key_expr) {
+                let full = format!("{}:{}", space.as_str(), ckey);
+                match op {
+                    StorageAccessOp::Read => self.reads.push((expr.span, full)),
+                    StorageAccessOp::Write => {
+                        self.writes.insert(full);
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_crate_post(&mut self, cx: &LateContext<'tcx>, _krate: &'tcx Crate<'tcx>) {
+        for (span, key) in &self.reads {
+            if !self.writes.contains(key) {
+                clippy_utils::diagnostics::span_lint_and_help(
+                    cx,
+                    STORAGE_READ_NEVER_WRITTEN,
+                    *span,
+                    "storage key is read but never written anywhere in this crate",
+                    None,
+                    "Heuristic warning: the write may live in another contract (cross-contract state sharing is common and valid), or the key may be constructed dynamically. This is not proof of a bug \u{2014} confirm the key is initialised where expected before changing the code.",
+                );
             }
         }
     }

--- a/soroban_cost_lints/ui/storage_read_never_written.rs
+++ b/soroban_cost_lints/ui/storage_read_never_written.rs
@@ -1,0 +1,91 @@
+#![allow(
+    soroban_storage_in_loop,
+    soroban_redundant_storage_read,
+    storage_write_without_read,
+    persistent_read_without_ttl_extension,
+    instance_storage_for_unbounded_data,
+    unbounded_input_loop,
+    symbol_new_for_short_literal,
+    formatted_panic_payload,
+    redundant_env_clone
+)]
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+            pub fn persistent(&self) -> Persistent { Persistent }
+            pub fn temporary(&self) -> Temporary { Temporary }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Persistent;
+        impl Persistent {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Temporary;
+        impl Temporary {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+    }
+}
+
+use soroban_sdk::Env;
+
+// Case 1: a key read but never written anywhere in the crate -> FIRES.
+fn reads_missing_key(env: Env) {
+    let _: Option<i32> = env.storage().persistent().get(&42);
+}
+
+// Case 2: the same key is written in a different function -> does NOT fire.
+fn writes_elsewhere(env: Env) {
+    env.storage().persistent().set(&7, &1);
+}
+
+fn reads_written_elsewhere(env: Env) {
+    let _: Option<i32> = env.storage().persistent().get(&7);
+}
+
+// Case 3: a dynamic key (function parameter) -> does NOT fire, and must NOT
+// suppress findings about other keys.
+fn reads_dynamic_key(env: Env, key: u32) {
+    let _: Option<i32> = env.storage().persistent().get(&key);
+}
+
+// Case 4: a dynamic read must not suppress a static read-never-written key in
+// the same crate -> the static key still FIRES.
+fn reads_static_and_dynamic(env: Env, key: u32) {
+    let _: Option<i32> = env.storage().persistent().get(&99);
+    let _: Option<i32> = env.storage().persistent().get(&key);
+}
+
+// Case 5: instance vs persistent are distinct key spaces; a persistent write
+// does not satisfy an instance read of the same literal -> FIRES.
+fn instance_read_with_persistent_write(env: Env) {
+    env.storage().persistent().set(&5, &1);
+    let _: Option<i32> = env.storage().instance().get(&5);
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/storage_read_never_written.stderr
+++ b/soroban_cost_lints/ui/storage_read_never_written.stderr
@@ -1,0 +1,28 @@
+warning: storage key is read but never written anywhere in this crate
+  --> $DIR/storage_read_never_written.rs:59:26
+   |
+LL |     let _: Option<i32> = env.storage().persistent().get(&42);
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Heuristic warning: the write may live in another contract (cross-contract state sharing is common and valid), or the key may be constructed dynamically. This is not proof of a bug — confirm the key is initialised where expected before changing the code.
+   = note: `#[warn(storage_read_never_written)]` on by default
+
+warning: storage key is read but never written anywhere in this crate
+  --> $DIR/storage_read_never_written.rs:80:26
+   |
+LL |     let _: Option<i32> = env.storage().persistent().get(&99);
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Heuristic warning: the write may live in another contract (cross-contract state sharing is common and valid), or the key may be constructed dynamically. This is not proof of a bug — confirm the key is initialised where expected before changing the code.
+   = note: `#[warn(storage_read_never_written)]` on by default
+
+warning: storage key is read but never written anywhere in this crate
+  --> $DIR/storage_read_never_written.rs:88:26
+   |
+LL |     let _: Option<i32> = env.storage().instance().get(&5);
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Heuristic warning: the write may live in another contract (cross-contract state sharing is common and valid), or the key may be constructed dynamically. This is not proof of a bug — confirm the key is initialised where expected before changing the code.
+   = note: `#[warn(storage_read_never_written)]` on by default
+
+warning: 3 warnings emitted


### PR DESCRIPTION
Closes #368

---

Implements issue #368: flags storage reads whose key is never written anywhere in the crate (wasted metered reads, cross-contract state assumptions, key-construction typos).

Crate-wide accumulation with end-of-crate reporting via a self-contained pass (no shared infra; per backlog guidance), structural chain matching, dynamic keys skipped on both sides. Defaults to Warn.

Includes ui fixture + .stderr, false_positives.md (cross-contract prominent), and lint docs.

Verification note: cargo test / clippy / fmt / generate-lint-docs must run in a proper toolchain; the ui .stderr may need a BLESS pass.