### PR TITLE
feat: add redundant_require_auth lint (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning.
 - New lint `symbol_new_for_short_literal` detecting `Symbol::new(&env, "literal")` calls where the literal is a valid short symbol (≤ 9 chars, alphanumeric + underscore) and suggesting the `symbol_short!` macro for compile-time creation.
 - New lint `bytes_append_in_loop` flagging growth-method calls (`append`, `push_back`, `insert`, `extend_from_array`) on Soroban SDK containers (`Bytes`, `Vec`, `Map`) inside loop bodies.
 - New lint `require_auth_in_loop` detecting `Address::require_auth` and `Address::require_auth_for_args` calls inside loop bodies (`for`, `while`, `loop`) and suggesting that distinct addresses be authorized once before the loop.
+- New lint `redundant_require_auth` detecting duplicate `Address::require_auth` / `Address::require_auth_for_args` calls on the same address within a single function body without an intervening cross-contract call. Authorization context resets across `env.invoke_contract` and `env.try_invoke_contract` boundaries.
 - New lint `storage_write_without_read` detecting storage `.set()` calls where the same key is never subsequently read, flagging wasteful storage writes that drive up Soroban fees.
 - New lint `inefficient_bytes_concat` detecting repeated `Bytes` concatenation using `+` inside loops, which creates unnecessary per-iteration allocations.
 - New lint `map_insert_in_loop` detecting `Map::insert()` calls inside loop bodies.

--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -140,3 +140,13 @@ Flags 128-bit arithmetic on values provably within 64 bits.
 
 - **Token Balances & External Inputs:** Arithmetic derived directly from token balances, cross-contract calls, or caller-supplied `i128` parameters does not fire.
 - **Handling:** If a 128-bit type is genuinely required by business logic across the entire expression, suppress with `#[allow(u128_where_u64_suffices)]`.
+
+### `redundant_require_auth`
+
+Fires when `Address::require_auth` or `Address::require_auth_for_args` is called more than once on the same address within a single function body, with no cross-contract call in between.
+
+**Security caveat:** This lint advises about authorization. A false positive here is worse than a false positive in any other lint, because acting on it would remove a security check. The lint is intentionally conservative:
+
+- **Address identity is compared by source-text snippet.** Two distinct variables holding the same address value are *not* flagged. This errs on the side of *not* flagging.
+- **Cross-contract calls reset tracking.** Authorization context can change across `env.invoke_contract` / `env.try_invoke_contract` boundaries.
+- **Cross-function analysis is out of scope.** If `require_auth` is called in two separate functions, the lint does not track across the function boundary.

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -12,6 +12,7 @@ use rustc_span::Span;
 use std::collections::HashSet;
 
 mod discarded_storage_read;
+mod redundant_require_auth;
 
 rustc_lint::declare_lint! {
     pub SOROBAN_STORAGE_IN_LOOP,
@@ -231,6 +232,12 @@ pub struct LintMeta {
 
 pub const LINT_METADATA: &[LintMeta] = &[
     LintMeta {
+        name: "redundant_require_auth",
+        category: LintCategory::Compute,
+        description: "require_auth called more than once on the same address in a single function body",
+        rationale: "require_auth walks the authorization tree and verifies signatures; calling it twice on the same address costs twice and proves nothing new.",
+    },
+    LintMeta {
         name: "soroban_storage_in_loop",
         category: LintCategory::Storage,
         description: "Performs a storage read or write inside a loop body",
@@ -446,5 +453,6 @@ dylint_lint_impl! {
         VEC_WHERE_SLICE_COULD_BE_USED,
         SOROBAN_INEFFICIENT_BYTES_CONCAT,
         U128_WHERE_U64_SUFFICES,
+        REDUNDANT_REQUIRE_AUTH,
     ]
 }

--- a/soroban_cost_lints/src/redundant_require_auth.rs
+++ b/soroban_cost_lints/src/redundant_require_auth.rs
@@ -1,0 +1,75 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::source::snippet_opt;
+use rustc_hir::{self as hir, ExprKind, StmtKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_lint, declare_lint_pass};
+use std::collections::HashMap;
+
+declare_lint! {
+    pub REDUNDANT_REQUIRE_AUTH,
+    Warn,
+    "require_auth called more than once on the same address in a single function body"
+}
+
+declare_lint_pass!(RedundantRequireAuth => [REDUNDANT_REQUIRE_AUTH]);
+
+const REQUIRE_AUTH_METHODS: &[&str] = &["require_auth", "require_auth_for_args"];
+
+impl<'tcx> LateLintPass<'tcx> for RedundantRequireAuth {
+    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx hir::Block<'tcx>) {
+        // source-text -> span of first require_auth call on that address
+        let mut first_auth: HashMap<String, rustc_span::Span> = HashMap::new();
+
+        for stmt in block.stmts {
+            let expr = match stmt.kind {
+                StmtKind::Let(hir::LetStmt { init: Some(init), .. }) => init,
+                StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr,
+                _ => continue,
+            };
+
+            if let ExprKind::MethodCall(path_segment, receiver, _args, _span) = expr.kind {
+                let method = path_segment.ident.name.as_str();
+
+                // Cross-contract call resets authorization tracking.
+                if (method == "invoke_contract" || method == "try_invoke_contract")
+                    && is_env_receiver(cx, receiver)
+                {
+                    first_auth.clear();
+                    continue;
+                }
+
+                // require_auth / require_auth_for_args on an Address.
+                if REQUIRE_AUTH_METHODS.contains(&method) && is_address_receiver(cx, receiver) {
+                    if let Some(key_text) = snippet_opt(cx, receiver.span) {
+                        if let Some(&_prev_span) = first_auth.get(&key_text) {
+                            span_lint_and_help(
+                                cx,
+                                REDUNDANT_REQUIRE_AUTH,
+                                expr.span,
+                                "require_auth already called on this address in this function",
+                                None,
+                                "remove this duplicate authorization call; the first require_auth on an address already establishes authorization for the entire invocation",
+                            );
+                        } else {
+                            first_auth.entry(key_text).or_insert(expr.span);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Returns `true` if `receiver` has type `soroban_sdk::Env`.
+fn is_env_receiver<'tcx>(cx: &LateContext<'tcx>, receiver: &'tcx hir::Expr<'tcx>) -> bool {
+    let peeled = cx.typeck_results().expr_ty(receiver).peel_refs();
+    let ty_str = format!("{:?}", peeled);
+    ty_str.contains("soroban_sdk::Env") || ty_str.contains("Env")
+}
+
+/// Returns `true` if `receiver` has type `soroban_sdk::Address`.
+fn is_address_receiver<'tcx>(cx: &LateContext<'tcx>, receiver: &'tcx hir::Expr<'tcx>) -> bool {
+    let peeled = cx.typeck_results().expr_ty(receiver).peel_refs();
+    let ty_str = format!("{:?}", peeled);
+    ty_str.contains("soroban_sdk::Address") || ty_str.contains("Address")
+}

--- a/soroban_cost_lints/ui/redundant_require_auth.rs
+++ b/soroban_cost_lints/ui/redundant_require_auth.rs
@@ -1,0 +1,95 @@
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn invoke_contract<T>(&self, _contract: &Address, _func: &Symbol, _args: ()) -> T
+        where T: Default {
+            T::default()
+        }
+        pub fn try_invoke_contract<T>(&self, _contract: &Address, _func: &Symbol, _args: ()) -> Result<T, ()>
+        where T: Default {
+            Ok(T::default())
+        }
+    }
+
+    pub struct Address;
+    impl Address {
+        pub fn require_auth(&self) {}
+        pub fn require_auth_for_args(&self, _args: &[i32]) {}
+    }
+
+    pub struct Symbol;
+    impl Symbol {
+        pub fn new(_env: &Env, _s: &str) -> Symbol { Symbol }
+    }
+}
+
+use soroban_sdk::{Address, Env, Symbol};
+
+// =======================================================================
+// Triggering cases — these MUST produce the redundant_require_auth warning
+// =======================================================================
+
+/// Same address, require_auth called twice.
+fn bad_double_require_auth(env: Env) {
+    let addr = Address;
+    addr.require_auth(); // first — no warning
+    addr.require_auth(); //~ WARNING require_auth already called on this address
+}
+
+/// Same address, mixed require_auth and require_auth_for_args.
+fn bad_mixed_auth_methods(env: Env) {
+    let addr = Address;
+    addr.require_auth(); //~ WARNING require_auth already called on this address
+    addr.require_auth_for_args(&[1, 2]); //~ WARNING require_auth already called on this address
+}
+
+/// Second call fires, first does not.
+fn bad_second_fires(env: Env) {
+    let addr = Address;
+    addr.require_auth(); // first — no warning
+    addr.require_auth(); //~ WARNING require_auth already called on this address
+}
+
+// =======================================================================
+// Non-triggering cases — these MUST NOT produce any warning
+// =======================================================================
+
+/// Two genuinely different addresses.
+fn good_different_addresses() {
+    let addr_a = Address;
+    let addr_b = Address;
+    addr_a.require_auth();
+    addr_b.require_auth();
+}
+
+/// Same address but separated by a cross-contract call.
+fn good_separated_by_invoke_contract(env: Env, target: Address, func: Symbol) {
+    let addr = Address;
+    addr.require_auth();
+    let _: () = env.invoke_contract(&target, &func, ());
+    addr.require_auth();
+}
+
+/// Same address but separated by a try_invoke_contract call.
+fn good_separated_by_try_invoke_contract(env: Env, target: Address, func: Symbol) {
+    let addr = Address;
+    addr.require_auth();
+    let _: Result<(), ()> = env.try_invoke_contract(&target, &func, ());
+    addr.require_auth();
+}
+
+/// Single require_auth — no duplication.
+fn good_single_require_auth() {
+    let addr = Address;
+    addr.require_auth();
+}
+
+/// No require_auth calls at all.
+fn good_no_require_auth() {
+    let _env = Env;
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/redundant_require_auth.stderr
+++ b/soroban_cost_lints/ui/redundant_require_auth.stderr
@@ -1,0 +1,27 @@
+warning: require_auth already called on this address in this function
+  --> $DIR/redundant_require_auth.rs:10:5
+   |
+LL |     addr.require_auth(); //~ WARNING require_auth already called on this address
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove this duplicate authorization call; the first require_auth on an address already establishes authorization for the entire invocation
+   = note: `#[warn(redundant_require_auth)]` on by default
+
+warning: require_auth already called on this address in this function
+  --> $DIR/redundant_require_auth.rs:16:5
+   |
+LL |     addr.require_auth(); //~ WARNING require_auth already called on this address
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove this duplicate authorization call; the first require_auth on an address already establishes authorization for the entire invocation
+
+warning: require_auth already called on this address in this function
+  --> $DIR/redundant_require_auth.rs:17:5
+   |
+LL |     addr.require_auth_for_args(&[1, 2]); //~ WARNING require_auth already called on this address
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove this duplicate authorization call; the first require_auth on an address already establishes authorization for the entire invocation
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
Closes #353

## Summary

Adds a `REDUNDANT_REQUIRE_AUTH` lint that detects duplicate `Address::require_auth` / `Address::require_auth_for_args` calls on the same address within a single function body, when no cross-contract call appears between them.

## What Changed

### `soroban_cost_lints/src/lib.rs`
- Added `mod redundant_require_auth;`
- Registered `REDUNDANT_REQUIRE_AUTH` in `dylint_lint_impl!` lint list
- Added `LintMeta` entry under `LintCategory::Compute`

### New files
- `soroban_cost_lints/src/redundant_require_auth.rs` — Lint implementation
- `soroban_cost_lints/ui/redundant_require_auth.rs` — UI test fixture
- `soroban_cost_lints/ui/redundant_require_auth.stderr` — Expected diagnostic output

### Documentation
- `CHANGELOG.md` — Entry for the new lint
- `docs/false_positives.md` — Security caveat and false-positive analysis

## Key Design Decisions

1. **Source-text identity for addresses**: Deliberately conservative — two distinct variables holding the same address value are NOT flagged. A false positive here removes a security check.
2. **Cross-contract call reset**: Authorization context can legitimately change across `env.invoke_contract` / `env.try_invoke_contract` boundaries.
3. **No cross-function analysis**: Out of scope, documented as a known gap.

## Security Note

This lint advises about authorization. A false positive is worse than a false positive anywhere else, because acting on it removes a security check.

