### PR TITLE
Fix: fix: replace the panic when cargo-dylint is missing with a real error (Auto-Generated)

### DIFF
--- a/cargo-cost-lint/src/error.rs
+++ b/cargo-cost-lint/src/error.rs
@@ -7,10 +7,6 @@ use std::io;
 /// error handling is consistent and caller-friendly instead of mixing `unwrap`,
 /// `expect`, `exit`, and ad‑hoc `eprintln!` calls.
 #[derive(Debug)]
-// `Subprocess` and `MissingPrerequisite` are part of the consolidated error
-// surface (#299/#281) but nothing raises them yet.
-// Kept: part of a consolidated error surface but currently unraised
-#[allow(dead_code)]
 pub enum LinterError {
     /// An I/O error — file read/write, pipe capture, etc.
     Io(io::Error),

--- a/cargo-cost-lint/src/main.rs
+++ b/cargo-cost-lint/src/main.rs
@@ -133,19 +133,18 @@ fn invoke_dylint(args: &[String]) -> LinterResult<Vec<LintFinding>> {
     // Forward user args
     cmd.args(args);
 
-    let output = cmd.output().map_err(|e| {
-        LinterError::Other(format!(
-            "Failed to execute cargo dylint. Ensure cargo-dylint is installed: {}",
-            e
-        ))
-    });
-
-    let output = match output {
+    let output = match cmd.output() {
         Ok(o) => o,
         Err(e) => {
-            // If cargo dylint is not installed or fails to launch in certain test contexts, return empty or error.
-            // But during cargo test, integration tests invoke the binary with proper environment.
-            return Err(e);
+            if e.kind() == io::ErrorKind::NotFound {
+                return Err(LinterError::MissingPrerequisite(
+                    "error: `cargo-dylint` is not installed.
+To install it, run:
+    cargo install cargo-dylint dylint-link --version \"^6.0.1\""
+                        .to_string(),
+                ));
+            }
+            return Err(LinterError::Io(e));
         }
     };
 
@@ -192,8 +191,8 @@ fn parse_dylint_output(output: &str) -> Vec<LintFinding> {
                                 span: output_formatters::Span {
                                     line_start,
                                     line_end,
-                                    column_start,
-                                    column_end,
+                                    column_start: col_start,
+                                    column_end: col_end,
                                 },
                                 message,
                                 help: None,


### PR DESCRIPTION
Closes #418

This pull request was generated automatically and scoped strictly to issue #418.

### Changes
Replace panic on missing cargo-dylint with a structured LinterError::MissingPrerequisite handled gracefully in main.rs, using action.yml version constraint (^6.0.1).

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #418` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->