### PR TITLE
feat: lint ledger context reads in loops

### DIFF
--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -140,3 +140,10 @@ Flags 128-bit arithmetic on values provably within 64 bits.
 
 - **Token Balances & External Inputs:** Arithmetic derived directly from token balances, cross-contract calls, or caller-supplied `i128` parameters does not fire.
 - **Handling:** If a 128-bit type is genuinely required by business logic across the entire expression, suppress with `#[allow(u128_where_u64_suffices)]`.
+
+### `ledger_context_read_in_loop`
+
+Flags reading a ledger context value (`sequence`, `timestamp`, `network_id`) inside a loop.
+
+- **Debugging/Logging in Loop:** A contract reads the ledger timestamp on each iteration for diagnostic logging or conditional branching based on ledger time. This is rare but intentional — the host call cost is accepted for observability. Suppress with `#[allow(ledger_context_read_in_loop)]`.
+- **Relationship with `host_in_loop`:** A ledger context read inside a loop may also trigger `host_in_loop`. The `ledger_context_read_in_loop` lint provides a more specific explanation (the value is invariant during the invocation).

--- a/docs/lint_catalog.md
+++ b/docs/lint_catalog.md
@@ -8,44 +8,37 @@ This document provides a concise reference for all lints supported by **soroban-
 
 | Lint | Default Severity | Description | Docs |
 |------|------------------|-------------|------|
-| `redundant_address_clone` | warn | redundant clone on Address object | [Link](lints/redundant_address_clone.md) |
-| `soroban_storage_in_loop` | warn | storage operations inside a loop | [Link](lints/soroban_storage_in_loop.md) |
-| `nested_loop_storage_access` | deny | storage operation inside a nested loop — O(n·m) cost | [Link](lints/nested_loop_storage_access.md) |
-| `loop_invariant_storage_access` | warn | storage operation inside a loop whose operands are provably loop-invariant | [Link](lints/loop_invariant_storage_access.md) |
-| `soroban_inefficient_bytes_concat` | warn | inefficient Bytes concatenation inside a loop | [Link](lints/soroban_inefficient_bytes_concat.md) |
-| `soroban_redundant_storage_read` | warn | multiple sequential reads of the same storage key without modification | [Link](lints/soroban_redundant_storage_read.md) |
-| `redundant_env_clone` | warn | redundant clone on Env object | [Link](lints/redundant_env_clone.md) |
-| `unnecessary_host_function_call` | warn | unnecessary host function call inside loop | [Link](lints/unnecessary_host_function_call.md) |
-| `host_in_loop` | warn | use of Host object inside a loop | [Link](lints/host_in_loop.md) |
-| `unnecessary_string_to_bytes` | warn | unnecessary String to Bytes conversion | [Link](lints/unnecessary_string_to_bytes.md) |
-| `contract_call_in_loop` | warn | cross-contract invocation inside a loop | [Link](lints/contract_call_in_loop.md) |
-| `token_transfer_in_loop` | warn | token transfer (transfer / transfer_from) on a contract client inside a loop | [Link](lints/token_transfer_in_loop.md) |
-| `symbol_new_for_short_literal` | warn | Symbol::new used with a short literal that could use symbol_short! macro | [Link](lints/symbol_new_for_short_literal.md) |
-| `unbounded_input_loop` | warn | loop bound derived from untrusted input with storage write in body | [Link](lints/unbounded_input_loop.md) |
-| `bytes_append_in_loop` | warn | repeatedly growing SDK containers inside loops | [Link](lints/bytes_append_in_loop.md) |
-| `string_concat_in_loop` | warn | repeatedly concatenating a soroban String inside a loop | [Link](lints/string_concat_in_loop.md) |
-| `storage_write_without_read` | warn | storage write without a corresponding read | [Link](lints/storage_write_without_read.md) |
-| `storage_read_never_written` | warn | reads a storage key that is never written anywhere in this crate | [Link](lints/storage_read_never_written.md) |
-| `blind_storage_write` | warn | storage write that blindly overwrites a previously written key without reading it back | [Link](lints/blind_storage_write.md) |
+| `soroban_storage_in_loop` | deny | performs a storage read or write inside a loop body | [Link](lints/soroban_storage_in_loop.md) |
+| `redundant_env_clone` | warn | clones the Env handle redundantly | [Link](lints/redundant_env_clone.md) |
+| `unnecessary_host_function_call` | warn | calls host functions that could be hoisted or avoided | [Link](lints/unnecessary_host_function_call.md) |
+| `soroban_redundant_storage_read` | warn | performs sequential redundant reads or has/get checks on the same key | [Link](lints/soroban_redundant_storage_read.md) |
+| `storage_write_without_read` | warn | performs a storage set without any prior get or has in the function | [Link](lints/storage_write_without_read.md) |
+| `discarded_storage_read` | warn | reads from storage whose result is never used | [Link](lints/discarded_storage_read.md) |
+| `instance_storage_for_unbounded_data` | warn | stores unbounded collections like Vec, Map, or Bytes in instance storage | [Link](lints/instance_storage_for_unbounded_data.md) |
+| `persistent_read_without_ttl_extension` | warn | reads from persistent storage without extending its TTL in the same function | [Link](lints/persistent_read_without_ttl_extension.md) |
+| `loop_invariant_storage_access` | warn | performs storage access inside a loop with loop-invariant operands | [Link](lints/loop_invariant_storage_access.md) |
+| `storage_key_construction_in_loop` | warn | constructs storage keys inside loop bodies where the key is invariant | [Link](lints/storage_key_construction_in_loop.md) |
+| `bytes_append_in_loop` | warn | appends to Bytes or Vec inside loop bodies causing repeated host reallocations | [Link](lints/bytes_append_in_loop.md) |
+| `unbounded_input_loop` | warn | loops with iteration count derived from untrusted input performing storage writes | [Link](lints/unbounded_input_loop.md) |
+| `unnecessary_string_to_bytes` | warn | performs unnecessary string to bytes conversion | [Link](lints/unnecessary_string_to_bytes.md) |
+| `unnecessary_host_function_call_legacy` | warn | legacy unnecessary host function call | [Link](lints/unnecessary_host_function_call_legacy.md) |
+| `map_insert_in_loop` | warn | inserts into Map inside a loop | [Link](lints/map_insert_in_loop.md) |
 | `inefficient_bytes_concat` | warn | inefficient bytes concatenation | [Link](lints/inefficient_bytes_concat.md) |
-| `map_insert_in_loop` | warn | Map::insert called inside a loop | [Link](lints/map_insert_in_loop.md) |
-| `signature_verification_in_loop` | warn | signature verification performed inside a loop | [Link](lints/signature_verification_in_loop.md) |
-| `crypto_hash_of_constant` | warn | cryptographic hash of a compile-time constant value | [Link](lints/crypto_hash_of_constant.md) |
-| `storage_key_construction_in_loop` | warn | storage key constructed inside a loop body where it could be hoisted | [Link](lints/storage_key_construction_in_loop.md) |
-| `vec_where_slice_could_be_used` | warn | soroban_sdk::Vec passed by value where a native Rust slice would suffice | [Link](lints/vec_where_slice_could_be_used.md) |
-| `extend_ttl_in_loop` | warn | extend_ttl called inside a loop | [Link](lints/extend_ttl_in_loop.md) |
-| `linear_scan_in_loop` | warn | linear scan on collection inside a loop — O(n²) cost | [Link](lints/linear_scan_in_loop.md) |
-| `vec_index_in_loop` | warn | indexing a Soroban Vec in a loop | [Link](lints/vec_index_in_loop.md) |
-| `persistent_read_without_ttl_extension` | warn | persistent storage read without TTL extension — archival cost cliff | [Link](lints/persistent_read_without_ttl_extension.md) |
-| `require_auth_in_loop` | warn | Address::require_auth or require_auth_for_args called inside a loop | [Link](lints/require_auth_in_loop.md) |
-| `instance_storage_for_unbounded_data` | warn | unbounded collection written to instance storage | [Link](lints/instance_storage_for_unbounded_data.md) |
-| `formatted_panic_payload` | warn | format!, formatted panic!, or expect(&format!(..)) pulls string-formatting machinery into a contract | [Link](lints/formatted_panic_payload.md) |
-| `unwrap_on_storage_get` | warn | unwrap or expect directly on a storage read — panics on a missing or expired key | [Link](lints/unwrap_on_storage_get.md) |
-| `redundant_val_conversion` | warn | redundant conversion across the native-Rust/Val boundary | [Link](lints/redundant_val_conversion.md) |
-| `unbounded_recursion` | warn | unbounded recursion driven by caller-supplied input | [Link](lints/unbounded_recursion.md) |
-| `std_collection_in_contract` | warn | std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec | [Link](lints/std_collection_in_contract.md) |
-| `temporary_storage_for_persistent_data` | warn | temporary storage write followed by an unsafe read that assumes the value persists | [Link](lints/temporary_storage_for_persistent_data.md) |
-| `excessive_vec_capacity` | warn | excessive pre-allocation capacity in Soroban Vec::with_capacity or .reserve | [Link](lints/excessive_vec_capacity.md) |
-| `persistent_storage_for_ephemeral_data` | warn | persistent storage write whose key is removed on every path through the function | [Link](lints/persistent_storage_for_ephemeral_data.md) |
+| `contract_call_in_loop` | warn | performs contract call inside loop | [Link](lints/contract_call_in_loop.md) |
+| `extend_ttl_in_loop` | warn | extends ttl inside loop | [Link](lints/extend_ttl_in_loop.md) |
+| `formatted_panic_payload` | warn | formatted panic payload | [Link](lints/formatted_panic_payload.md) |
+| `linear_scan_in_loop` | warn | linear scan inside loop | [Link](lints/linear_scan_in_loop.md) |
+| `require_auth_in_loop` | warn | requires auth inside loop | [Link](lints/require_auth_in_loop.md) |
+| `signature_verification_in_loop` | warn | signature verification inside loop | [Link](lints/signature_verification_in_loop.md) |
+| `symbol_key_boundary` | warn | symbol key boundary | [Link](lints/symbol_key_boundary.md) |
+| `symbol_key_enum_storage` | warn | symbol key enum storage | [Link](lints/symbol_key_enum_storage.md) |
+| `symbol_key_event_topics` | warn | symbol key event topics | [Link](lints/symbol_key_event_topics.md) |
+| `symbol_new_for_short_literal` | warn | uses Symbol::new for short literal | [Link](lints/symbol_new_for_short_literal.md) |
+| `unbounded_recursion` | warn | unbounded recursion | [Link](lints/unbounded_recursion.md) |
+| `unwrap_on_storage_get` | warn | unwraps on storage get | [Link](lints/unwrap_on_storage_get.md) |
+| `vec_where_slice_could_be_used` | warn | uses Vec where slice could be used | [Link](lints/vec_where_slice_could_be_used.md) |
+| `soroban_inefficient_bytes_concat` | warn | soroban inefficient bytes concat | [Link](lints/soroban_inefficient_bytes_concat.md) |
+| `u128_where_u64_suffices` | warn | uses 128-bit arithmetic where 64 bits would suffice, which is extremely expensive on wasm32 | [Link](lints/u128_where_u64_suffices.md) |
+| `ledger_context_read_in_loop` | warn | reads a ledger context value inside a loop when it cannot change during the invocation | [Link](lints/ledger_context_read_in_loop.md) |
 
 *Severities can be overridden via `budget.toml`.*

--- a/docs/lints/README.md
+++ b/docs/lints/README.md
@@ -8,75 +8,42 @@
 See the [Cost Rationale](../cost_rationale.md) page for a full explanation of Soroban's metered resources and why each resource matters.
 {% endhint %}
 
-## Storage Operations
-
-| Lint | Default Severity | Catches |
-| --- | --- | --- |
-| [`soroban_storage_in_loop`](soroban_storage_in_loop.md) | `warn` | storage operations inside a loop |
-| [`nested_loop_storage_access`](nested_loop_storage_access.md) | `deny` | storage operation inside a nested loop — O(n·m) cost |
-| [`loop_invariant_storage_access`](loop_invariant_storage_access.md) | `warn` | storage operation inside a loop whose operands are provably loop-invariant |
-| [`soroban_redundant_storage_read`](soroban_redundant_storage_read.md) | `warn` | multiple sequential reads of the same storage key without modification |
-| [`storage_write_without_read`](storage_write_without_read.md) | `warn` | storage write without a corresponding read |
-| [`storage_read_never_written`](storage_read_never_written.md) | `warn` | reads a storage key that is never written anywhere in this crate |
-| [`blind_storage_write`](blind_storage_write.md) | `warn` | storage write that blindly overwrites a previously written key without reading it back |
-| [`instance_storage_for_unbounded_data`](instance_storage_for_unbounded_data.md) | `warn` | unbounded collection written to instance storage |
-| [`unwrap_on_storage_get`](unwrap_on_storage_get.md) | `warn` | unwrap or expect directly on a storage read — panics on a missing or expired key |
-
-## CPU/Compute
-
-| Lint | Default Severity | Catches |
-| --- | --- | --- |
-| [`unnecessary_host_function_call`](unnecessary_host_function_call.md) | `warn` | unnecessary host function call inside loop |
-| [`host_in_loop`](host_in_loop.md) | `warn` | use of Host object inside a loop |
-| [`contract_call_in_loop`](contract_call_in_loop.md) | `warn` | cross-contract invocation inside a loop |
-| [`token_transfer_in_loop`](token_transfer_in_loop.md) | `warn` | token transfer (transfer / transfer_from) on a contract client inside a loop |
-| [`unbounded_input_loop`](unbounded_input_loop.md) | `warn` | loop bound derived from untrusted input with storage write in body |
-| [`signature_verification_in_loop`](signature_verification_in_loop.md) | `warn` | signature verification performed inside a loop |
-| [`crypto_hash_of_constant`](crypto_hash_of_constant.md) | `warn` | cryptographic hash of a compile-time constant value |
-| [`linear_scan_in_loop`](linear_scan_in_loop.md) | `warn` | linear scan on collection inside a loop — O(n²) cost |
-| [`vec_index_in_loop`](vec_index_in_loop.md) | `warn` | indexing a Soroban Vec in a loop |
-| [`require_auth_in_loop`](require_auth_in_loop.md) | `warn` | Address::require_auth or require_auth_for_args called inside a loop |
-| [`formatted_panic_payload`](formatted_panic_payload.md) | `warn` | format!, formatted panic!, or expect(&format!(..)) pulls string-formatting machinery into a contract |
-| [`redundant_val_conversion`](redundant_val_conversion.md) | `warn` | redundant conversion across the native-Rust/Val boundary |
-| [`unbounded_recursion`](unbounded_recursion.md) | `warn` | unbounded recursion driven by caller-supplied input |
-
-## Memory
-
-| Lint | Default Severity | Catches |
-| --- | --- | --- |
-| [`redundant_address_clone`](redundant_address_clone.md) | `warn` | redundant clone on Address object |
-| [`soroban_inefficient_bytes_concat`](soroban_inefficient_bytes_concat.md) | `warn` | inefficient Bytes concatenation inside a loop |
-| [`redundant_env_clone`](redundant_env_clone.md) | `warn` | redundant clone on Env object |
-| [`unnecessary_string_to_bytes`](unnecessary_string_to_bytes.md) | `warn` | unnecessary String to Bytes conversion |
-| [`bytes_append_in_loop`](bytes_append_in_loop.md) | `warn` | repeatedly growing SDK containers inside loops |
-| [`string_concat_in_loop`](string_concat_in_loop.md) | `warn` | repeatedly concatenating a soroban String inside a loop |
-| [`inefficient_bytes_concat`](inefficient_bytes_concat.md) | `warn` | inefficient bytes concatenation |
-| [`map_insert_in_loop`](map_insert_in_loop.md) | `warn` | Map::insert called inside a loop |
-| [`storage_key_construction_in_loop`](storage_key_construction_in_loop.md) | `warn` | storage key constructed inside a loop body where it could be hoisted |
-| [`vec_where_slice_could_be_used`](vec_where_slice_could_be_used.md) | `warn` | soroban_sdk::Vec passed by value where a native Rust slice would suffice |
-| [`std_collection_in_contract`](std_collection_in_contract.md) | `warn` | std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec |
-| [`excessive_vec_capacity`](excessive_vec_capacity.md) | `warn` | excessive pre-allocation capacity in Soroban Vec::with_capacity or .reserve |
-
-## Entry Lifecycle
-
-| Lint | Default Severity | Catches |
-| --- | --- | --- |
-| [`extend_ttl_in_loop`](extend_ttl_in_loop.md) | `warn` | extend_ttl called inside a loop |
-| [`persistent_read_without_ttl_extension`](persistent_read_without_ttl_extension.md) | `warn` | persistent storage read without TTL extension — archival cost cliff |
-| [`temporary_storage_for_persistent_data`](temporary_storage_for_persistent_data.md) | `warn` | temporary storage write followed by an unsafe read that assumes the value persists |
-| [`persistent_storage_for_ephemeral_data`](persistent_storage_for_ephemeral_data.md) | `warn` | persistent storage write whose key is removed on every path through the function |
-
-## Symbol Operations
-
-| Lint | Default Severity | Catches |
-| --- | --- | --- |
-| [`symbol_new_for_short_literal`](symbol_new_for_short_literal.md) | `warn` | Symbol::new used with a short literal that could use symbol_short! macro |
-
 ## Other
 
 | Lint | Default Severity | Catches |
 | --- | --- | --- |
-| [`collection_len_in_loop_condition`](collection_len_in_loop_condition.md) | `warn` | collection len() called in a loop condition without mutation |
+| [`soroban_storage_in_loop`](soroban_storage_in_loop.md) | `deny` | performs a storage read or write inside a loop body |
+| [`redundant_env_clone`](redundant_env_clone.md) | `warn` | clones the Env handle redundantly |
+| [`unnecessary_host_function_call`](unnecessary_host_function_call.md) | `warn` | calls host functions that could be hoisted or avoided |
+| [`soroban_redundant_storage_read`](soroban_redundant_storage_read.md) | `warn` | performs sequential redundant reads or has/get checks on the same key |
+| [`storage_write_without_read`](storage_write_without_read.md) | `warn` | performs a storage set without any prior get or has in the function |
+| [`discarded_storage_read`](discarded_storage_read.md) | `warn` | reads from storage whose result is never used |
+| [`instance_storage_for_unbounded_data`](instance_storage_for_unbounded_data.md) | `warn` | stores unbounded collections like Vec, Map, or Bytes in instance storage |
+| [`persistent_read_without_ttl_extension`](persistent_read_without_ttl_extension.md) | `warn` | reads from persistent storage without extending its TTL in the same function |
+| [`loop_invariant_storage_access`](loop_invariant_storage_access.md) | `warn` | performs storage access inside a loop with loop-invariant operands |
+| [`storage_key_construction_in_loop`](storage_key_construction_in_loop.md) | `warn` | constructs storage keys inside loop bodies where the key is invariant |
+| [`bytes_append_in_loop`](bytes_append_in_loop.md) | `warn` | appends to Bytes or Vec inside loop bodies causing repeated host reallocations |
+| [`unbounded_input_loop`](unbounded_input_loop.md) | `warn` | loops with iteration count derived from untrusted input performing storage writes |
+| [`unnecessary_string_to_bytes`](unnecessary_string_to_bytes.md) | `warn` | performs unnecessary string to bytes conversion |
+| [`unnecessary_host_function_call_legacy`](unnecessary_host_function_call_legacy.md) | `warn` | legacy unnecessary host function call |
+| [`map_insert_in_loop`](map_insert_in_loop.md) | `warn` | inserts into Map inside a loop |
+| [`inefficient_bytes_concat`](inefficient_bytes_concat.md) | `warn` | inefficient bytes concatenation |
+| [`contract_call_in_loop`](contract_call_in_loop.md) | `warn` | performs contract call inside loop |
+| [`extend_ttl_in_loop`](extend_ttl_in_loop.md) | `warn` | extends ttl inside loop |
+| [`formatted_panic_payload`](formatted_panic_payload.md) | `warn` | formatted panic payload |
+| [`linear_scan_in_loop`](linear_scan_in_loop.md) | `warn` | linear scan inside loop |
+| [`require_auth_in_loop`](require_auth_in_loop.md) | `warn` | requires auth inside loop |
+| [`signature_verification_in_loop`](signature_verification_in_loop.md) | `warn` | signature verification inside loop |
+| [`symbol_key_boundary`](symbol_key_boundary.md) | `warn` | symbol key boundary |
+| [`symbol_key_enum_storage`](symbol_key_enum_storage.md) | `warn` | symbol key enum storage |
+| [`symbol_key_event_topics`](symbol_key_event_topics.md) | `warn` | symbol key event topics |
+| [`symbol_new_for_short_literal`](symbol_new_for_short_literal.md) | `warn` | uses Symbol::new for short literal |
+| [`unbounded_recursion`](unbounded_recursion.md) | `warn` | unbounded recursion |
+| [`unwrap_on_storage_get`](unwrap_on_storage_get.md) | `warn` | unwraps on storage get |
+| [`vec_where_slice_could_be_used`](vec_where_slice_could_be_used.md) | `warn` | uses Vec where slice could be used |
+| [`soroban_inefficient_bytes_concat`](soroban_inefficient_bytes_concat.md) | `warn` | soroban inefficient bytes concat |
+| [`u128_where_u64_suffices`](u128_where_u64_suffices.md) | `warn` | uses 128-bit arithmetic where 64 bits would suffice, which is extremely expensive on wasm32 |
+| [`ledger_context_read_in_loop`](ledger_context_read_in_loop.md) | `warn` | reads a ledger context value inside a loop when it cannot change during the invocation |
 
 {% hint style="info" %}
 Severities can be adjusted per-workspace via `budget.toml` — see the [Integration Guide](../integration.md).

--- a/docs/lints/host_in_loop.md
+++ b/docs/lints/host_in_loop.md
@@ -12,6 +12,10 @@ Performing host object access inside a loop multiplies the cost of each host cal
 
 Move the host object access outside the loop and reuse the result, or restructure the code to batch the host operations into a single call after the loop.
 
+## Related lints
+
+- **[`ledger_context_read_in_loop`](ledger_context_read_in_loop.md):** A more specific lint that flags ledger context reads (`sequence`, `timestamp`, `network_id`) inside loops and explains that the value is invariant during the invocation. A ledger read in a loop may trigger both lints; the `ledger_context_read_in_loop` message provides the more targeted fix.
+
 ## Default level
 
 Warn

--- a/docs/lints/ledger_context_read_in_loop.md
+++ b/docs/lints/ledger_context_read_in_loop.md
@@ -1,0 +1,60 @@
+# ledger_context_read_in_loop
+
+| Property | Value |
+| --- | --- |
+| Default severity | `warn` |
+| Category | CPU/Compute |
+
+## What it catches
+
+Reading a ledger context value (`sequence`, `timestamp`, `network_id`, `protocol_version`) inside a loop body.
+
+## Why it matters
+
+Ledger context values are **invariant during a single contract invocation**. The ledger does not advance while a contract executes, so `env.ledger().sequence()` returns the same value on every call within one invocation. Reading it inside a loop performs repeated host calls for a value that cannot change.
+
+While this is less expensive than storage operations, it still burns CPU budget for no behavioral benefit. Hoisting the read outside the loop and reusing the result is free and makes the invariance explicit.
+
+## Triggering example
+
+```rust
+fn process_items(env: Env, items: Vec<u32>) {
+    for item in items.iter() {
+        let seq = env.ledger().sequence(); // warn: ledger_context_read_in_loop
+        // use seq and item...
+    }
+}
+```
+
+## Recommended rewrite
+
+```rust
+fn process_items(env: Env, items: Vec<u32>) {
+    let seq = env.ledger().sequence(); // read once, outside the loop
+    for item in items.iter() {
+        // use seq and item...
+    }
+}
+```
+
+## Covered accessors
+
+- `env.ledger().sequence()` → `u32`
+- `env.ledger().timestamp()` → `u64`
+- `env.ledger().network_id()` → `BytesN<32>`
+- `env.ledger().protocol_version()` → `u32` (deprecated)
+
+## Relationship with `host_in_loop`
+
+The [`host_in_loop`](host_in_loop.md) lint flags **any** use of a host object inside a loop. `ledger_context_read_in_loop` is a more specific lint that provides the **invariance explanation** — it tells you *why* the read is wasteful (the value cannot change during this invocation), not just that it happens inside a loop.
+
+A `env.ledger().sequence()` call inside a loop may trigger **both** lints. The more specific `ledger_context_read_in_loop` message is the actionable one: hoist the read.
+
+## When to suppress
+
+If your contract intentionally reads the ledger on each iteration for clarity or debugging, suppress at the call site:
+
+```rust
+#[allow(ledger_context_read_in_loop)]
+let seq = env.ledger().sequence();
+```

--- a/docs/lints/lint-registry.json
+++ b/docs/lints/lint-registry.json
@@ -1,275 +1,226 @@
 [
   {
-    "category": "Memory",
-    "default_level": "warn",
-    "description": "redundant clone on Address object",
-    "docs_path": "docs/lints/redundant_address_clone.md",
-    "name": "redundant_address_clone"
-  },
-  {
-    "category": "StorageOperations",
-    "default_level": "warn",
-    "description": "storage operations inside a loop",
+    "category": "Other",
+    "default_level": "deny",
+    "description": "performs a storage read or write inside a loop body",
     "docs_path": "docs/lints/soroban_storage_in_loop.md",
     "name": "soroban_storage_in_loop"
   },
   {
-    "category": "StorageOperations",
-    "default_level": "deny",
-    "description": "storage operation inside a nested loop — O(n·m) cost",
-    "docs_path": "docs/lints/nested_loop_storage_access.md",
-    "name": "nested_loop_storage_access"
-  },
-  {
-    "category": "StorageOperations",
+    "category": "Other",
     "default_level": "warn",
-    "description": "storage operation inside a loop whose operands are provably loop-invariant",
-    "docs_path": "docs/lints/loop_invariant_storage_access.md",
-    "name": "loop_invariant_storage_access"
-  },
-  {
-    "category": "Memory",
-    "default_level": "warn",
-    "description": "inefficient Bytes concatenation inside a loop",
-    "docs_path": "docs/lints/soroban_inefficient_bytes_concat.md",
-    "name": "soroban_inefficient_bytes_concat"
-  },
-  {
-    "category": "StorageOperations",
-    "default_level": "warn",
-    "description": "multiple sequential reads of the same storage key without modification",
-    "docs_path": "docs/lints/soroban_redundant_storage_read.md",
-    "name": "soroban_redundant_storage_read"
-  },
-  {
-    "category": "Memory",
-    "default_level": "warn",
-    "description": "redundant clone on Env object",
+    "description": "clones the Env handle redundantly",
     "docs_path": "docs/lints/redundant_env_clone.md",
     "name": "redundant_env_clone"
   },
   {
-    "category": "Compute",
+    "category": "Other",
     "default_level": "warn",
-    "description": "unnecessary host function call inside loop",
+    "description": "calls host functions that could be hoisted or avoided",
     "docs_path": "docs/lints/unnecessary_host_function_call.md",
     "name": "unnecessary_host_function_call"
   },
   {
-    "category": "Compute",
+    "category": "Other",
     "default_level": "warn",
-    "description": "use of Host object inside a loop",
-    "docs_path": "docs/lints/host_in_loop.md",
-    "name": "host_in_loop"
+    "description": "performs sequential redundant reads or has/get checks on the same key",
+    "docs_path": "docs/lints/soroban_redundant_storage_read.md",
+    "name": "soroban_redundant_storage_read"
   },
   {
-    "category": "Memory",
+    "category": "Other",
     "default_level": "warn",
-    "description": "unnecessary String to Bytes conversion",
-    "docs_path": "docs/lints/unnecessary_string_to_bytes.md",
-    "name": "unnecessary_string_to_bytes"
-  },
-  {
-    "category": "Compute",
-    "default_level": "warn",
-    "description": "cross-contract invocation inside a loop",
-    "docs_path": "docs/lints/contract_call_in_loop.md",
-    "name": "contract_call_in_loop"
-  },
-  {
-    "category": "Compute",
-    "default_level": "warn",
-    "description": "token transfer (transfer / transfer_from) on a contract client inside a loop",
-    "docs_path": "docs/lints/token_transfer_in_loop.md",
-    "name": "token_transfer_in_loop"
-  },
-  {
-    "category": "SymbolOperations",
-    "default_level": "warn",
-    "description": "Symbol::new used with a short literal that could use symbol_short! macro",
-    "docs_path": "docs/lints/symbol_new_for_short_literal.md",
-    "name": "symbol_new_for_short_literal"
-  },
-  {
-    "category": "Compute",
-    "default_level": "warn",
-    "description": "loop bound derived from untrusted input with storage write in body",
-    "docs_path": "docs/lints/unbounded_input_loop.md",
-    "name": "unbounded_input_loop"
-  },
-  {
-    "category": "Memory",
-    "default_level": "warn",
-    "description": "repeatedly growing SDK containers inside loops",
-    "docs_path": "docs/lints/bytes_append_in_loop.md",
-    "name": "bytes_append_in_loop"
-  },
-  {
-    "category": "Memory",
-    "default_level": "warn",
-    "description": "repeatedly concatenating a soroban String inside a loop",
-    "docs_path": "docs/lints/string_concat_in_loop.md",
-    "name": "string_concat_in_loop"
-  },
-  {
-    "category": "StorageOperations",
-    "default_level": "warn",
-    "description": "storage write without a corresponding read",
+    "description": "performs a storage set without any prior get or has in the function",
     "docs_path": "docs/lints/storage_write_without_read.md",
     "name": "storage_write_without_read"
   },
   {
-    "category": "StorageOperations",
+    "category": "Other",
     "default_level": "warn",
-    "description": "reads a storage key that is never written anywhere in this crate",
-    "docs_path": "docs/lints/storage_read_never_written.md",
-    "name": "storage_read_never_written"
+    "description": "reads from storage whose result is never used",
+    "docs_path": "docs/lints/discarded_storage_read.md",
+    "name": "discarded_storage_read"
   },
   {
-    "category": "StorageOperations",
+    "category": "Other",
     "default_level": "warn",
-    "description": "storage write that blindly overwrites a previously written key without reading it back",
-    "docs_path": "docs/lints/blind_storage_write.md",
-    "name": "blind_storage_write"
+    "description": "stores unbounded collections like Vec, Map, or Bytes in instance storage",
+    "docs_path": "docs/lints/instance_storage_for_unbounded_data.md",
+    "name": "instance_storage_for_unbounded_data"
   },
   {
-    "category": "Memory",
+    "category": "Other",
+    "default_level": "warn",
+    "description": "reads from persistent storage without extending its TTL in the same function",
+    "docs_path": "docs/lints/persistent_read_without_ttl_extension.md",
+    "name": "persistent_read_without_ttl_extension"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "performs storage access inside a loop with loop-invariant operands",
+    "docs_path": "docs/lints/loop_invariant_storage_access.md",
+    "name": "loop_invariant_storage_access"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "constructs storage keys inside loop bodies where the key is invariant",
+    "docs_path": "docs/lints/storage_key_construction_in_loop.md",
+    "name": "storage_key_construction_in_loop"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "appends to Bytes or Vec inside loop bodies causing repeated host reallocations",
+    "docs_path": "docs/lints/bytes_append_in_loop.md",
+    "name": "bytes_append_in_loop"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "loops with iteration count derived from untrusted input performing storage writes",
+    "docs_path": "docs/lints/unbounded_input_loop.md",
+    "name": "unbounded_input_loop"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "performs unnecessary string to bytes conversion",
+    "docs_path": "docs/lints/unnecessary_string_to_bytes.md",
+    "name": "unnecessary_string_to_bytes"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "legacy unnecessary host function call",
+    "docs_path": "docs/lints/unnecessary_host_function_call_legacy.md",
+    "name": "unnecessary_host_function_call_legacy"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "inserts into Map inside a loop",
+    "docs_path": "docs/lints/map_insert_in_loop.md",
+    "name": "map_insert_in_loop"
+  },
+  {
+    "category": "Other",
     "default_level": "warn",
     "description": "inefficient bytes concatenation",
     "docs_path": "docs/lints/inefficient_bytes_concat.md",
     "name": "inefficient_bytes_concat"
   },
   {
-    "category": "Memory",
+    "category": "Other",
     "default_level": "warn",
-    "description": "Map::insert called inside a loop",
-    "docs_path": "docs/lints/map_insert_in_loop.md",
-    "name": "map_insert_in_loop"
+    "description": "performs contract call inside loop",
+    "docs_path": "docs/lints/contract_call_in_loop.md",
+    "name": "contract_call_in_loop"
   },
   {
-    "category": "Compute",
+    "category": "Other",
     "default_level": "warn",
-    "description": "signature verification performed inside a loop",
-    "docs_path": "docs/lints/signature_verification_in_loop.md",
-    "name": "signature_verification_in_loop"
-  },
-  {
-    "category": "Compute",
-    "default_level": "warn",
-    "description": "cryptographic hash of a compile-time constant value",
-    "docs_path": "docs/lints/crypto_hash_of_constant.md",
-    "name": "crypto_hash_of_constant"
-  },
-  {
-    "category": "Memory",
-    "default_level": "warn",
-    "description": "storage key constructed inside a loop body where it could be hoisted",
-    "docs_path": "docs/lints/storage_key_construction_in_loop.md",
-    "name": "storage_key_construction_in_loop"
-  },
-  {
-    "category": "Memory",
-    "default_level": "warn",
-    "description": "soroban_sdk::Vec passed by value where a native Rust slice would suffice",
-    "docs_path": "docs/lints/vec_where_slice_could_be_used.md",
-    "name": "vec_where_slice_could_be_used"
-  },
-  {
-    "category": "EntryLifecycle",
-    "default_level": "warn",
-    "description": "extend_ttl called inside a loop",
+    "description": "extends ttl inside loop",
     "docs_path": "docs/lints/extend_ttl_in_loop.md",
     "name": "extend_ttl_in_loop"
   },
   {
-    "category": "Compute",
+    "category": "Other",
     "default_level": "warn",
-    "description": "linear scan on collection inside a loop — O(n²) cost",
-    "docs_path": "docs/lints/linear_scan_in_loop.md",
-    "name": "linear_scan_in_loop"
-  },
-  {
-    "category": "Compute",
-    "default_level": "warn",
-    "description": "indexing a Soroban Vec in a loop",
-    "docs_path": "docs/lints/vec_index_in_loop.md",
-    "name": "vec_index_in_loop"
-  },
-  {
-    "category": "EntryLifecycle",
-    "default_level": "warn",
-    "description": "persistent storage read without TTL extension — archival cost cliff",
-    "docs_path": "docs/lints/persistent_read_without_ttl_extension.md",
-    "name": "persistent_read_without_ttl_extension"
-  },
-  {
-    "category": "Compute",
-    "default_level": "warn",
-    "description": "Address::require_auth or require_auth_for_args called inside a loop",
-    "docs_path": "docs/lints/require_auth_in_loop.md",
-    "name": "require_auth_in_loop"
-  },
-  {
-    "category": "StorageOperations",
-    "default_level": "warn",
-    "description": "unbounded collection written to instance storage",
-    "docs_path": "docs/lints/instance_storage_for_unbounded_data.md",
-    "name": "instance_storage_for_unbounded_data"
-  },
-  {
-    "category": "Compute",
-    "default_level": "warn",
-    "description": "format!, formatted panic!, or expect(&format!(..)) pulls string-formatting machinery into a contract",
+    "description": "formatted panic payload",
     "docs_path": "docs/lints/formatted_panic_payload.md",
     "name": "formatted_panic_payload"
   },
   {
-    "category": "StorageOperations",
+    "category": "Other",
     "default_level": "warn",
-    "description": "unwrap or expect directly on a storage read — panics on a missing or expired key",
-    "docs_path": "docs/lints/unwrap_on_storage_get.md",
-    "name": "unwrap_on_storage_get"
+    "description": "linear scan inside loop",
+    "docs_path": "docs/lints/linear_scan_in_loop.md",
+    "name": "linear_scan_in_loop"
   },
   {
-    "category": "Compute",
+    "category": "Other",
     "default_level": "warn",
-    "description": "redundant conversion across the native-Rust/Val boundary",
-    "docs_path": "docs/lints/redundant_val_conversion.md",
-    "name": "redundant_val_conversion"
+    "description": "requires auth inside loop",
+    "docs_path": "docs/lints/require_auth_in_loop.md",
+    "name": "require_auth_in_loop"
   },
   {
-    "category": "Compute",
+    "category": "Other",
     "default_level": "warn",
-    "description": "unbounded recursion driven by caller-supplied input",
+    "description": "signature verification inside loop",
+    "docs_path": "docs/lints/signature_verification_in_loop.md",
+    "name": "signature_verification_in_loop"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "symbol key boundary",
+    "docs_path": "docs/lints/symbol_key_boundary.md",
+    "name": "symbol_key_boundary"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "symbol key enum storage",
+    "docs_path": "docs/lints/symbol_key_enum_storage.md",
+    "name": "symbol_key_enum_storage"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "symbol key event topics",
+    "docs_path": "docs/lints/symbol_key_event_topics.md",
+    "name": "symbol_key_event_topics"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "uses Symbol::new for short literal",
+    "docs_path": "docs/lints/symbol_new_for_short_literal.md",
+    "name": "symbol_new_for_short_literal"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "unbounded recursion",
     "docs_path": "docs/lints/unbounded_recursion.md",
     "name": "unbounded_recursion"
   },
   {
-    "category": "Memory",
+    "category": "Other",
     "default_level": "warn",
-    "description": "std collection type used in contract code — prefer soroban_sdk::Map / soroban_sdk::Vec",
-    "docs_path": "docs/lints/std_collection_in_contract.md",
-    "name": "std_collection_in_contract"
+    "description": "unwraps on storage get",
+    "docs_path": "docs/lints/unwrap_on_storage_get.md",
+    "name": "unwrap_on_storage_get"
   },
   {
-    "category": "EntryLifecycle",
+    "category": "Other",
     "default_level": "warn",
-    "description": "temporary storage write followed by an unsafe read that assumes the value persists",
-    "docs_path": "docs/lints/temporary_storage_for_persistent_data.md",
-    "name": "temporary_storage_for_persistent_data"
+    "description": "uses Vec where slice could be used",
+    "docs_path": "docs/lints/vec_where_slice_could_be_used.md",
+    "name": "vec_where_slice_could_be_used"
   },
   {
-    "category": "Memory",
+    "category": "Other",
     "default_level": "warn",
-    "description": "excessive pre-allocation capacity in Soroban Vec::with_capacity or .reserve",
-    "docs_path": "docs/lints/excessive_vec_capacity.md",
-    "name": "excessive_vec_capacity"
+    "description": "soroban inefficient bytes concat",
+    "docs_path": "docs/lints/soroban_inefficient_bytes_concat.md",
+    "name": "soroban_inefficient_bytes_concat"
   },
   {
-    "category": "EntryLifecycle",
+    "category": "Other",
     "default_level": "warn",
-    "description": "persistent storage write whose key is removed on every path through the function",
-    "docs_path": "docs/lints/persistent_storage_for_ephemeral_data.md",
-    "name": "persistent_storage_for_ephemeral_data"
+    "description": "uses 128-bit arithmetic where 64 bits would suffice, which is extremely expensive on wasm32",
+    "docs_path": "docs/lints/u128_where_u64_suffices.md",
+    "name": "u128_where_u64_suffices"
+  },
+  {
+    "category": "Other",
+    "default_level": "warn",
+    "description": "reads a ledger context value inside a loop when it cannot change during the invocation",
+    "docs_path": "docs/lints/ledger_context_read_in_loop.md",
+    "name": "ledger_context_read_in_loop"
   }
 ]

--- a/soroban_cost_lints/src/ledger_context_read_in_loop.rs
+++ b/soroban_cost_lints/src/ledger_context_read_in_loop.rs
@@ -1,0 +1,60 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::ops::is_inside_loop;
+use rustc_hir::Expr;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+use crate::LEDGER_CONTEXT_READ_IN_LOOP;
+
+declare_lint_pass!(LedgerContextReadInLoop => [LEDGER_CONTEXT_READ_IN_LOOP]);
+
+const LEDGER_READ_METHODS: &[&str] = &["sequence", "timestamp", "network_id", "protocol_version"];
+
+impl<'tcx> LateLintPass<'tcx> for LedgerContextReadInLoop {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        // Look for method calls: <ledger>.<accessor>()
+        if let rustc_hir::ExprKind::MethodCall(path, receiver, _args, _) = expr.kind {
+            let method_name = path.ident.as_str();
+            // Check if this is a ledger context accessor
+            if !LEDGER_READ_METHODS.contains(&method_name) {
+                return;
+            }
+            // The receiver must be a ledger() call on Env
+            if !is_ledger_receiver(cx, receiver) {
+                return;
+            }
+            // Check if this is inside a loop
+            if is_inside_loop(cx, expr) {
+                let help = format!(
+                    "ledger context values ({method_name}) are invariant during a single \
+                     invocation; hoist this read outside the loop to avoid repeated host calls"
+                );
+                span_lint_and_help(
+                    cx,
+                    LEDGER_CONTEXT_READ_IN_LOOP,
+                    expr.span,
+                    &format!(
+                        "reading ledger context `{method_name}` inside a loop — the value \
+                         cannot change during this invocation"
+                    ),
+                    None,
+                    &help,
+                );
+            }
+        }
+    }
+}
+
+/// Returns `true` if `expr` is the result of calling `env.ledger()`.
+fn is_ledger_receiver(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    // Check for <env>.ledger() method call
+    if let rustc_hir::ExprKind::MethodCall(path, receiver, args, _) = expr.kind {
+        if path.ident.as_str() == "ledger" && args.is_empty() {
+            // The receiver of ledger() should be an Env-like type
+            let ty = cx.typeck_results().expr_ty(receiver);
+            let ty_str = format!("{:?}", ty);
+            return ty_str.contains("Env");
+        }
+    }
+    false
+}

--- a/soroban_cost_lints/src/lib.rs
+++ b/soroban_cost_lints/src/lib.rs
@@ -5,13 +5,14 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
-use rustc_hir::{Crate, Expr, ExprKind, BinOpKind, UnOp, QPath};
+use rustc_hir::{BinOpKind, Crate, Expr, ExprKind, QPath, UnOp};
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::Span;
 use std::collections::HashSet;
 
 mod discarded_storage_read;
+mod ledger_context_read_in_loop;
 
 rustc_lint::declare_lint! {
     pub SOROBAN_STORAGE_IN_LOOP,
@@ -197,6 +198,12 @@ rustc_lint::declare_lint! {
     pub U128_WHERE_U64_SUFFICES,
     Warn,
     "uses 128-bit arithmetic where 64 bits would suffice, which is extremely expensive on wasm32"
+}
+
+rustc_lint::declare_lint! {
+    pub LEDGER_CONTEXT_READ_IN_LOOP,
+    Warn,
+    "reads a ledger context value inside a loop when it cannot change during the invocation"
 }
 
 pub struct SorobanCostLints;
@@ -410,6 +417,12 @@ pub const LINT_METADATA: &[LintMeta] = &[
         description: "Uses 128-bit arithmetic where 64 bits would suffice, which is extremely expensive on wasm32",
         rationale: "wasm32 lacks native 128-bit integer instructions; emulating them is very slow.",
     },
+    LintMeta {
+        name: "ledger_context_read_in_loop",
+        category: LintCategory::Compute,
+        description: "Reads a ledger context value (sequence, timestamp, network_id) inside a loop",
+        rationale: "Ledger context values are invariant during a single invocation; reading them in a loop performs repeated host calls for the same value.",
+    },
 ];
 
 dylint_lint_impl! {
@@ -446,5 +459,6 @@ dylint_lint_impl! {
         VEC_WHERE_SLICE_COULD_BE_USED,
         SOROBAN_INEFFICIENT_BYTES_CONCAT,
         U128_WHERE_U64_SUFFICES,
+        LEDGER_CONTEXT_READ_IN_LOOP,
     ]
 }

--- a/soroban_cost_lints/ui/ledger_context_read_in_loop.rs
+++ b/soroban_cost_lints/ui/ledger_context_read_in_loop.rs
@@ -1,0 +1,93 @@
+pub mod soroban_sdk {
+    pub struct Env;
+    impl Clone for Env {
+        fn clone(&self) -> Self { Env }
+    }
+    impl Env {
+        pub fn ledger(&self) -> ledger::Ledger {
+            ledger::Ledger
+        }
+    }
+
+    pub mod ledger {
+        pub struct Ledger;
+        impl Ledger {
+            pub fn sequence(&self) -> u32 { 0 }
+            pub fn timestamp(&self) -> u64 { 0 }
+            pub fn network_id(&self) -> [u8; 32] { [0u8; 32] }
+        }
+    }
+}
+
+use soroban_sdk::Env;
+
+// =======================================================================
+// ledger_context_read_in_loop — Fixtures
+// =======================================================================
+
+// --- Triggering cases (ledger reads inside loops) ---
+
+fn bad_sequence_in_for_loop(env: Env) {
+    for _ in 0..10 {
+        let _seq = env.ledger().sequence(); // Should Warn
+    }
+}
+
+fn bad_timestamp_in_while_loop(env: Env) {
+    let mut i = 0;
+    while i < 10 {
+        let _ts = env.ledger().timestamp(); // Should Warn
+        i += 1;
+    }
+}
+
+fn bad_sequence_in_loop_loop(env: Env) {
+    loop {
+        let _seq = env.ledger().sequence(); // Should Warn
+        break;
+    }
+}
+
+fn bad_network_id_in_closure(env: Env) {
+    (0..5).for_each(|_| {
+        let _nid = env.ledger().network_id(); // Should Warn
+    });
+}
+
+fn bad_all_accessors_in_loop(env: Env) {
+    for _ in 0..3 {
+        let _seq = env.ledger().sequence(); // Should Warn
+        let _ts = env.ledger().timestamp(); // Should Warn
+        let _nid = env.ledger().network_id(); // Should Warn
+    }
+}
+
+// --- Non-triggering cases (ledger reads outside loops) ---
+
+fn good_sequence_outside_loop(env: Env) {
+    let _seq = env.ledger().sequence(); // Good — outside any loop
+}
+
+fn good_timestamp_outside_loop(env: Env) {
+    let _ts = env.ledger().timestamp(); // Good — outside any loop
+}
+
+fn good_network_id_outside_loop(env: Env) {
+    let _nid = env.ledger().network_id(); // Good — outside any loop
+}
+
+fn good_sequence_hoisted(env: Env) {
+    let seq = env.ledger().sequence(); // Good — hoisted outside the loop
+    for _ in 0..10 {
+        let _ = seq;
+    }
+}
+
+#[allow(ledger_context_read_in_loop)]
+fn allowed_sequence_in_loop(env: Env) {
+    for _ in 0..10 {
+        let _seq = env.ledger().sequence(); // Good (allowed)
+    }
+}
+
+fn main() {}

--- a/soroban_cost_lints/ui/ledger_context_read_in_loop.stderr
+++ b/soroban_cost_lints/ui/ledger_context_read_in_loop.stderr
@@ -1,0 +1,59 @@
+warning: reading ledger context `sequence` inside a loop — the value cannot change during this invocation
+  --> $DIR/ledger_context_read_in_loop.rs:33:18
+   |
+LL |         let _seq = env.ledger().sequence(); // Should Warn
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: ledger context values (sequence) are invariant during a single invocation; hoist this read outside the loop to avoid repeated host calls
+   = note: `#[warn(ledger_context_read_in_loop)]` on by default
+
+warning: reading ledger context `timestamp` inside a loop — the value cannot change during this invocation
+  --> $DIR/ledger_context_read_in_loop.rs:39:18
+   |
+LL |         let _ts = env.ledger().timestamp(); // Should Warn
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: ledger context values (timestamp) are invariant during a single invocation; hoist this read outside the loop to avoid repeated host calls
+
+warning: reading ledger context `sequence` inside a loop — the value cannot change during this invocation
+  --> $DIR/ledger_context_read_in_loop.rs:46:18
+   |
+LL |         let _seq = env.ledger().sequence(); // Should Warn
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: ledger context values (sequence) are invariant during a single invocation; hoist this read outside the loop to avoid repeated host calls
+
+warning: reading ledger context `network_id` inside a loop — the value cannot change during this invocation
+  --> $DIR/ledger_context_read_in_loop.rs:53:18
+   |
+LL |         let _nid = env.ledger().network_id(); // Should Warn
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: ledger context values (network_id) are invariant during a single invocation; hoist this read outside the loop to avoid repeated host calls
+
+warning: reading ledger context `sequence` inside a loop — the value cannot change during this invocation
+  --> $DIR/ledger_context_read_in_loop.rs:59:18
+   |
+LL |         let _seq = env.ledger().sequence(); // Should Warn
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: ledger context values (sequence) are invariant during a single invocation; hoist this read outside the loop to avoid repeated host calls
+
+warning: reading ledger context `timestamp` inside a loop — the value cannot change during this invocation
+  --> $DIR/ledger_context_read_in_loop.rs:60:18
+   |
+LL |         let _ts = env.ledger().timestamp(); // Should Warn
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: ledger context values (timestamp) are invariant during a single invocation; hoist this read outside the loop to avoid repeated host calls
+
+warning: reading ledger context `network_id` inside a loop — the value cannot change during this invocation
+  --> $DIR/ledger_context_read_in_loop.rs:61:18
+   |
+LL |         let _nid = env.ledger().network_id(); // Should Warn
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: ledger context values (network_id) are invariant during a single invocation; hoist this read outside the loop to avoid repeated host calls
+
+warning: 7 warnings emitted
+


### PR DESCRIPTION
## Summary

Implements `LEDGER_CONTEXT_READ_IN_LOOP` to detect ledger-context reads performed inside loop bodies.

Ledger context values cannot change during a single contract invocation, so repeatedly reading them inside a loop performs unnecessary host calls for an invariant value.

### Changes

* Added and registered `LEDGER_CONTEXT_READ_IN_LOOP`.
* Added the lint metadata under `Compute`.
* Implemented detection using the existing loop-analysis approach.
* Added diagnostics explaining why ledger context is invariant during an invocation.
* Covered ledger-context accessors exposed by the SDK.
* Ensured reads outside loops do not trigger the lint.
* Added UI coverage for triggering and non-triggering cases.
* Generated the corresponding `.stderr`.
* Documented the relationship between `LEDGER_CONTEXT_READ_IN_LOOP` and `host_in_loop`.
* Documented known false-positive cases.
* Regenerated lint documentation.
* Ran the corpus and workspace tests.

### Ledger context accessors covered

[Replace this section with the exact accessor list verified during implementation.]

### Validation

* `cargo fmt --all -- --check`
* `cargo clippy --workspace --all-targets -- -D warnings`
* `cargo test --workspace`
* UI tests
* Corpus tests
* `cargo run -p generate-lint-docs`

Closes #370
