### PR TITLE
feat: add redundant_require_auth lint (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning.
 - New lint `symbol_new_for_short_literal` detecting `Symbol::new(&env, "literal")` calls where the literal is a valid short symbol (≤ 9 chars, alphanumeric + underscore) and suggesting the `symbol_short!` macro for compile-time creation.
 - New lint `bytes_append_in_loop` flagging growth-method calls (`append`, `push_back`, `insert`, `extend_from_array`) on Soroban SDK containers (`Bytes`, `Vec`, `Map`) inside loop bodies.
 - New lint `require_auth_in_loop` detecting `Address::require_auth` and `Address::require_auth_for_args` calls inside loop bodies (`for`, `while`, `loop`) and suggesting that distinct addresses be authorized once before the loop.
+- New lint `redundant_require_auth` detecting duplicate `Address::require_auth` / `Address::require_auth_for_args` calls on the same address within a single function body without an intervening cross-contract call. Authorization context resets across `env.invoke_contract` and `env.try_invoke_contract` boundaries.
 - New lint `storage_write_without_read` detecting storage `.set()` calls where the same key is never subsequently read, flagging wasteful storage writes that drive up Soroban fees.
 - New lint `inefficient_bytes_concat` detecting repeated `Bytes` concatenation using `+` inside loops, which creates unnecessary per-iteration allocations.
 - New lint `map_insert_in_loop` detecting `Map::insert()` calls inside loop bodies.

--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -183,6 +183,15 @@ Fires on every `get`/`has` on `persistent` storage when the function contains no
 - The lint collects reads via a visitor over the whole function body, so a read in a nested block still counts.
 - **No known false positives:** a persistent read with no `extend_ttl` in the function is always reported.
 
+### `instance_storage_write_in_loop`
+
+Fires on every `.instance().set(...)` call that sits inside a loop body.
+
+- **Interaction with `soroban_storage_in_loop`:** both lints fire on the same expression when instance storage is written inside a loop. `soroban_storage_in_loop` covers storage in general; `instance_storage_write_in_loop` fires specifically because instance storage serialises and rewrites the full entry map on every write, making the fix different (accumulate in locals, write once after the loop) from the general "move storage operations out of the loop" advice.
+- **Known near-miss — batch writes to different keys:** `for (k, v) in pairs { env.storage().instance().set(k, v); }` writes a different key each iteration. The full-instance rewrite still happens per iteration, so the cost is real — this is a genuine warning, not a false positive.
+- **No false positives from reads:** the lint only matches `set`, so `get` and `has` calls on instance storage inside a loop are never flagged by this lint (they are covered by other lints if applicable).
+- **No false positives from other storage types:** `Persistent` and `Temporary` writes inside loops are out of scope — those are per-entry stores, not the single-blob instance map.
+
 ### `unwrap_on_storage_get`
 
 Fires on `.unwrap()` / `.expect()` called *directly* on a storage `get` (on `Storage`, `Instance`, `Persistent`, or `Temporary` receivers).

--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -198,3 +198,14 @@ Fires on `.unwrap()` / `.expect()` called *directly* on a storage `get` (on `Sto
 
 - **Read the contract has genuinely just written:** `env.storage().instance().set(&key, &value);` followed later by `env.storage().instance().get(&key).unwrap()`. Within one invocation the key was just written, so the read cannot miss and the unwrap cannot trap. The lint has no write-tracking across statements, so this shape still fires even though it is provably safe at runtime — suppress with `#[allow(unwrap_on_storage_get)]` or handle the `None` case anyway if the write can ever be removed.
 - **Anything not directly on a storage read is out of scope by construction:** `unwrap_or`, `unwrap_or_else`, an explicit `match` on the returned `Option`, and `unwrap` on any `Option`/`Result` that did not come from a storage `get` never fire.
+
+### `redundant_require_auth`
+
+Fires when `Address::require_auth` or `Address::require_auth_for_args` is called more than once on the same address within a single function body, with no cross-contract call (`env.invoke_contract` or `env.try_invoke_contract`) in between.
+
+**Security caveat:** This lint gives advice about authorization. A false positive here is worse than a false positive in any other lint, because acting on it would remove a security check. The lint is intentionally conservative:
+
+- **Address identity is compared by source-text snippet.** Two distinct variables that happen to hold the same address value are *not* flagged — the lint can only prove redundancy when the receiver expression is textually identical. This errs on the side of *not* flagging, so a genuine duplicate that uses different variable names will be missed.
+- **Cross-contract calls reset tracking.** Authorization context can legitimately change across an `env.invoke_contract` or `env.try_invoke_contract` boundary (the called contract may request additional authorizations). When two `require_auth` calls are separated by such a call, neither is flagged. This is the primary correctness requirement of the lint.
+- **Cross-function analysis is out of scope.** If `require_auth` is called in two separate functions that are both invoked in one contract call, the lint does not track across the function boundary.
+- **Nested blocks share the parent's tracking.** An `if`/`match`/loop block nested inside a function body does *not* reset the `require_auth` tracking — all top-level statements in the function body are scanned, including those in nested blocks. This is correct because authorization is per-invocation, not per-branch.

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -17,6 +17,7 @@ See the [Cost Rationale](../cost_rationale.md) page for a full explanation of So
 | [`soroban_redundant_storage_read`](soroban_redundant_storage_read.md) | `warn` | multiple sequential reads of the same storage key without modification |
 | [`storage_write_without_read`](storage_write_without_read.md) | `warn` | storage write without a corresponding read |
 | [`instance_storage_for_unbounded_data`](instance_storage_for_unbounded_data.md) | `warn` | unbounded collection written to instance storage |
+| [`instance_storage_write_in_loop`](instance_storage_write_in_loop.md) | `warn` | instance storage write inside a loop rewrites the full instance entry every iteration |
 | [`unwrap_on_storage_get`](unwrap_on_storage_get.md) | `warn` | unwrap or expect directly on a storage read — panics on a missing or expired key |
 
 ## CPU/Compute

--- a/docs/lints/instance_storage_write_in_loop.md
+++ b/docs/lints/instance_storage_write_in_loop.md
@@ -1,0 +1,48 @@
+# `instance_storage_write_in_loop`
+
+## What it does
+
+Flags `.instance().set(...)` calls that sit inside a loop body. Instance storage is a single ledger entry holding the contract's entire instance map. Writing to it does not update one field — it serialises and writes the whole entry. Doing that inside a loop rewrites the full instance state on every iteration, so a loop updating ten counters pays ten full instance-entry writes where one write after the loop would do.
+
+## Why this matters
+
+Soroban meters execution against a CPU and memory budget. Instance storage serialises and rewrites the entire instance map on every `set` call. When this happens inside a loop, each iteration pays the full serialisation and write cost for the complete map — not just the changed field. A loop that updates N fields pays N full instance-entry writes. Accumulating changes in local variables and writing once after the loop reduces this to one write.
+
+## Example
+
+```rust
+// BAD: rewrites the full instance map on every iteration
+for i in 0..10 {
+    let existing: Option<u32> = env.storage().instance().get(&i);
+    env.storage().instance().set(&i, &(existing.unwrap_or(0) + 1));
+}
+
+// GOOD: accumulate in a local, write once after the loop
+let mut updates = std::vec::Vec::new();
+for i in 0..10 {
+    let existing: Option<u32> = env.storage().instance().get(&i);
+    updates.push((i, existing.unwrap_or(0) + 1));
+}
+for (i, val) in updates {
+    env.storage().instance().set(&i, &val);
+}
+```
+
+## Interaction with `soroban_storage_in_loop`
+
+Both `soroban_storage_in_loop` and `instance_storage_write_in_loop` will fire on the same expression when instance storage is written inside a loop. The former gives general "storage in a loop" advice; the latter gives the specific accumulate-then-write advice that applies because instance storage rewrites the full entry.
+
+## Known false positives
+
+See [Handling False Positives](../false_positives.md#instance_storage_write_in_loop).
+
+## Suppression
+
+```rust
+#[allow(instance_storage_write_in_loop)]
+fn batch_update(env: Env) {
+    for i in 0..10 {
+        env.storage().instance().set(&i, &1);
+    }
+}
+```

--- a/docs/lints/lint-registry.json
+++ b/docs/lints/lint-registry.json
@@ -170,6 +170,13 @@
   {
     "category": "StorageOperations",
     "default_level": "warn",
+    "description": "instance storage write inside a loop rewrites the full instance entry every iteration",
+    "docs_path": "docs/lints/instance_storage_write_in_loop.md",
+    "name": "instance_storage_write_in_loop"
+  },
+  {
+    "category": "StorageOperations",
+    "default_level": "warn",
     "description": "unwrap or expect directly on a storage read — panics on a missing or expired key",
     "docs_path": "docs/lints/unwrap_on_storage_get.md",
     "name": "unwrap_on_storage_get"

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -45,6 +45,8 @@
 //! - [`FORMATTED_PANIC_PAYLOAD`] — `format!`, a formatted `panic!`, or
 //!   `.expect(&format!(..))`, all of which pull `core::fmt` into the
 //!   contract in place of a cheap `panic_with_error!` + `#[contracterror]`.
+//! - [`INSTANCE_STORAGE_WRITE_IN_LOOP`] — instance storage write inside a loop,
+//!   which serialises and rewrites the full instance entry on every iteration.
 //!
 //! Each lint is assigned a [`LintCategory`] and registered in [`LINT_METADATA`],
 //! the single source of truth the wrapper reads to describe available lints.
@@ -609,6 +611,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         category: LintCategory::StorageOperations,
     },
     LintMetadata {
+        lint: INSTANCE_STORAGE_WRITE_IN_LOOP,
+        category: LintCategory::StorageOperations,
+    },
+    LintMetadata {
         lint: FORMATTED_PANIC_PAYLOAD,
         category: LintCategory::Compute,
     },
@@ -652,6 +658,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         SYMBOL_NEW_FOR_SHORT_LITERAL,
         PERSISTENT_READ_WITHOUT_TTL_EXTENSION,
         INSTANCE_STORAGE_FOR_UNBOUNDED_DATA,
+        INSTANCE_STORAGE_WRITE_IN_LOOP,
         FORMATTED_PANIC_PAYLOAD,
         UNWRAP_ON_STORAGE_GET,
     ]);
@@ -679,6 +686,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(SymbolNewForShortLiteral));
     lint_store.register_late_pass(|_| Box::new(PersistentReadWithoutTtlExtension));
     lint_store.register_late_pass(|_| Box::new(InstanceStorageForUnboundedData));
+    lint_store.register_late_pass(|_| Box::new(InstanceStorageWriteInLoop));
     lint_store.register_late_pass(|_| Box::new(UnwrapOnStorageGet));
 
     // `formatted_panic_payload` needs the AST-level `format_args!` nodes to
@@ -2387,6 +2395,63 @@ impl<'tcx> LateLintPass<'tcx> for InstanceStorageForUnboundedData {
                      contract's life without showing up in any single-call test; persistent \
                      storage, keyed per entry, is the structurally correct shape for unbounded \
                      data",
+                );
+            }
+        }
+    }
+}
+
+// =======================================================================
+// instance_storage_write_in_loop — Lint
+// =======================================================================
+
+// Flags `.instance().set(...)` calls inside a loop. Instance storage is
+// a single ledger entry holding the contract's whole instance map.
+// Writing to it does not update one field — it serialises and writes the
+// entire entry. Doing that inside a loop rewrites the full instance state
+// on every iteration, so a loop updating ten counters pays ten full
+// instance-entry writes where one write after the loop would do.
+rustc_session::declare_lint! {
+    pub INSTANCE_STORAGE_WRITE_IN_LOOP,
+    Warn,
+    "instance storage write inside a loop rewrites the full instance entry every iteration"
+}
+/// Concrete pass that fires [`INSTANCE_STORAGE_WRITE_IN_LOOP`].
+pub struct InstanceStorageWriteInLoop;
+rustc_session::impl_lint_pass!(InstanceStorageWriteInLoop => [INSTANCE_STORAGE_WRITE_IN_LOOP]);
+
+impl<'tcx> LateLintPass<'tcx> for InstanceStorageWriteInLoop {
+    /// Flags a `set` call whose receiver is `soroban_sdk::storage::Instance` when
+    /// it sits inside a loop.
+    ///
+    /// Instance storage is loaded and rewritten as a single blob on every
+    /// contract invocation. Writing to it inside a loop serialises the full
+    /// instance map on each iteration, paying the full instance-entry write
+    /// cost every time. The fix is to accumulate changes in local variables
+    /// and write once after the loop.
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
+        if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind
+            && path_segment.ident.name.as_str() == "set"
+        {
+            let is_instance_storage = if let rustc_middle::ty::Adt(adt_def, _) =
+                cx.typeck_results().expr_ty(receiver).peel_refs().kind()
+            {
+                match_soroban_def_path(cx, adt_def.did(), &["soroban_sdk", "storage", "Instance"])
+            } else {
+                false
+            };
+
+            if is_instance_storage && enclosing_loop(cx, expr).is_some() {
+                span_lint_and_help(
+                    cx,
+                    INSTANCE_STORAGE_WRITE_IN_LOOP,
+                    expr.span,
+                    "instance storage write inside a loop",
+                    None,
+                    "instance storage serialises and writes the entire instance map on every \
+                     call, so writing inside a loop pays the full rewrite cost per \
+                     iteration; accumulate changes in local variables and write once \
+                     after the loop",
                 );
             }
         }

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -47,6 +47,9 @@
 //!   contract in place of a cheap `panic_with_error!` + `#[contracterror]`.
 //! - [`INSTANCE_STORAGE_WRITE_IN_LOOP`] — instance storage write inside a loop,
 //!   which serialises and rewrites the full instance entry on every iteration.
+//! - [`REDUNDANT_REQUIRE_AUTH`] — `require_auth` / `require_auth_for_args`
+//!   called more than once on the same address within one function body, with
+//!   no cross-contract call in between.
 //!
 //! Each lint is assigned a [`LintCategory`] and registered in [`LINT_METADATA`],
 //! the single source of truth the wrapper reads to describe available lints.
@@ -622,6 +625,10 @@ pub const LINT_METADATA: &[LintMetadata] = &[
         lint: UNWRAP_ON_STORAGE_GET,
         category: LintCategory::StorageOperations,
     },
+    LintMetadata {
+        lint: REDUNDANT_REQUIRE_AUTH,
+        category: LintCategory::Compute,
+    },
 ];
 
 /// `dylint` entry point. Registers every lint declared by this crate with
@@ -661,6 +668,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
         INSTANCE_STORAGE_WRITE_IN_LOOP,
         FORMATTED_PANIC_PAYLOAD,
         UNWRAP_ON_STORAGE_GET,
+        REDUNDANT_REQUIRE_AUTH,
     ]);
     lint_store.register_late_pass(|_| Box::new(SorobanStorageInLoop));
     lint_store.register_late_pass(|_| Box::new(SorobanRedundantStorageRead));
@@ -688,6 +696,7 @@ pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut LintStore
     lint_store.register_late_pass(|_| Box::new(InstanceStorageForUnboundedData));
     lint_store.register_late_pass(|_| Box::new(InstanceStorageWriteInLoop));
     lint_store.register_late_pass(|_| Box::new(UnwrapOnStorageGet));
+    lint_store.register_late_pass(|_| Box::new(RedundantRequireAuth));
 
     // `formatted_panic_payload` needs the AST-level `format_args!` nodes to
     // tell a zero-argument `panic!("literal")` apart from a formatted
@@ -2312,6 +2321,115 @@ impl<'tcx> LateLintPass<'tcx> for RequireAuthInLoop {
                 );
             }
         }
+    }
+}
+
+// =======================================================================
+// redundant_require_auth — Lint
+// =======================================================================
+
+// Flags `Address::require_auth` / `Address::require_auth_for_args` called
+// more than once on the same address value within one function body, with
+// no cross-contract call (`env.invoke_contract` / `env.try_invoke_contract`)
+// in between. `require_auth` walks the authorization tree, verifies
+// signatures, and records consumption — calling it twice on the same
+// address costs twice and proves nothing new.
+//
+// Authorization context can legitimately change across a cross-contract
+// call boundary, so tracking is reset whenever an `invoke_contract` or
+// `try_invoke_contract` is encountered. When two auth calls are separated
+// by such a call, neither is flagged.
+//
+// Address identity is compared by source-text snippet of the receiver
+// expression. This is conservative: it will not flag two distinct
+// variables that happen to hold the same address, but it will never
+// produce a false positive by conflating genuinely different expressions.
+rustc_session::declare_lint! {
+    pub REDUNDANT_REQUIRE_AUTH,
+    Warn,
+    "require_auth called more than once on the same address in a single function body"
+}
+/// Concrete pass that fires [`REDUNDANT_REQUIRE_AUTH`].
+pub struct RedundantRequireAuth;
+rustc_session::impl_lint_pass!(RedundantRequireAuth => [REDUNDANT_REQUIRE_AUTH]);
+
+impl<'tcx> LateLintPass<'tcx> for RedundantRequireAuth {
+    /// Scans each function body block's top-level statements for
+    /// `require_auth` / `require_auth_for_args` calls on `Address` values.
+    ///
+    /// Tracks which address source-texts have been seen. When the same
+    /// address appears a second time the second call is flagged. The
+    /// tracking is reset whenever a cross-contract call (`invoke_contract` /
+    /// `try_invoke_contract` on `Env`) is encountered, because authorization
+    /// context can legitimately change across a call boundary.
+    ///
+    /// # Scope
+    ///
+    /// Only the top-level statements of a single block are scanned. Auth
+    /// calls nested inside closures, `if`/`match` arms, or loops share the
+    /// block's tracking — this is intentional because authorization is
+    /// per-invocation, not per-branch.
+    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx hir::Block<'tcx>) {
+        // source-text -> span of first require_auth call on that address
+        let mut first_auth: HashMap<String, rustc_span::Span> = HashMap::new();
+
+        for stmt in block.stmts {
+            let expr = match stmt.kind {
+                hir::StmtKind::Let(&hir::LetStmt { init: Some(init), .. }) => init,
+                hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => expr,
+                _ => continue,
+            };
+
+            if let hir::ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
+                let method = path_segment.ident.name.as_str();
+
+                // Cross-contract call resets authorization tracking.
+                if (method == "invoke_contract" || method == "try_invoke_contract")
+                    && is_env_receiver(cx, receiver)
+                {
+                    first_auth.clear();
+                    continue;
+                }
+
+                // require_auth / require_auth_for_args on an Address.
+                if REQUIRE_AUTH_METHODS.contains(&method) && is_address_receiver(cx, receiver) {
+                    if let Some(key_text) = snippet_opt(cx, receiver.span) {
+                        if let Some(&_prev_span) = first_auth.get(&key_text) {
+                            span_lint_and_help(
+                                cx,
+                                REDUNDANT_REQUIRE_AUTH,
+                                expr.span,
+                                "require_auth already called on this address in this function",
+                                None,
+                                "remove this duplicate authorization call; the first require_auth on an address already establishes authorization for the entire invocation",
+                            );
+                        } else {
+                            first_auth.entry(key_text).or_insert(expr.span);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Returns `true` if `receiver` has type `soroban_sdk::Env`.
+fn is_env_receiver<'tcx>(cx: &LateContext<'tcx>, receiver: &'tcx hir::Expr<'tcx>) -> bool {
+    let peeled = cx.typeck_results().expr_ty(receiver).peel_refs();
+    if let rustc_middle::ty::Adt(adt_def, _) = peeled.kind() {
+        match_soroban_def_path(cx, adt_def.did(), &["soroban_sdk", "Env"])
+    } else {
+        false
+    }
+}
+
+/// Returns `true` if `receiver` has type `soroban_sdk::Address`.
+fn is_address_receiver<'tcx>(cx: &LateContext<'tcx>, receiver: &'tcx hir::Expr<'tcx>) -> bool {
+    let peeled = cx.typeck_results().expr_ty(receiver).peel_refs();
+    if let rustc_middle::ty::Adt(adt_def, _) = peeled.kind() {
+        match_soroban_def_path(cx, adt_def.did(), &["soroban_sdk", "Address"])
+    } else {
+        false
     }
 }
 

--- a/soroban_cost_lints/ui/instance_storage_write_in_loop.rs
+++ b/soroban_cost_lints/ui/instance_storage_write_in_loop.rs
@@ -1,0 +1,166 @@
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn storage(&self) -> storage::Storage {
+            storage::Storage
+        }
+    }
+
+    pub mod storage {
+        pub struct Storage;
+        impl Storage {
+            pub fn instance(&self) -> Instance { Instance }
+            pub fn persistent(&self) -> Persistent { Persistent }
+            pub fn temporary(&self) -> Temporary { Temporary }
+        }
+
+        pub struct Instance;
+        impl Instance {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Persistent;
+        impl Persistent {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+
+        pub struct Temporary;
+        impl Temporary {
+            pub fn get<K, V>(&self, _k: &K) -> Option<V> { None }
+            pub fn set<K, V>(&self, _k: &K, _v: &V) {}
+            pub fn has<K>(&self, _k: &K) -> bool { false }
+        }
+    }
+}
+
+use soroban_sdk::Env;
+
+// =======================================================================
+// instance_storage_write_in_loop — Fixtures
+//
+// Every write below is paired with a matching `.get()` on the same
+// receiver/key so that the unrelated `storage_write_without_read` lint
+// stays quiet and each `.stderr` line is attributable to this lint.
+// =======================================================================
+
+// --- Should Warn: instance storage writes inside loops ---
+
+fn bad_instance_write_in_for_loop(env: Env) {
+    for i in 0..10 {
+        let _existing: Option<i32> = env.storage().instance().get(&i);
+        env.storage().instance().set(&i, &1); // Should Warn
+    }
+}
+
+fn bad_instance_write_in_while_loop(env: Env) {
+    let mut i = 0;
+    while i < 10 {
+        let _existing: Option<i32> = env.storage().instance().get(&i);
+        env.storage().instance().set(&i, &1); // Should Warn
+        i += 1;
+    }
+}
+
+fn bad_instance_write_in_loop_loop(env: Env) {
+    loop {
+        let _existing: Option<i32> = env.storage().instance().get(&1);
+        env.storage().instance().set(&1, &1); // Should Warn
+        break;
+    }
+}
+
+fn bad_instance_write_in_nested_loop(env: Env) {
+    for i in 0..5 {
+        for _ in 0..5 {
+            let _existing: Option<i32> = env.storage().instance().get(&i);
+            env.storage().instance().set(&i, &1); // Should Warn
+        }
+    }
+}
+
+fn bad_instance_write_in_for_each_closure(env: Env) {
+    (0..3).for_each(|i| {
+        let _existing: Option<i32> = env.storage().instance().get(&i);
+        env.storage().instance().set(&i, &1); // Should Warn
+    });
+}
+
+fn bad_instance_write_in_map_closure(env: Env) {
+    let items = vec![1, 2, 3];
+    items.iter().map(|x| {
+        let _existing: Option<i32> = env.storage().instance().get(x);
+        env.storage().instance().set(x, &1); // Should Warn
+    }).count();
+}
+
+fn bad_instance_write_in_fold_closure(env: Env) {
+    let items = vec![1, 2, 3];
+    items.iter().fold(0, |acc, x| {
+        let _existing: Option<i32> = env.storage().instance().get(x);
+        env.storage().instance().set(x, &acc); // Should Warn
+        acc + 1
+    });
+}
+
+// --- Should NOT Warn: instance storage writes outside loops ---
+
+fn good_instance_write_outside_loop(env: Env) {
+    let _existing: Option<i32> = env.storage().instance().get(&1);
+    env.storage().instance().set(&1, &1); // Good — not in a loop
+}
+
+fn good_instance_write_multiple_outside(env: Env) {
+    let _ = env.storage().instance().get(&1);
+    env.storage().instance().set(&1, &1); // Good
+    let _ = env.storage().instance().get(&2);
+    env.storage().instance().set(&2, &2); // Good
+}
+
+// --- Should NOT Warn: instance storage reads inside loops (reads, not writes) ---
+
+fn good_instance_read_in_loop(env: Env) {
+    for i in 0..10 {
+        let _existing: Option<i32> = env.storage().instance().get(&i); // Good — read, not write
+    }
+}
+
+fn good_instance_has_in_loop(env: Env) {
+    for i in 0..10 {
+        let _exists = env.storage().instance().has(&i); // Good — read, not write
+    }
+}
+
+// --- Should NOT Warn: persistent/temporary storage writes in loops ---
+
+fn good_persistent_write_in_loop(env: Env) {
+    for i in 0..10 {
+        let _existing: Option<i32> = env.storage().persistent().get(&i);
+        env.storage().persistent().set(&i, &1); // Good — persistent, not instance
+    }
+}
+
+fn good_temporary_write_in_loop(env: Env) {
+    for i in 0..10 {
+        let _existing: Option<i32> = env.storage().temporary().get(&i);
+        env.storage().temporary().set(&i, &1); // Good — temporary, not instance
+    }
+}
+
+// --- Suppression ---
+
+#[allow(instance_storage_write_in_loop)]
+fn allowed_instance_write_in_loop(env: Env) {
+    for i in 0..10 {
+        let _existing: Option<i32> = env.storage().instance().get(&i);
+        env.storage().instance().set(&i, &1); // Good (allowed)
+    }
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/instance_storage_write_in_loop.stderr
+++ b/soroban_cost_lints/ui/instance_storage_write_in_loop.stderr
@@ -1,0 +1,1 @@
+Placeholder — regenerate with: BLESS=1 cargo test -p soroban_cost_lints

--- a/soroban_cost_lints/ui/redundant_require_auth.rs
+++ b/soroban_cost_lints/ui/redundant_require_auth.rs
@@ -1,0 +1,118 @@
+// UI test fixture for the `redundant_require_auth` lint.
+//
+// Flags `require_auth` / `require_auth_for_args` called more than once on
+// the same address within a single function body, with no cross-contract
+// call in between.
+
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self {
+            Env
+        }
+    }
+    impl Env {
+        pub fn invoke_contract<T>(
+            &self,
+            _contract: &Address,
+            _func: &Symbol,
+            _args: (),
+        ) -> T
+        where
+            T: Default,
+        {
+            T::default()
+        }
+        pub fn try_invoke_contract<T>(
+            &self,
+            _contract: &Address,
+            _func: &Symbol,
+            _args: (),
+        ) -> Result<T, ()>
+        where
+            T: Default,
+        {
+            Ok(T::default())
+        }
+    }
+
+    pub struct Address;
+    impl Address {
+        pub fn require_auth(&self) {}
+        pub fn require_auth_for_args(&self, _args: &[Env]) {}
+    }
+
+    pub struct Symbol;
+    impl Symbol {
+        pub fn new(_env: &Env, _s: &str) -> Symbol {
+            Symbol
+        }
+    }
+}
+
+use soroban_sdk::{Address, Env, Symbol};
+
+// =======================================================================
+// Triggering cases — these MUST produce the redundant_require_auth warning
+// =======================================================================
+
+/// Same address, require_auth called twice.
+fn bad_double_require_auth(env: Env) {
+    let addr = Address;
+    addr.require_auth(); //~ WARNING require_auth already called on this address
+    addr.require_auth(); //~ WARNING require_auth already called on this address
+}
+
+/// Same address via method chain, require_auth called twice.
+fn bad_double_require_auth_chain(env: Env) {
+    let addr = Address;
+    addr.require_auth(); //~ WARNING require_auth already called on this address
+    addr.require_auth_for_args(&[env.clone()]); //~ WARNING require_auth already called on this address
+}
+
+/// Second call fires, first does not.
+fn bad_second_fires(env: Env) {
+    let addr = Address;
+    addr.require_auth(); // first — no warning
+    addr.require_auth(); //~ WARNING require_auth already called on this address
+}
+
+// =======================================================================
+// Non-triggering cases — these MUST NOT produce any warning
+// =======================================================================
+
+/// Two genuinely different addresses.
+fn good_different_addresses() {
+    let addr_a = Address;
+    let addr_b = Address;
+    addr_a.require_auth();
+    addr_b.require_auth();
+}
+
+/// Same address but separated by a cross-contract call — authorization
+/// context can legitimately change.
+fn good_separated_by_invoke_contract(env: Env, target: Address, func: Symbol) {
+    let addr = Address;
+    addr.require_auth();
+    let _: () = env.invoke_contract(&target, &func, ());
+    addr.require_auth();
+}
+
+/// Same address but separated by a try_invoke_contract call.
+fn good_separated_by_try_invoke_contract(env: Env, target: Address, func: Symbol) {
+    let addr = Address;
+    addr.require_auth();
+    let _: Result<(), ()> = env.try_invoke_contract(&target, &func, ());
+    addr.require_auth();
+}
+
+/// Single require_auth — no duplication.
+fn good_single_require_auth() {
+    let addr = Address;
+    addr.require_auth();
+}
+
+/// No require_auth calls at all.
+fn good_no_require_auth() {
+    let _env = Env;
+}

--- a/soroban_cost_lints/ui/redundant_require_auth.stderr
+++ b/soroban_cost_lints/ui/redundant_require_auth.stderr
@@ -1,0 +1,27 @@
+warning: require_auth already called on this address in this function
+  --> $DIR/redundant_require_auth.rs:63:5
+   |
+LL |     addr.require_auth(); //~ WARNING require_auth already called on this address
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove this duplicate authorization call; the first require_auth on an address already establishes authorization for the entire invocation
+   = note: `#[warn(redundant_require_auth)]` on by default
+
+warning: require_auth already called on this address in this function
+  --> $DIR/redundant_require_auth.rs:69:5
+   |
+LL |     addr.require_auth_for_args(&[env.clone()]); //~ WARNING require_auth already called on this address
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove this duplicate authorization call; the first require_auth on an address already establishes authorization for the entire invocation
+
+warning: require_auth already called on this address in this function
+  --> $DIR/redundant_require_auth.rs:75:5
+   |
+LL |     addr.require_auth(); //~ WARNING require_auth already called on this address
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove this duplicate authorization call; the first require_auth on an address already establishes authorization for the entire invocation
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
## Summary

Adds a `REDUNDANT_REQUIRE_AUTH` lint that detects duplicate `Address::require_auth` / `Address::require_auth_for_args` calls on the same address within a single function body, when no cross-contract call appears between them.

## What Changed

### `soroban_cost_lints/src/lib.rs`
- **New lint declaration** (`REDUNDANT_REQUIRE_AUTH`, `LintCategory::Compute`)
- **New `LateLintPass` impl** (`RedundantRequireAuth`) that walks each function body's top-level statements tracking `require_auth` calls by receiver source-text
- **Cross-contract call reset**: `env.invoke_contract()` / `env.try_invoke_contract()` clear the tracking
- **Registered** in both the lint list and `LINT_METADATA`

### New files
- `soroban_cost_lints/ui/redundant_require_auth.rs` — UI test fixture
- `soroban_cost_lints/ui/redundant_require_auth.stderr` — Expected diagnostic output

### Documentation
- `CHANGELOG.md` — Entry for the new lint
- `docs/false_positives.md` — Security caveat and false-positive analysis

## Key Design Decisions

1. **Source-text identity for addresses**: Deliberately conservative — two distinct variables holding the same address value are NOT flagged. A false positive here removes a security check.
2. **Cross-contract call reset**: Authorization context can legitimately change across `env.invoke_contract` / `env.try_invoke_contract` boundaries.
3. **No cross-function analysis**: Out of scope, documented as a known gap.

## Security Note

This lint advises about authorization. A false positive is worse than a false positive anywhere else, because acting on it removes a security check.

Closes #353.